### PR TITLE
fix: declare external dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,37 +16,23 @@ A lightweight Minecraft: Bedrock Edition server software written in [V](https://
 ### Prerequisites
 
 * [V](https://vlang.io/)
-* [nbt](https://github.com/bedrock-v/nbt)
-* [raknet](https://github.com/bedrock-v/raknet)
-* [protocol](https://github.com/bedrock-v/protocol)
-* [i18n](https://github.com/nepinhum/i18n)
-
-Some modules aren't available through VPM yet. Until they're published, clone them manually into your V modules directory.
-
-The V modules directory is usually:
-
-* Linux/macOS: `~/.vmodules`
-* Windows: `%USERPROFILE%\.vmodules`
-
-```bash
-git clone https://github.com/bedrock-v/nbt VMODULES_PATH/nbt
-git clone https://github.com/bedrock-v/protocol VMODULES_PATH/protocol
-git clone https://github.com/bedrock-v/raknet VMODULES_PATH/raknet
-
-v install nepinhum.i18n
-```
 
 ### Clone Vedrock
 
 ```bash
 git clone https://github.com/bedrock-v/Vedrock.git
+cd Vedrock
+```
+
+### Install dependencies
+
+```bash
+v install
 ```
 
 ### Run or build
 
 ```bash
-cd Vedrock
-
 # Run without keeping a binary
 v run .
 

--- a/v.mod
+++ b/v.mod
@@ -3,5 +3,10 @@ Module {
 	description: 'Minecraft Bedrock Edition server software written in V'
 	version: '0.0.1-alpha2'
 	license: 'LGPL-3.0'
-	dependencies: ['nepinhum.i18n']
+	dependencies: [
+		'nepinhum.i18n',
+		'https://github.com/bedrock-v/nbt',
+		'https://github.com/bedrock-v/protocol',
+		'https://github.com/bedrock-v/raknet'
+	]
 }


### PR DESCRIPTION
Declares the nbt, protocol, and raknet dependencies and documents `v install`; this is waiting on bedrock-v/nbt#1.