### PR TITLE
feat: actor-based concurrency model for gameplay state

### DIFF
--- a/server/server.v
+++ b/server/server.v
@@ -114,8 +114,8 @@ fn (mut s Server) console_loop() {
 			max_players:    s.cfg.max_players
 			server_motd:    s.cfg.motd
 			uptime_seconds: s.hub.uptime_seconds()
-			tps:            s.hub.tps
-			load:           s.hub.load
+			tps:            s.hub.tps()
+			load:           s.hub.load()
 		}
 		s.hub.commands.dispatch(line, mut sender, ctx) or {
 			s.log.error('Console command failed: ${err}')
@@ -130,13 +130,17 @@ fn (mut s Server) tick_loop() {
 	mut window_start := time.now()
 	mut window_ticks := 0
 	mut window_work := i64(0)
+	// Carried between ticks so every TickJob has a meaningful value, even on
+	// the 19 out of 20 ticks that don't recompute the window.
+	mut tps := f64(ticks_per_second)
+	mut load := f64(0)
 	for s.running.load() {
 		tick_start := time.now()
 		tick++
-		s.hub.world_time = int((tick % day_length_ticks))
+		world_time := int(tick % day_length_ticks)
 		if tick % u64(ticks_per_second) == 0 {
 			s.hub.broadcast(&protocol.SetTimePacket{
-				time: s.hub.world_time
+				time: world_time
 			})
 			s.listener.set_pong_data(s.pong_data(s.hub.count()).bytes()) or {
 				s.log.warn('Failed to update pong data: ${err}')
@@ -148,12 +152,19 @@ fn (mut s Server) tick_loop() {
 		elapsed := time.now() - window_start
 		if elapsed >= time.second {
 			seconds := f64(elapsed.nanoseconds()) / f64(time.second)
-			s.hub.tps = f64(window_ticks) / seconds
-			s.hub.load = f64(window_work) / f64(elapsed.nanoseconds()) * 100.0
+			tps = f64(window_ticks) / seconds
+			load = f64(window_work) / f64(elapsed.nanoseconds()) * 100.0
 			window_start = time.now()
 			window_ticks = 0
 			window_work = 0
 		}
+		// world_time/tps/load are Hub's, not tick_loop's own. This is the
+		// only place that writes them via the actor.
+		s.hub.submit(session.TickJob{
+			world_time: world_time
+			tps:        tps
+			load:       load
+		})
 		deadline := loop_start.add(time.Duration(i64(interval) * i64(tick)))
 		sleep_for := deadline - time.now()
 		if sleep_for > 0 {

--- a/server/session/chat.v
+++ b/server/session/chat.v
@@ -37,8 +37,8 @@ fn (mut s NetworkSession) run_command(line string) ! {
 		max_players:    s.cfg.max_players
 		server_motd:    s.cfg.motd
 		uptime_seconds: s.hub.uptime_seconds()
-		tps:            s.hub.tps
-		load:           s.hub.load
+		tps:            s.hub.tps()
+		load:           s.hub.load()
 	}
 	s.hub.commands.dispatch(line, mut s, ctx)!
 }

--- a/server/session/combat.v
+++ b/server/session/combat.v
@@ -11,16 +11,40 @@ const knockback_vertical = f32(0.4)
 const critical_multiplier = f32(1.5)
 const sound_attack_strong = 'game.player.attack.strong'
 
-fn (mut s NetworkSession) handle_attack(target_runtime_id u64, held types.ItemStackWrapper) ! {
-	if s.dead {
-		return
-	}
-	mut victim := s.hub.session_by_runtime(target_runtime_id) or { return }
-	if victim.runtime_id == s.runtime_id || victim.dead || !victim.spawned {
-		return
-	}
-	if victim.game_mode == protocol.game_type_creative
+// DamageJob is combat's cross-session mutation as a WorldJob.
+struct DamageJob {
+	victim_runtime_id u64
+	amount            f32
+	attacker_name     string
+	knockback_from    types.Vector3
+	critical          bool
+}
+
+fn (j DamageJob) run(mut h Hub) {
+	mut victim := h.session_by_runtime(j.victim_runtime_id) or { return }
+	if victim.dead || !victim.spawned || victim.game_mode == protocol.game_type_creative
 		|| victim.game_mode == protocol.game_type_spectator {
+		return
+	}
+	victim.apply_knockback(j.knockback_from)
+	victim.take_damage(j.amount, j.attacker_name)
+	if j.critical {
+		h.broadcast(&protocol.AnimatePacket{
+			action:           protocol.animate_action_critical_hit
+			actor_runtime_id: victim.runtime_id
+		})
+		h.broadcast(&protocol.LevelSoundEventPacket{
+			sound:           sound_attack_strong
+			position:        victim.current_position()
+			extra_data:      -1
+			entity_type:     'minecraft:player'
+			actor_unique_id: i64(victim.runtime_id)
+		})
+	}
+}
+
+fn (mut s NetworkSession) handle_attack(target_runtime_id u64, held types.ItemStackWrapper) ! {
+	if s.dead || target_runtime_id == s.runtime_id {
 		return
 	}
 	mut damage := s.weapon_damage(s.hub.data.item_name(held.item_stack.id))
@@ -28,24 +52,12 @@ fn (mut s NetworkSession) handle_attack(target_runtime_id u64, held types.ItemSt
 	if critical {
 		damage *= critical_multiplier
 	}
-	victim.apply_knockback(s.position)
-	victim.take_damage(damage, s.identity.display_name)
-	if critical {
-		s.broadcast_critical(victim.runtime_id, victim.position)
-	}
-}
-
-fn (mut s NetworkSession) broadcast_critical(target_runtime_id u64, position types.Vector3) {
-	s.hub.broadcast(&protocol.AnimatePacket{
-		action:           protocol.animate_action_critical_hit
-		actor_runtime_id: target_runtime_id
-	})
-	s.hub.broadcast(&protocol.LevelSoundEventPacket{
-		sound:           sound_attack_strong
-		position:        position
-		extra_data:      -1
-		entity_type:     'minecraft:player'
-		actor_unique_id: i64(target_runtime_id)
+	s.hub.submit(DamageJob{
+		victim_runtime_id: target_runtime_id
+		amount:            damage
+		attacker_name:     s.identity.display_name
+		knockback_from:    s.position
+		critical:          critical
 	})
 }
 
@@ -91,9 +103,23 @@ fn (mut s NetworkSession) die(attacker_name string) {
 	})
 }
 
+// RespawnJob is respawn() run through the actor. respawn() writes
+// dead/health/position, the same fields DamageJob writes, so it must run
+// exclusively on run_jobs()'s thread. Same as combat.
+struct RespawnJob {
+	runtime_id u64
+}
+
+fn (j RespawnJob) run(mut h Hub) {
+	mut target := h.session_by_runtime(j.runtime_id) or { return }
+	target.respawn()
+}
+
 fn (mut s NetworkSession) handle_respawn(p protocol.RespawnPacket) ! {
 	if p.respawn_state == protocol.respawn_state_client_ready {
-		s.respawn()
+		s.hub.submit(RespawnJob{
+			runtime_id: s.runtime_id
+		})
 	}
 }
 
@@ -104,9 +130,11 @@ fn (mut s NetworkSession) respawn() {
 	s.dead = false
 	s.health = 20.0
 	spawn_y := s.generator.spawn_y()
+	s.pos_mutex.lock()
 	s.position = types.Vector3{0.0, f32(spawn_y) + player_eye_height, 0.0}
 	s.prev_y = s.position.y
 	s.vy = 0.0
+	s.pos_mutex.unlock()
 	s.transport.send(s.health_update()) or {}
 	s.transport.send(&protocol.RespawnPacket{
 		position:         s.position
@@ -127,9 +155,19 @@ fn (mut s NetworkSession) respawn() {
 	s.hub.broadcast_except(s.runtime_id, s.add_player_packet())
 }
 
+// current_position is the only safe way to read position from run_jobs():
+// update_movement writes position on the session's own connection thread
+// under the same pos_mutex. See the pos_mutex field comment in session.v.
+fn (mut s NetworkSession) current_position() types.Vector3 {
+	s.pos_mutex.lock()
+	defer { s.pos_mutex.unlock() }
+	return s.position
+}
+
 fn (mut s NetworkSession) apply_knockback(from types.Vector3) {
-	mut dx := s.position.x - from.x
-	mut dz := s.position.z - from.z
+	pos := s.current_position()
+	mut dx := pos.x - from.x
+	mut dz := pos.z - from.z
 	mut dist := math.sqrtf(dx * dx + dz * dz)
 	if dist < 0.0001 {
 		dx = 0.0

--- a/server/session/gamemode.v
+++ b/server/session/gamemode.v
@@ -11,7 +11,26 @@ fn gamemode_id(name string) int {
 	}
 }
 
+// SetGamemodeJob is `set_gamemode` run through the actor. 
+struct SetGamemodeJob {
+	runtime_id u64
+	mode       int
+}
+
+fn (j SetGamemodeJob) run(mut h Hub) {
+	mut target := h.session_by_runtime(j.runtime_id) or { return }
+	target.apply_gamemode(j.mode)
+}
+
 fn (mut s NetworkSession) set_gamemode(mode int) {
+	s.hub.submit(SetGamemodeJob{
+		runtime_id: s.runtime_id
+		mode:       mode
+	})
+}
+
+// apply_gamemode is the actual mutation, run exclusively from run_jobs().
+fn (mut s NetworkSession) apply_gamemode(mode int) {
 	s.game_mode = mode
 	s.transport.send(&protocol.SetPlayerGameTypePacket{
 		gamemode: mode

--- a/server/session/hub.v
+++ b/server/session/hub.v
@@ -1,6 +1,8 @@
 module session
 
 import sync
+import sync.stdatomic
+import math
 import time
 import protocol
 import server.internal.gamedata
@@ -15,32 +17,54 @@ import server.permission
 pub struct Hub {
 mut:
 	sessions        map[u64]&NetworkSession
-	mutex           &sync.Mutex = sync.new_mutex()
-	next_runtime_id u64         = 1
+	mutex           &sync.Mutex   = sync.new_mutex()
+	next_runtime_id u64           = 1
+	// jobs is the only door into gameplay-mutable state that spans sessions
+	// (combat, targeted /gamemode, etc.). run_jobs() is the sole consumer.
+	jobs chan WorldJob = chan WorldJob{cap: 256}
+	tps_bits  &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](math.f64_bits(20.0))
+	load_bits &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](0)
+	online_count &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](0)
 pub mut:
 	world_time   int
 	data         gamedata.GameData
 	items        item.Registry    = item.new_registry()
 	lang         &language.Lang   = unsafe { nil }
-	commands     cmd.Registry = cmd.new_registry()
+	commands     cmd.Registry     = cmd.new_registry()
 	started_at   i64
-	tps          f64 = 20.0
-	load         f64
 	world_blocks map[string]int
 	world_store  &db.WorldStore = unsafe { nil }
 	ops          permission.OpList
 }
 
+pub fn (mut h Hub) tps() f64 {
+	return math.f64_from_bits(h.tps_bits.load())
+}
+
+fn (mut h Hub) set_tps(v f64) {
+	h.tps_bits.store(math.f64_bits(v))
+}
+
+pub fn (mut h Hub) load() f64 {
+	return math.f64_from_bits(h.load_bits.load())
+}
+
+fn (mut h Hub) set_load(v f64) {
+	h.load_bits.store(math.f64_bits(v))
+}
+
 pub fn new_hub(data gamedata.GameData) &Hub {
 	mut commands := cmd.new_registry()
 	defaultcmd.register_all(mut commands)
-	return &Hub{
+	mut hub := &Hub{
 		sessions:   map[u64]&NetworkSession{}
 		mutex:      sync.new_mutex()
 		data:       data
 		commands:   commands
 		started_at: time.now().unix()
 	}
+	spawn hub.run_jobs()
+	return hub
 }
 
 pub fn (h &Hub) uptime_seconds() i64 {
@@ -120,12 +144,14 @@ pub fn (mut h Hub) add(target &NetworkSession) {
 	h.mutex.lock()
 	h.sessions[target.runtime_id] = target
 	h.mutex.unlock()
+	h.online_count.add(1)
 }
 
 pub fn (mut h Hub) remove(runtime_id u64) {
 	h.mutex.lock()
 	h.sessions.delete(runtime_id)
 	h.mutex.unlock()
+	h.online_count.sub(1)
 }
 
 pub fn (mut h Hub) session_by_runtime(runtime_id u64) ?&NetworkSession {
@@ -152,10 +178,7 @@ pub fn (mut h Hub) session_by_name(name string) ?&NetworkSession {
 }
 
 pub fn (mut h Hub) count() int {
-	h.mutex.lock()
-	n := h.sessions.len
-	h.mutex.unlock()
-	return n
+	return int(h.online_count.load())
 }
 
 fn (mut h Hub) snapshot() []&NetworkSession {
@@ -185,5 +208,19 @@ pub fn (mut h Hub) broadcast_except(runtime_id u64, p protocol.Packet) {
 pub fn (mut h Hub) disconnect_all(message string) {
 	for mut target in h.snapshot() {
 		target.disconnect(message)
+	}
+}
+
+// submit queues a WorldJob for run_jobs() to execute. Blocks if the queue is full.
+pub fn (mut h Hub) submit(job WorldJob) {
+	h.jobs <- job
+}
+
+// run_jobs is the single owner thread for gameplay-mutable state that spans
+// sessions. Nothing else may run a WorldJob's run().
+fn (mut h Hub) run_jobs() {
+	for {
+		job := <-h.jobs or { break }
+		job.run(mut h)
 	}
 }

--- a/server/session/session.v
+++ b/server/session/session.v
@@ -11,6 +11,7 @@ import server.world
 import server.player.playerdb
 import server.permission
 import server.cmd
+import sync
 
 pub const players_dir = 'players'
 pub const player_eye_height = f32(1.62)
@@ -33,6 +34,7 @@ mut:
 	generator        world.Generator = world.VoidGenerator{}
 	identity         auth.Identity
 	runtime_id       u64
+	pos_mutex        &sync.Mutex = sync.new_mutex()
 	position         types.Vector3
 	pitch            f32
 	yaw              f32
@@ -124,9 +126,11 @@ fn (mut s NetworkSession) leave() {
 }
 
 fn (mut s NetworkSession) update_movement(position types.Vector3, pitch f32, yaw f32, head_yaw f32) {
+	s.pos_mutex.lock()
 	s.vy = position.y - s.prev_y
 	s.prev_y = position.y
 	s.position = position
+	s.pos_mutex.unlock()
 	s.pitch = pitch
 	s.yaw = yaw
 	s.head_yaw = head_yaw

--- a/server/session/tick.v
+++ b/server/session/tick.v
@@ -1,0 +1,18 @@
+module session
+
+// TickJob carries the once-a-tick snapshot server/server.v's tick_loop
+// computes (world time, tps, load, etc.) into Hub.
+// tick_loop owns the 20 Hz sleep/wake cadence and the tps/load window math on its own thread
+// and submits one of these per tick rather than writing Hub's fields directly.
+pub struct TickJob {
+pub:
+	world_time int
+	tps        f64
+	load       f64
+}
+
+fn (j TickJob) run(mut h Hub) {
+	h.world_time = j.world_time
+	h.set_tps(j.tps)
+	h.set_load(j.load)
+}

--- a/server/session/worldjob.v
+++ b/server/session/worldjob.v
@@ -1,0 +1,5 @@
+module session
+
+pub interface WorldJob {
+	run(mut h Hub)
+}

--- a/server/session/worldjob_test.v
+++ b/server/session/worldjob_test.v
@@ -1,0 +1,56 @@
+module session
+
+import server.internal.gamedata
+import server.internal.auth
+import time
+
+struct TestOnlyDamageJob {
+	victim_runtime_id u64
+	amount            f32
+}
+
+fn (j TestOnlyDamageJob) run(mut h Hub) {
+	mut victim := h.session_by_runtime(j.victim_runtime_id) or { return }
+	victim.health -= j.amount
+}
+
+fn damage_worker(hub &Hub, victim_runtime_id u64, amount f32, times int) {
+	mut mut_hub := unsafe { hub }
+	for _ in 0 .. times {
+		mut_hub.submit(TestOnlyDamageJob{
+			victim_runtime_id: victim_runtime_id
+			amount:            amount
+		})
+	}
+}
+
+fn test_concurrent_damage_jobs_serialize_without_lost_updates() {
+	mut hub := new_hub(gamedata.GameData{})
+	victim := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Victim'
+		}
+		runtime_id: 1
+		health:     1000.0
+	}
+	hub.add(victim)
+
+	attackers := 50
+	hits_per_attacker := 10
+	amount := f32(1.0)
+
+	mut threads := []thread{}
+	for _ in 0 .. attackers {
+		threads << spawn damage_worker(hub, u64(1), amount, hits_per_attacker)
+	}
+	threads.wait()
+
+	// submit() only enqueues; run_jobs() drains the channel on its own thread
+	// so the victim's health settles asynchronously. Poll instead of assuming it's already applied once every submitter has returned.
+	expected := f32(1000.0) - f32(attackers * hits_per_attacker) * amount
+	deadline := time.now().add(5 * time.second)
+	for time.now() < deadline && victim.health != expected {
+		time.sleep(5 * time.millisecond)
+	}
+	assert victim.health == expected
+}


### PR DESCRIPTION
## Problem

Vedrock's only synchronization primitive was `Hub.mutex` and it only ever guarded the
`sessions` map itself, not the data any session pointer led to. The moment two players
can affect each other (combat is the obvious case but also a targeted `/gamemode` and the
tick loop's stats) there's no protection against two threads mutating the same
`NetworkSession` fields at once.

## What this does

- Introduces a single owner actor for anything that mutates state across more than one
session:
  -  `Hub.run_jobs()`: one dedicated thread, started once at hub construction. It's the
  only code allowed to touch a `NetworkSession`'s gameplay fields directly.