### PR TITLE
chore: add CI, community health files, docs and dev tooling

### DIFF
--- a/.claude/commands/vedrock-fmt.md
+++ b/.claude/commands/vedrock-fmt.md
@@ -1,0 +1,19 @@
+---
+description: Format the Vedrock source tree with v fmt and report what changed.
+allowed-tools: Bash
+---
+
+Format the whole project in place and summarize:
+
+```sh
+v fmt -w .
+```
+
+Then show which files changed:
+
+```sh
+git status --short
+```
+
+Report the list of reformatted files. Do not commit. If `v fmt` errors on a file, show the
+error - it usually points at a real syntax problem.

--- a/.claude/commands/vedrock-verify.md
+++ b/.claude/commands/vedrock-verify.md
@@ -1,0 +1,30 @@
+---
+description: Verify the Vedrock build - type-check, run tests, and boot-smoke the server.
+allowed-tools: Bash, Read
+---
+
+Run the full Vedrock verification loop and report results concisely. Stop at the first hard
+failure and show the error output.
+
+1. Type-check the whole project:
+
+   ```sh
+   v -check .
+   ```
+
+2. Run the test suite:
+
+   ```sh
+   v test server
+   ```
+
+3. Build and boot-smoke (confirm it starts, then kill after ~3s):
+
+   ```sh
+   v -o /tmp/vedrock_smoke . && (/tmp/vedrock_smoke & PID=$!; sleep 3; kill $PID 2>/dev/null)
+   ```
+
+Report: the check result, test pass/total, and whether the log shows "Started successfully". A
+change is done only when steps 1 and 2 are fully green.
+
+Build only with V 0.5.1 (0c3183c) - see AGENTS.md for the pin and dependency layout.

--- a/.claude/skills/vedrock-plugin/SKILL.md
+++ b/.claude/skills/vedrock-plugin/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: vedrock-plugin
+description: Scaffold new content for Vedrock's in-tree plugin system - new plugins, commands, event listeners, and entity types. Use when adding a plugin, command, listener, or mob following the existing codebase patterns.
+---
+
+# Vedrock plugin scaffolding
+
+Vedrock plugins are compiled in-tree (no disk loading). A plugin gets one `Api` handle
+on enable and registers commands, listeners, and scheduled tasks through it. This skill
+covers the four common scaffolds. All templates compile against the current source.
+
+Reference example: `server/plugin/sample/greeter.v`.
+
+## Global gotchas
+
+- Every exported struct and its methods must be `pub` and the struct name capitalized.
+  V requires `pub struct`/`pub fn` for anything the plugin/server package touches.
+- `ServerView` and `Sender` methods are `mut`. You cannot call them directly on an
+  interface field or command value receiver. Copy the value to a `mut` local first:
+  `mut s := c.server` then `s.spawn_entity(...)`.
+- Commands are registered by value (the `Command` interface is a value), so `execute`
+  takes `c Command` (value receiver). To mutate server state, hold a `ServerView` field
+  and copy it to a `mut` local inside `execute`.
+- Listeners embed `event.NopHandler` so you only define the events you care about.
+- Scheduler ticks: 20 ticks = 1 second.
+
+---
+
+## 1. New plugin
+
+Put it in its own package under `server/plugin/<name>/`. Embed `plugin.Base` for a
+free scoped logger.
+
+```v
+module myplugin
+
+import server.event
+import server.plugin
+import server.scheduler
+
+pub struct MyPlugin {
+	plugin.Base
+mut:
+	heartbeat &scheduler.TaskHandler = unsafe { nil }
+}
+
+pub fn (p &MyPlugin) meta() plugin.Meta {
+	return plugin.Meta{
+		name:    'MyPlugin'
+		version: '1.0.0'
+		authors: ['You']
+	}
+}
+
+pub fn (mut p MyPlugin) on_enable(mut api plugin.Api) {
+	api.register_command(MyCommand{})
+	api.register_listener(&MyListener{}, event.Priority.normal)
+
+	log := api.log
+	p.heartbeat = api.run_repeating(scheduler.new_closure_task(fn [log] () {
+		log.info('tick')
+	}), 1200) // every 60s
+}
+
+pub fn (mut p MyPlugin) on_disable() {
+	if p.heartbeat != unsafe { nil } {
+		p.heartbeat.cancel()
+	}
+}
+```
+
+`Api` methods available:
+- `register_command(c cmd.Command)`
+- `register_listener(h event.Handler, priority event.Priority)`
+- `run_delayed(task scheduler.Task, delay i64) &scheduler.TaskHandler`
+- `run_repeating(task scheduler.Task, period i64) &scheduler.TaskHandler`
+- `api.server` is a `ServerView`; `api.log` is a `&logger.Logger`.
+
+`ServerView` methods (all `mut` - copy to a local): `broadcast_message(text)`,
+`online_count() int`, `player_names() []string`,
+`spawn_entity(name string, x f32, y f32, z f32) bool`, `entity_type_names() []string`.
+
+**Register it.** Add one line to `register_plugins` in `server/server.v`
+(NOTE: another agent owns `server/`; request the edit or leave a note):
+
+```v
+plugins.register(&myplugin.MyPlugin{})
+```
+
+and `import server.plugin.myplugin` at the top of `server/server.v`.
+
+---
+
+## 2. New command
+
+Implement the `cmd.Command` interface. Value receivers throughout.
+
+```v
+struct MyCommand {}
+
+pub fn (c MyCommand) name() string { return 'mycmd' }
+pub fn (c MyCommand) description() string { return 'Does a thing' }
+pub fn (c MyCommand) aliases() []string { return ['mc'] }
+pub fn (c MyCommand) permission() string { return '' } // '' = public
+
+pub fn (c MyCommand) arguments() []cmd.Argument {
+	return [
+		cmd.StringArgument{ arg_name: 'player' },
+		cmd.IntArgument{ arg_name: 'count', arg_optional: true },
+	]
+}
+
+pub fn (c MyCommand) execute(mut sender cmd.Sender, ctx cmd.Context) ! {
+	target := ctx.args[0]
+	sender.send_message('§aHello ${target}')!
+}
+```
+
+Argument types (`server/cmd/argument.v`), all take `arg_name` and optional `arg_optional`:
+- `StringArgument` - one non-empty token
+- `IntArgument` - one integer token
+- `TargetArgument` - one connected-player name
+- `TextArgument` - consumes the rest of the line (must be last)
+- `StringEnumArgument` - fixed case-insensitive set; also takes `values []string`
+
+Registry validates args before `execute` runs, so `ctx.args` is already the right shape;
+optional args may be absent, so guard with `ctx.args.len`. `execute` returns `!` -
+propagate `send_message(...)!`.
+
+`ctx.args` are the raw string tokens. `ctx.lang` gives translations
+(`ctx.lang.t('key')`, `ctx.lang.tf('key', {'Name': x})`).
+
+`Sender` (value, methods are `mut`): `name()`, `is_player()`, `has_permission(name)`,
+`send_message(msg) !`, `position() (f32,f32,f32)`, `find_player(name) ?Sender`,
+`give_item(id, count) bool`, `teleport(x,y,z)`, `set_gamemode(mode)`, etc.
+See `server/cmd/sender.v`.
+
+**To mutate server state from a command**, hold a `ServerView` and copy to a mut local:
+
+```v
+struct SummonCommand {
+mut:
+	server plugin.ServerView
+}
+
+pub fn (c SummonCommand) execute(mut sender cmd.Sender, ctx cmd.Context) ! {
+	mut server := c.server // ServerView methods are mut - copy first
+	x, y, z := sender.position()
+	if !server.spawn_entity(ctx.args[0], x, y, z) {
+		sender.send_message('§cunknown type')!
+	}
+}
+```
+
+Register with the field wired: `api.register_command(SummonCommand{ server: api.server })`.
+
+Built-in commands live in `server/cmd/default/` (e.g. `give.v`) - same shape, but they
+use `permission.command_*` nodes instead of `''`.
+
+---
+
+## 3. New event listener
+
+Embed `event.NopHandler`, override only the events you need. Handler methods take a
+`mut ctx event.Context[T]`. Mutate `ctx.val` to change the outcome; call `ctx.cancel()`
+to cancel.
+
+```v
+struct MyListener {
+	event.NopHandler
+mut:
+	server plugin.ServerView
+}
+
+pub fn (mut l MyListener) on_player_join(mut ctx event.Context[event.JoinData]) {
+	ctx.val.message = '§a${ctx.val.player.name()} joined'
+}
+
+pub fn (mut l MyListener) on_block_break(mut ctx event.Context[event.BlockBreakData]) {
+	if ctx.val.x == 0 && ctx.val.z == 0 {
+		ctx.val.player.send_message('§cprotected') or {}
+		ctx.cancel()
+	}
+}
+```
+
+Register: `api.register_listener(&MyListener{ server: api.server }, event.Priority.normal)`.
+Priorities (`lowest low normal high highest monitor`): lowest runs first, monitor last -
+`monitor` should only observe.
+
+Events and their `ctx.val` fields (all in `server/event/events.v`; `player` is a
+`cmd.Sender`):
+- `on_player_join(JoinData)` - `player`, `message`
+- `on_player_quit(QuitData)` - `player`, `message`
+- `on_player_chat(ChatData)` - `player`, `message`
+- `on_player_command(CommandData)` - `player`, `command`
+- `on_block_break(BlockBreakData)` - `x y z block_id`, `player`
+- `on_block_place(BlockPlaceData)` - `x y z block_id`, `player`
+- `on_player_interact(InteractData)` - `x y z face`, `player`
+- `on_player_attack(AttackData)` - `victim_runtime_id critical`, `player damage`
+- `on_player_hurt(HurtData)` - `attacker_name`, `player amount`
+- `on_player_death(DeathData)` - `params`, `player message_key`
+- `on_player_respawn(RespawnData)` - `player x y z`
+- `on_player_move(MoveData)` - `x y z`, `player` (editing coords is ignored; cancel snaps back)
+- `on_gamemode_change(GameModeChangeData)` - `player mode`
+
+`ctx.val.player.send_message(...)` returns `!` - swallow with `or {}` inside a handler
+(handlers don't return an error).
+
+---
+
+## 4. New entity type
+
+An entity type is a name mapped to a `BehaviourFactory` (`fn () Behaviour`). Each spawn
+gets a fresh `Behaviour`. Reuse the shipped behaviours or write your own.
+
+**Reuse a built-in behaviour** - register in `register_defaults` in
+`server/entity/registry.v` (another agent owns `server/`):
+
+```v
+r.register('slime', fn () Behaviour {
+	return &PassiveBehaviour{ network_id: 'minecraft:slime' }
+})
+```
+
+`PassiveBehaviour` (idle, physics only) and `ProjectileBehaviour`
+(flies, despawns on ground or after `max_age` ticks, default 100) are in
+`server/entity/behaviour.v`.
+
+**Custom behaviour** - implement the `Behaviour` interface:
+
+```v
+pub struct SpinBehaviour {
+	network_id string
+}
+
+pub fn (b &SpinBehaviour) identifier() string { return b.network_id }
+
+pub fn (mut b SpinBehaviour) tick(mut e Entity) {
+	e.yaw += 10.0
+	if e.age > 200 {
+		e.kill()
+	}
+}
+```
+
+`identifier()` returns the network type id (e.g. `'minecraft:pig'`) sent to clients.
+`tick(mut e Entity)` runs once per server tick before physics. Mutate the entity:
+`e.set_velocity(v)`, `e.teleport(pos)`, `e.kill()`, or fields `e.yaw`, `e.pitch`,
+`e.no_gravity`, `e.health`; read `e.age`, `e.on_ground`, `e.pos`. See
+`server/entity/entity.v`.
+
+Then register the factory:
+
+```v
+r.register('spinner', fn () Behaviour {
+	return &SpinBehaviour{ network_id: 'minecraft:armor_stand' }
+})
+```
+
+Names are lower-cased on register and lookup. Once registered, the type is spawnable via
+`ServerView.spawn_entity(name, x, y, z)` and the `/summon` command.
+
+---
+
+## Quick checklist
+
+- [ ] structs and methods are `pub` and capitalized
+- [ ] listener embeds `event.NopHandler`
+- [ ] `ServerView`/`Sender` calls go through a `mut` local
+- [ ] plugin registered in `server/server.v` `register_plugins` (+ import)
+- [ ] entity type registered in `server/entity/registry.v` `register_defaults`
+- [ ] scheduled `TaskHandler` cancelled in `on_disable`

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,23 @@
+# .codex
+
+Codex-specific assets for the Vedrock project. The canonical project instructions live in the
+repo-root `AGENTS.md`, which Codex reads automatically - this folder is for extras.
+
+## prompts/
+
+Custom slash prompts (the Codex equivalent of a Claude Code skill). Each `.md` file becomes a
+`/name` command.
+
+- `vedrock-plugin` - scaffold a new plugin, command, event listener, or entity type.
+- `vedrock-verify` - type-check, test, and boot-smoke the build.
+
+To use these globally instead of per-project, copy or symlink them into `~/.codex/prompts/`.
+
+## What else can live here
+
+Besides prompts, useful additions for a Codex-driven repo:
+
+- `AGENTS.md` (repo root) - the primary instruction file. Already present.
+- More prompts - e.g. a release/changelog prompt, a "add a default command" prompt, a protocol
+  packet scaffold prompt. Add a markdown file per task.
+- Project `config.toml` overrides live in global `~/.codex/config.toml`, not here.

--- a/.codex/prompts/vedrock-fmt.md
+++ b/.codex/prompts/vedrock-fmt.md
@@ -1,0 +1,20 @@
+---
+description: Format the Vedrock source tree with v fmt and report what changed.
+---
+
+# Format Vedrock
+
+Format the whole project in place and summarize:
+
+```sh
+v fmt -w .
+```
+
+Then show which files changed:
+
+```sh
+git status --short
+```
+
+Report the list of reformatted files. Do not commit. If `v fmt` errors on a file, show the
+error - it usually points at a real syntax problem.

--- a/.codex/prompts/vedrock-plugin.md
+++ b/.codex/prompts/vedrock-plugin.md
@@ -1,0 +1,274 @@
+---
+description: Scaffold new Vedrock content - plugins, commands, event listeners, entity types.
+---
+
+# Vedrock plugin scaffolding
+
+Codex prompt. Use when adding a plugin, command, listener, or mob to Vedrock following the
+existing codebase patterns. See `AGENTS.md` for build/test and the threading model.
+
+Vedrock plugins are compiled in-tree (no disk loading). A plugin gets one `Api` handle
+on enable and registers commands, listeners, and scheduled tasks through it. This prompt
+covers the four common scaffolds. All templates compile against the current source.
+
+Reference example: `server/plugin/sample/greeter.v`.
+
+## Global gotchas
+
+- Every exported struct and its methods must be `pub` and the struct name capitalized.
+  V requires `pub struct`/`pub fn` for anything the plugin/server package touches.
+- `ServerView` and `Sender` methods are `mut`. You cannot call them directly on an
+  interface field or command value receiver. Copy the value to a `mut` local first:
+  `mut s := c.server` then `s.spawn_entity(...)`.
+- Commands are registered by value (the `Command` interface is a value), so `execute`
+  takes `c Command` (value receiver). To mutate server state, hold a `ServerView` field
+  and copy it to a `mut` local inside `execute`.
+- Listeners embed `event.NopHandler` so you only define the events you care about.
+- Scheduler ticks: 20 ticks = 1 second.
+
+---
+
+## 1. New plugin
+
+Put it in its own package under `server/plugin/<name>/`. Embed `plugin.Base` for a
+free scoped logger.
+
+```v
+module myplugin
+
+import server.event
+import server.plugin
+import server.scheduler
+
+pub struct MyPlugin {
+	plugin.Base
+mut:
+	heartbeat &scheduler.TaskHandler = unsafe { nil }
+}
+
+pub fn (p &MyPlugin) meta() plugin.Meta {
+	return plugin.Meta{
+		name:    'MyPlugin'
+		version: '1.0.0'
+		authors: ['You']
+	}
+}
+
+pub fn (mut p MyPlugin) on_enable(mut api plugin.Api) {
+	api.register_command(MyCommand{})
+	api.register_listener(&MyListener{}, event.Priority.normal)
+
+	log := api.log
+	p.heartbeat = api.run_repeating(scheduler.new_closure_task(fn [log] () {
+		log.info('tick')
+	}), 1200) // every 60s
+}
+
+pub fn (mut p MyPlugin) on_disable() {
+	if p.heartbeat != unsafe { nil } {
+		p.heartbeat.cancel()
+	}
+}
+```
+
+`Api` methods available:
+- `register_command(c cmd.Command)`
+- `register_listener(h event.Handler, priority event.Priority)`
+- `run_delayed(task scheduler.Task, delay i64) &scheduler.TaskHandler`
+- `run_repeating(task scheduler.Task, period i64) &scheduler.TaskHandler`
+- `api.server` is a `ServerView`; `api.log` is a `&logger.Logger`.
+
+`ServerView` methods (all `mut` - copy to a local): `broadcast_message(text)`,
+`online_count() int`, `player_names() []string`,
+`spawn_entity(name string, x f32, y f32, z f32) bool`, `entity_type_names() []string`.
+
+**Register it.** Add one line to `register_plugins` in `server/server.v`:
+
+```v
+plugins.register(&myplugin.MyPlugin{})
+```
+
+and `import server.plugin.myplugin` at the top of `server/server.v`.
+
+---
+
+## 2. New command
+
+Implement the `cmd.Command` interface. Value receivers throughout.
+
+```v
+struct MyCommand {}
+
+pub fn (c MyCommand) name() string { return 'mycmd' }
+pub fn (c MyCommand) description() string { return 'Does a thing' }
+pub fn (c MyCommand) aliases() []string { return ['mc'] }
+pub fn (c MyCommand) permission() string { return '' } // '' = public
+
+pub fn (c MyCommand) arguments() []cmd.Argument {
+	return [
+		cmd.StringArgument{ arg_name: 'player' },
+		cmd.IntArgument{ arg_name: 'count', arg_optional: true },
+	]
+}
+
+pub fn (c MyCommand) execute(mut sender cmd.Sender, ctx cmd.Context) ! {
+	target := ctx.args[0]
+	sender.send_message('§aHello ${target}')!
+}
+```
+
+Argument types (`server/cmd/argument.v`), all take `arg_name` and optional `arg_optional`:
+- `StringArgument` - one non-empty token
+- `IntArgument` - one integer token
+- `TargetArgument` - one connected-player name
+- `TextArgument` - consumes the rest of the line (must be last)
+- `StringEnumArgument` - fixed case-insensitive set; also takes `values []string`
+
+Registry validates args before `execute` runs, so `ctx.args` is already the right shape;
+optional args may be absent, so guard with `ctx.args.len`. `execute` returns `!` -
+propagate `send_message(...)!`.
+
+`ctx.args` are the raw string tokens. `ctx.lang` gives translations
+(`ctx.lang.t('key')`, `ctx.lang.tf('key', {'Name': x})`).
+
+`Sender` (value, methods are `mut`): `name()`, `is_player()`, `has_permission(name)`,
+`send_message(msg) !`, `position() (f32,f32,f32)`, `find_player(name) ?Sender`,
+`give_item(id, count) bool`, `teleport(x,y,z)`, `set_gamemode(mode)`, etc.
+See `server/cmd/sender.v`.
+
+**To mutate server state from a command**, hold a `ServerView` and copy to a mut local:
+
+```v
+struct SummonCommand {
+mut:
+	server plugin.ServerView
+}
+
+pub fn (c SummonCommand) execute(mut sender cmd.Sender, ctx cmd.Context) ! {
+	mut server := c.server // ServerView methods are mut - copy first
+	x, y, z := sender.position()
+	if !server.spawn_entity(ctx.args[0], x, y, z) {
+		sender.send_message('§cunknown type')!
+	}
+}
+```
+
+Register with the field wired: `api.register_command(SummonCommand{ server: api.server })`.
+
+Built-in commands live in `server/cmd/default/` (e.g. `give.v`) - same shape, but they
+use `permission.command_*` nodes instead of `''`.
+
+---
+
+## 3. New event listener
+
+Embed `event.NopHandler`, override only the events you need. Handler methods take a
+`mut ctx event.Context[T]`. Mutate `ctx.val` to change the outcome; call `ctx.cancel()`
+to cancel.
+
+```v
+struct MyListener {
+	event.NopHandler
+mut:
+	server plugin.ServerView
+}
+
+pub fn (mut l MyListener) on_player_join(mut ctx event.Context[event.JoinData]) {
+	ctx.val.message = '§a${ctx.val.player.name()} joined'
+}
+
+pub fn (mut l MyListener) on_block_break(mut ctx event.Context[event.BlockBreakData]) {
+	if ctx.val.x == 0 && ctx.val.z == 0 {
+		ctx.val.player.send_message('§cprotected') or {}
+		ctx.cancel()
+	}
+}
+```
+
+Register: `api.register_listener(&MyListener{ server: api.server }, event.Priority.normal)`.
+Priorities (`lowest low normal high highest monitor`): lowest runs first, monitor last -
+`monitor` should only observe.
+
+Events and their `ctx.val` fields (all in `server/event/events.v`; `player` is a
+`cmd.Sender`):
+- `on_player_join(JoinData)` - `player`, `message`
+- `on_player_quit(QuitData)` - `player`, `message`
+- `on_player_chat(ChatData)` - `player`, `message`
+- `on_player_command(CommandData)` - `player`, `command`
+- `on_block_break(BlockBreakData)` - `x y z block_id`, `player`
+- `on_block_place(BlockPlaceData)` - `x y z block_id`, `player`
+- `on_player_interact(InteractData)` - `x y z face`, `player`
+- `on_player_attack(AttackData)` - `victim_runtime_id critical`, `player damage`
+- `on_player_hurt(HurtData)` - `attacker_name`, `player amount`
+- `on_player_death(DeathData)` - `params`, `player message_key`
+- `on_player_respawn(RespawnData)` - `player x y z`
+- `on_player_move(MoveData)` - `x y z`, `player` (editing coords is ignored; cancel snaps back)
+- `on_gamemode_change(GameModeChangeData)` - `player mode`
+
+`ctx.val.player.send_message(...)` returns `!` - swallow with `or {}` inside a handler
+(handlers don't return an error).
+
+---
+
+## 4. New entity type
+
+An entity type is a name mapped to a `BehaviourFactory` (`fn () Behaviour`). Each spawn
+gets a fresh `Behaviour`. Reuse the shipped behaviours or write your own.
+
+**Reuse a built-in behaviour** - register in `register_defaults` in
+`server/entity/registry.v`:
+
+```v
+r.register('slime', fn () Behaviour {
+	return &PassiveBehaviour{ network_id: 'minecraft:slime' }
+})
+```
+
+`PassiveBehaviour` (idle, physics only) and `ProjectileBehaviour`
+(flies, despawns on ground or after `max_age` ticks, default 100) are in
+`server/entity/behaviour.v`.
+
+**Custom behaviour** - implement the `Behaviour` interface:
+
+```v
+pub struct SpinBehaviour {
+	network_id string
+}
+
+pub fn (b &SpinBehaviour) identifier() string { return b.network_id }
+
+pub fn (mut b SpinBehaviour) tick(mut e Entity) {
+	e.yaw += 10.0
+	if e.age > 200 {
+		e.kill()
+	}
+}
+```
+
+`identifier()` returns the network type id (e.g. `'minecraft:pig'`) sent to clients.
+`tick(mut e Entity)` runs once per server tick before physics. Mutate the entity:
+`e.set_velocity(v)`, `e.teleport(pos)`, `e.kill()`, or fields `e.yaw`, `e.pitch`,
+`e.no_gravity`, `e.health`; read `e.age`, `e.on_ground`, `e.pos`. See
+`server/entity/entity.v`.
+
+Then register the factory:
+
+```v
+r.register('spinner', fn () Behaviour {
+	return &SpinBehaviour{ network_id: 'minecraft:armor_stand' }
+})
+```
+
+Names are lower-cased on register and lookup. Once registered, the type is spawnable via
+`ServerView.spawn_entity(name, x, y, z)` and the `/summon` command.
+
+---
+
+## Quick checklist
+
+- [ ] structs and methods are `pub` and capitalized
+- [ ] listener embeds `event.NopHandler`
+- [ ] `ServerView`/`Sender` calls go through a `mut` local
+- [ ] plugin registered in `server/server.v` `register_plugins` (+ import)
+- [ ] entity type registered in `server/entity/registry.v` `register_defaults`
+- [ ] scheduled `TaskHandler` cancelled in `on_disable`

--- a/.codex/prompts/vedrock-verify.md
+++ b/.codex/prompts/vedrock-verify.md
@@ -1,0 +1,32 @@
+---
+description: Verify the Vedrock build - type-check, run tests, and boot-smoke the server.
+---
+
+# Verify Vedrock
+
+Run the full verification loop and report results concisely. Stop at the first hard failure and
+show the error.
+
+1. Type-check the whole project:
+
+   ```sh
+   v -check .
+   ```
+
+2. Run the test suite:
+
+   ```sh
+   v test server
+   ```
+
+3. Build and boot-smoke (confirm it starts, then kill after ~3s):
+
+   ```sh
+   v -o /tmp/vedrock_smoke .
+   /tmp/vedrock_smoke & PID=$!; sleep 3; kill $PID 2>/dev/null
+   ```
+
+Report: check result, test pass/total, and whether it logged "Started successfully". A change
+is done only when steps 1 and 2 are fully green.
+
+Build only with V 0.5.1 (0c3183c). See `AGENTS.md` for the pin and dependency layout.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for the whole repository.
+* @nepinhum
+* @xRookieFight

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,7 @@
+# Funding platforms for Vedrock. Uncomment and fill in when a link exists.
+
+# github: # up to 4 GitHub Sponsors usernames, e.g. [user1, user2]
+# ko_fi: # a single Ko-fi username
+# open_collective: # a single Open Collective username
+# patreon: # a single Patreon username
+# custom: # a URL, e.g. https://example.com/donate

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Report something in Vedrock not working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. Vedrock is early-stage (alpha), so
+        bugs are expected - but a clear, reproducible report is what actually gets them fixed.
+
+        > [!IMPORTANT]
+        > Vedrock has an in-tree plugin system. If you run a custom plugin, please try to
+        > reproduce the bug without it first. This saves everyone time if the plugin is the cause.
+
+  - type: dropdown
+    attributes:
+      label: Are plugins involved?
+      description: Vedrock loads plugins at startup. Tell us whether a custom plugin is in play.
+      options:
+        - "No custom plugins loaded"
+        - "Bug still happens without custom plugins"
+        - "Bug only happens with a custom plugin (describe below)"
+        - "Not sure / haven't tested without plugins"
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Reproduction steps
+      description: Exact steps to trigger the bug. This is the most important field.
+      placeholder: |
+        1. Start the server with ...
+        2. Connect and do ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actual behaviour
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Logs / crash output
+      description: Paste any server logs, panic traces or crash output. This is auto-formatted, no backticks needed.
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: Vedrock version / commit
+      description: Version from v.mod, or the git commit you built from.
+      placeholder: e.g. 0.0.1-alpha2 (commit dbae6f5)
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: V compiler version
+      description: Output of `v version`. Note that Vedrock is pinned to V 0.5.1 (commit 0c3183c).
+      placeholder: e.g. V 0.5.1 0c3183c
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Operating system
+      placeholder: e.g. Ubuntu 24.04, Windows 11, macOS 14
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & discussion
+    url: https://github.com/bedrock-v/Vedrock/discussions
+    about: For questions, ideas and general help - please use Discussions, not the issue tracker.
+  # - name: Chat on Discord
+  #   url: <add-discord-invite>
+  #   about: Ask for help or chat with the community.

--- a/.github/ISSUE_TEMPLATE/feature-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/feature-proposal.yml
@@ -1,0 +1,37 @@
+name: Feature proposal
+description: Suggest a new feature, or a change to an existing one
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Vedrock is early-stage, so APIs and structure still move around. For larger changes,
+        opening a proposal first lets the design be discussed before anyone writes code.
+
+  - type: textarea
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve, or what is missing today?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Proposed solution
+      description: Describe what you think should be added or changed.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you have looked at.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Scope
+      description: How large is this? Does it touch the protocol, the plugin API, worlds, etc?
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!-- Describe what this PR does and why. Keep it focused. -->
+
+## Description
+
+
+## Related issue
+<!-- e.g. Fixes #1, Related to #2. Delete if none. -->
+
+
+## Checklist
+- [ ] `v -check .` is clean
+- [ ] `v test server` is fully green
+- [ ] Follows the conventions in AGENTS.md (OOP, `pub`/capitalized exports, no import cycles, minimal comments)
+- [ ] Cross-session gameplay state is only mutated on the actor thread (via `hub.submit(...)`)
+- [ ] No unrelated changes bundled in

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot config. V modules are not a supported ecosystem, so this keeps the
+# two things Dependabot can track for this repo up to date: GitHub Actions used
+# in workflows, and the Docker base image.
+version: 2
+updates:
+  # GitHub Actions - bumps action versions across .github/workflows/*.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+    labels:
+      - dependencies
+      - github-actions
+
+  # Docker - bumps the base image in the Dockerfile.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: docker
+    labels:
+      - dependencies
+      - docker

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,39 @@
+# Path-based PR label rules for actions/labeler@v5.
+server:
+  - changed-files:
+      - any-glob-to-any-file: server/**
+
+network:
+  - changed-files:
+      - any-glob-to-any-file: server/internal/network/**
+
+protocol:
+  - changed-files:
+      - any-glob-to-any-file: server/internal/network/**
+
+world:
+  - changed-files:
+      - any-glob-to-any-file: server/world/**
+
+plugin:
+  - changed-files:
+      - any-glob-to-any-file:
+          - server/plugin/**
+          - server/event/**
+          - server/entity/**
+          - server/scheduler/**
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - AGENTS.md
+          - README.md
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file: .github/**
+
+i18n:
+  - changed-files:
+      - any-glob-to-any-file: lang/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - "feat/**"
+  pull_request:
+
+# Cancel superseded runs on the same ref to save runner minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Builds the pinned V compiler (0.5.1 @ 0c3183c) and clones/symlinks
+      # raknet, nbt and protocol into ~/.vmodules. Newer V master breaks
+      # this project, so the pin is mandatory.
+      - name: Setup V
+        uses: ./.github/actions/setup-v
+
+      # setup-v does not pull leveldb, but server/world/db needs it for both
+      # the full build and `v test server`. Same step the release workflows use.
+      - name: Install leveldb module
+        run: git clone --depth 1 https://github.com/vlang/leveldb ~/.vmodules/leveldb
+
+      # Type-checks the whole project without emitting a binary. Fast fail.
+      - name: Check
+        run: v -check .
+
+      # Full production build - catches codegen issues `-check` alone misses.
+      - name: Build
+        run: v -prod -o vedrock .
+
+      - name: Test
+        run: v test server
+
+  format:
+    name: Format check
+    runs-on: ubuntu-latest
+    # The codebase is not fully vfmt-clean yet (20 files as of writing), so this
+    # job is informational only and must not block merges. Drop continue-on-error
+    # once `v fmt -w .` has been applied across the tree.
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup V
+        uses: ./.github/actions/setup-v
+
+      - name: Verify formatting
+        run: v fmt -verify .
+
+  vet:
+    name: Vet
+    runs-on: ubuntu-latest
+    # `v vet .` currently reports trailing-whitespace errors and missing-doc
+    # warnings, so it is advisory only for now. Remove continue-on-error once
+    # the reported issues are cleaned up.
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup V
+        uses: ./.github/actions/setup-v
+
+      - name: Install leveldb module
+        run: git clone --depth 1 https://github.com/vlang/leveldb ~/.vmodules/leveldb
+
+      - name: Vet
+        run: v vet .

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -1,0 +1,46 @@
+# Pulls translated lang/*.toml back from Crowdin on a weekly schedule and
+# opens a PR with the changes. Manual runs via workflow_dispatch.
+#
+# Required repo secrets:
+#   - CROWDIN_PROJECT_ID
+#   - CROWDIN_PERSONAL_TOKEN
+name: Crowdin download
+
+on:
+  schedule:
+    # Every Monday at 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: crowdin-download
+  cancel-in-progress: false
+
+jobs:
+  download:
+    name: Download translations
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download translations from Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+          localization_branch_name: chore/crowdin-translations
+          create_pull_request: true
+          pull_request_title: "chore(i18n): sync translations from Crowdin"
+          pull_request_body: "Automated translation sync from Crowdin."
+          pull_request_base_branch_name: master
+          commit_message: "chore(i18n): sync translations from Crowdin"
+        env:
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -1,0 +1,40 @@
+# Uploads source strings (lang/en.toml) to Crowdin on every push to master
+# that touches the source file. Manual runs via workflow_dispatch.
+#
+# Required repo secrets:
+#   - CROWDIN_PROJECT_ID
+#   - CROWDIN_PERSONAL_TOKEN
+name: Crowdin upload
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - lang/en.toml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: crowdin-upload
+  cancel-in-progress: true
+
+jobs:
+  upload:
+    name: Upload sources
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Upload sources to Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+        env:
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+# Auto-labels PRs by changed path. Rules live in .github/labeler.yml.
+name: Labeler
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Apply labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR
+        uses: actions/labeler@v5

--- a/.github/workflows/pr-stale.yml
+++ b/.github/workflows/pr-stale.yml
@@ -1,0 +1,34 @@
+# Marks inactive PRs stale, then closes them if still untouched.
+# Conservative timings. Issues are left alone.
+name: Stale PRs
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Flag stale PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Issues are not touched.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          stale-pr-message: >
+            This PR has had no activity for 30 days and is now marked stale.
+            It will be closed in 14 days if there is no further activity.
+          close-pr-message: >
+            Closing this PR due to inactivity. Feel free to reopen it if you
+            want to continue the work.
+          exempt-pr-labels: pinned,security
+          exempt-all-assignees: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# AGENTS.md
+
+Guidance for AI coding agents (and humans) working on Vedrock - a Minecraft: Bedrock Edition
+server written in V. This is the canonical instruction file; `CLAUDE.md` points here.
+
+## What this is
+
+Vedrock is an early-stage Bedrock server. It accepts RakNet connections, speaks the Bedrock
+protocol, and runs a tick-based game loop. Core gameplay (blocks, combat, worlds, inventory,
+forms, permissions) plus an in-tree plugin system, event bus, scheduler, entity system, world
+management API, and a chunk upgrader.
+
+## Build, test, run
+
+Build ONLY with the pinned compiler - newer V master breaks the build:
+
+- V compiler: `0.5.1` (commit `0c3183c`)
+- vc bootstrap pin: `f461dfeb`
+
+Commands:
+
+```sh
+v -check .        # type-check the whole project - fast, use this while iterating
+v .               # full debug build -> ./vedrock
+v -prod -o main . # release build
+v test server     # run every _test.v under server/
+v test server/entity   # run one package's tests
+```
+
+A change is done only when `v -check .` is clean and `v test server` is fully green.
+
+### Dependencies
+
+Some modules are not on VPM yet. Clone them into `~/.vmodules` (see README):
+`nbt`, `raknet`, `protocol` (from github.com/bedrock-v), `i18n` (from github.com/nepinhum).
+`server/world/db` also needs a local leveldb. The dependency modules are git-cloned and
+symlinked into `~/.vmodules`; symlinks must point outside `VMODULES`.
+
+## Architecture
+
+Entry: `main.v` -> `server.new(cfg)` -> `srv.start()`.
+
+- `server/` - the server package tree, one subpackage per concern.
+- `server/session/` - `NetworkSession` (one per connection) and `Hub` (shared server state).
+- `server/session/hub.v` - `Hub` owns worlds, commands, events, scheduler, entities, sessions.
+
+### Threading model - read before touching shared state
+
+- Each connection runs on its own thread (`NetworkSession.handle_loop`).
+- `Hub.run_jobs()` is a single actor thread draining a `WorldJob` channel. It is the ONLY
+  place allowed to mutate gameplay state that spans sessions (combat, gamemode, world swaps).
+- To mutate cross-session state off the connection thread, submit a `WorldJob` via
+  `hub.submit(...)` - do not mutate directly.
+- `server/server.v` `tick_loop` submits one `TickJob` per tick (20 TPS). `TickJob.run` (on the
+  actor thread) advances world time, the scheduler heartbeat, and the entity tick.
+- Subsystems added later (scheduler, entity manager) are mutex-guarded so they are safe to
+  touch from any thread, but their tick runs on the actor thread.
+
+### Subsystems
+
+- `server/plugin/` - in-tree plugin system. A `Plugin` gets one `Api` on enable to register
+  commands, event listeners, and scheduled tasks. Built-ins wired in `server/server.v`
+  `register_plugins`. Example: `server/plugin/sample/greeter.v`.
+- `server/event/` - dragonfly-style event bus. Generic `Context[T]` (cancel + mutable `val`),
+  a `Handler` interface with one method per event, embeddable `NopHandler`, priority-ordered
+  `Bus`. 13 events dispatched from real session hooks (join/quit/chat/command/block break-place/
+  interact/attack/hurt/death/respawn/move/gamemode). See `server/event/events.v`.
+- `server/scheduler/` - PocketMine-style tick scheduler. `Task`/`ClosureTask`, `TaskHandler`,
+  delayed + repeating, mutex-guarded, `heartbeat(tick)` on the actor thread. 20 ticks = 1s.
+- `server/entity/` - non-player actors (mobs/projectiles). `Entity` + pluggable `Behaviour`
+  (dragonfly model), a `Registry` (name -> factory), a mutex-guarded `Manager`. Players stay
+  as `NetworkSession`. Spawn via `ServerView.spawn_entity` or `/summon`.
+- `server/world/db/` - LevelDB-backed worlds. Management API in `manage.v` + `Hub` methods
+  (`create_world`/`unload_world`/`delete_world`/`list_worlds`/`world_info`), exposed via the
+  `/world` command. Deletion refuses the default world and worlds with players, always closes
+  the LevelDB handle before removing files, and blocks path traversal.
+- `server/world/upgrader/` - schema-driven block-state upgrader (df-mc/worldupgrader model).
+  Versioned upgrade steps (rename, meta->state, value remap) applied on chunk load via a hook
+  in `server/world/db/vanilla.v`; current-version data is a pass-through no-op.
+- `server/cmd/` - `Command` interface + `Registry`. Defaults in `server/cmd/default/`.
+- `server/permission/`, `server/form/`, `server/resource/`, `server/item/`, `server/block/`.
+
+## Conventions
+
+- OOP. Model with structs, interfaces, and methods - match the surrounding code's idioms.
+- Comments: minimal. Only where the "why" isn't obvious. Use "-" not em-dashes, and write them
+  like a human would. Do not narrate the obvious.
+- Documentation/markdown: use "-" not em-dashes.
+- Keep new packages self-contained and avoid import cycles - lower layers (`event`, `scheduler`,
+  `entity`) must not import `session`. They take primitives or shared interfaces (`cmd.Sender`,
+  `plugin.ServerView`) instead.
+- Every exported struct/method is `pub` and the struct name is capitalized (V requirement).
+
+## Extending the server
+
+There is a scaffolding guide for the four most common additions (plugin, command, listener,
+entity type) with copy-pasteable templates:
+
+- Claude Code: skill at `.claude/skills/vedrock-plugin/SKILL.md` (invoke `/vedrock-plugin`).
+- Codex / other tools: prompt at `.codex/prompts/vedrock-plugin.md`.
+
+Register points: plugins in `server/server.v` `register_plugins`; entity types in
+`server/entity/registry.v` `register_defaults`; default commands in
+`server/cmd/default/register.v`.
+
+## Do not
+
+- Do not build with a V version other than the pin.
+- Do not mutate cross-session gameplay state off the actor thread.
+- Do not commit unless asked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# CLAUDE.md
+
+Project guidance for Claude Code. The canonical, tool-agnostic instructions live in
+`AGENTS.md` - read it first:
+
+@AGENTS.md
+
+## Claude-specific
+
+- Scaffolding skill: `/vedrock-plugin` (`.claude/skills/vedrock-plugin/SKILL.md`) generates
+  new plugins, commands, event listeners, and entity types from the current APIs.
+- Quick verify loop: `v -check .` then `v test server`. Both must pass before declaring done.
+- Build only with V 0.5.1 (0c3183c) - see AGENTS.md for the full pin and dependency layout.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to Vedrock
+
+Thanks for your interest in Vedrock - a Minecraft: Bedrock Edition server written in [V](https://vlang.io/).
+
+Vedrock is early-stage (alpha), so APIs, project structure and behaviour still change often.
+Contributions are welcome: bug reports, feature proposals, docs, and pull requests.
+
+## Reporting bugs and proposing features
+
+Use the issue templates. For questions and general discussion, use
+[Discussions](https://github.com/bedrock-v/Vedrock/discussions), not the issue tracker.
+
+For anything larger than a small fix, opening an issue first is recommended so the design can be
+discussed before you write code.
+
+## Building from source
+
+### V compiler pin
+
+Build only with the pinned compiler - newer V master breaks this project.
+
+- V compiler: `0.5.1` (commit `0c3183c`)
+- vc bootstrap pin: `f461dfeb`
+
+### Dependencies
+
+Some modules aren't on VPM yet. Clone them into your V modules directory (`~/.vmodules` on
+Linux/macOS, `%USERPROFILE%\.vmodules` on Windows):
+
+```bash
+git clone https://github.com/bedrock-v/nbt      ~/.vmodules/nbt
+git clone https://github.com/bedrock-v/raknet   ~/.vmodules/raknet
+git clone https://github.com/bedrock-v/protocol ~/.vmodules/protocol
+
+v install nepinhum.i18n
+```
+
+`server/world/db` also needs a local leveldb module:
+
+```bash
+git clone --depth 1 https://github.com/vlang/leveldb ~/.vmodules/leveldb
+```
+
+### Build and run
+
+```bash
+git clone https://github.com/bedrock-v/Vedrock.git
+cd Vedrock
+
+v -check .   # type-check the whole project - fast, use while iterating
+v run .      # run without keeping a binary
+v .          # debug build -> ./vedrock
+```
+
+## Running tests
+
+```bash
+v test server         # run every _test.v under server/
+v test server/entity  # run one package's tests
+```
+
+A change is done only when `v -check .` is clean and `v test server` is fully green. This is the
+same thing CI checks.
+
+## Coding conventions
+
+Full details are in [AGENTS.md](AGENTS.md). In short:
+
+- OOP. Model with structs, interfaces, and methods, matching the surrounding code.
+- Every exported struct/method is `pub` and the struct name is capitalized (V requirement).
+- Keep new packages self-contained and avoid import cycles. Lower layers (`event`, `scheduler`,
+  `entity`) must not import `session` - they take primitives or shared interfaces instead.
+- Do not mutate cross-session gameplay state off the actor thread. Submit a `WorldJob` via
+  `hub.submit(...)` instead. See the threading section in AGENTS.md.
+- Comments: minimal, only where the "why" isn't obvious. Use "-" not em-dashes, and write them
+  like a human would. Same for markdown docs.
+
+## Commit style
+
+Use a conventional-commit subject line (`feat:`, `fix:`, `docs:`, `refactor:` etc). A body is
+optional - only add one when the subject doesn't explain the "why".
+
+## Pull requests
+
+- Keep changes focused and easy to review. No unrelated changes bundled in.
+- Make sure `v -check .` and `v test server` pass before opening the PR.
+- Fill in the pull request template and link any related issue.
+
+By participating in this project, you are expected to follow the bedrock-v Code of Conduct.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported versions
+
+Vedrock is in early alpha. Only the current alpha line receives security fixes.
+
+| Version        | Supported |
+| -------------- | --------- |
+| 0.0.1-alpha2   | Yes       |
+| older alphas   | No        |
+
+## Reporting a vulnerability
+
+Please report vulnerabilities privately - do **not** open a public issue.
+
+> [!WARNING]
+> The issue tracker is public. Reporting a vulnerability there may expose live servers to attack
+> before a fix is available.
+
+### Report via GitHub (preferred)
+
+Go to https://github.com/bedrock-v/Vedrock/security and click "Report a vulnerability" to open a
+private security advisory.
+
+### Report via email
+
+If you can't use GitHub advisories, email `<add-security-contact-email>`. Please include:
+
+- The Vedrock version or commit affected
+- A description of the vulnerability and how to trigger it
+- What impact it has
+- Your GitHub username, if you want to be credited in the advisory
+
+## Disclosure expectations
+
+As Vedrock is a small, early-stage project, we can't promise a fixed response time. We'll look into
+valid reports as soon as we can and coordinate disclosure with you once a fix is ready. Please give
+us reasonable time to release a fix before disclosing publicly.

--- a/docs/security-review.md
+++ b/docs/security-review.md
@@ -1,0 +1,246 @@
+# Vedrock Security Review
+
+Independent security audit of the Vedrock Bedrock server, performed read-only against the
+`feat/multiWorld` branch. Line references are as-read; note that three other agents are
+concurrently hardening login/auth, network/DoS and robustness, so a few gaps flagged below may
+already be closing. Where the code is genuinely fine, it is called out as such rather than padded.
+
+## Executive summary
+
+Overall posture: **not safe to expose to the public internet as-is.** The network/DoS layer is in
+good shape - batch size caps, decompression-bomb rejection, per-connection rate limits and a
+pre-login packet cap are all present and correct (`server/internal/network/*`). The problem is
+higher up, in identity and trust:
+
+- **There is no protocol encryption.** The login chain carries a `client_public_key` that the
+  server parses and then throws away. The whole session runs in cleartext, so anyone on the path
+  can read and inject packets.
+- **The login chain-of-trust is not anchored to Mojang.** `verify_chain` decides "Xbox
+  authenticated" from a field inside a token that the client itself signs. A crafted chain can set
+  `xbox_authenticated = true` without any Mojang signature. Combined with the fact that op status,
+  whitelist and player save files are all keyed off the client-supplied `displayName`, this lets an
+  attacker impersonate any operator.
+- **Offline mode + display-name-keyed persistence = path traversal.** When `xbox-auth` is off (or
+  bypassed per above), the display name is fully attacker-controlled and is written straight into a
+  filesystem path with no sanitisation.
+
+Server-side authorization for commands is enforced correctly (permission is re-checked on execute,
+not just on client visibility), and the world-delete path-traversal guard is solid. The core
+gameplay-authorization gaps are combat (no reach/line-of-sight check) and a handful of client-trust
+issues. Concurrency is mostly disciplined via the actor model, but there are real unguarded
+cross-thread map/field reads.
+
+Bottom line: fix the auth-chain trust anchor, add encryption, and sanitise the player-file key
+before this faces untrusted clients.
+
+## Findings (most severe first)
+
+### 1. Critical - Auth - Forgeable Xbox-authentication / operator impersonation
+`server/internal/auth/chain.v:69-102`, consumed at `server/session/login.v:36-51`
+
+`verify_chain` walks the JWT chain but never anchors the root of trust to Mojang's public key. The
+first token is verified against the `x5u` header of the *same token* (`chain.v:70-79`), i.e. it is
+self-signed and self-validating. The `xbox_authenticated` flag is then derived at `chain.v:86` from
+`next_key == mojang_public_key`, where `next_key` is the `identityPublicKey` field *inside* the
+client-supplied first token. Nothing forces that first token to actually be signed by Mojang.
+
+Exploit: an attacker builds a one-token chain, signs it with their own ECDSA key, puts that key in
+the `x5u` header (so `verify_jwt` passes), and sets `payload.identityPublicKey` to the hard-coded
+`mojang_public_key` string. `authenticated` becomes `true`, `extraData.displayName/XUID` are
+whatever they choose. With `xbox-auth: true` the server still accepts them as Xbox-authenticated.
+Because ops (`server/permission/ops.v`), whitelist and player files are all keyed by `displayName`,
+they log in as any operator (e.g. name themselves after a known op) and gain full `/op`, `/deop`,
+`/world delete`, etc.
+
+Fix: pin the trust root. The first chain token must be verified against the known Mojang root key
+(the chain is Mojang-key -> intermediate -> client), not against its own `x5u`. Only set
+`xbox_authenticated` when the signature actually chains up to Mojang, and validate token expiry
+(`nbf`/`exp`) while you are there. The existing `mojang_public_key` const should be the *verifying*
+key of token 0, not a value you compare a client field against.
+
+### 2. Critical - Persistence - Path traversal via unsanitised player key
+`server/player/playerdb/player.v:25-41`, key from `server/session/spawn.v:12-20`
+
+`player_path` interpolates the key straight into `os.join_path(dir, '${key}.json')` with no
+validation. `player_key()` returns `xuid`, else `uuid`, else `display_name`. In offline mode (or
+after finding 1), `display_name` is attacker-controlled. A name like `../../ops` or
+`../../whitelist` causes `save_player`/`load_player` to read and write outside `players/`.
+
+Exploit: connect offline with a crafted name, trigger a save (`save_player_data` on quit,
+`items.v:118-140`), and clobber an arbitrary `*.json` on disk with player JSON, or read one back on
+join. Even without traversal, a name with `/` creates junk directories, and a name colliding with
+another player's file corrupts their data.
+
+Fix: never use a free-form display name as a filesystem key. Prefer the XUID/UUID only, reject empty,
+and sanitise to a strict charset (or hash the key). Reuse the pattern already applied in
+`server/world/db/manage.v:11-29` (`safe_world_dir`) which correctly rejects `/`, `\`, `..`, `.`,
+absolute paths and post-normalisation escapes.
+
+### 3. High - Transport - No protocol encryption negotiated
+`server/session/login.v:36-56`, `server/internal/network/session.v`
+
+Bedrock supports ECDH-negotiated AES encryption after login using the client public key. Vedrock
+parses `client_public_key` (`chain.v`) but never initiates a `ServerToClientHandshakePacket` /
+enables a cipher. Compression is toggled (`login.v:32`) but the stream is otherwise plaintext for the
+entire session.
+
+Impact: any on-path attacker (shared LAN, malicious router, ISP) can read chat, credentials-adjacent
+identity data, and inject or modify packets - including forging commands from an authenticated
+session. This also removes the only cryptographic binding between the login identity and subsequent
+packets, compounding finding 1.
+
+Fix: implement Bedrock's login encryption handshake (ECDH over the client public key, AES-GCM/CTR per
+protocol) and require it before entering `.play`.
+
+### 4. High - Identity - Op/whitelist/identity keyed on spoofable display name
+`server/session/login.v:42-49`, `server/permission/ops.v:32-34`, `server/permission/whitelist.v`
+
+Even independent of the chain-forgery bug, authorization is tied to `identity.display_name`:
+`whitelist.is_allowed(display_name)` (`login.v:42`), `ops.is_op(display_name)` (`login.v:48`), and
+grants via `player_grants.apply(... display_name, xuid, uuid)` (`login.v:49`). Display names are not
+unique or authenticated (they are chosen client-side in offline mode and only weakly bound even with
+Xbox). Two accounts can share a name; an offline player picks any name.
+
+Impact: whitelist and op lists are trivially bypassed/impersonated whenever Xbox auth is off or
+bypassed. Op is granted purely on a name match.
+
+Fix: key ops, whitelist and grants on XUID (authenticated identity), not display name. Treat display
+name as a cosmetic label only.
+
+### 5. High - Combat - No reach or line-of-sight check on attack
+`server/session/combat.v:46-72`, dispatched from `server/session/blocks.v:48-55`
+
+`handle_attack` takes the client-supplied `target_entity_runtime_id` and applies damage with no
+distance check between attacker and victim, and no validation that the target is actually a valid,
+visible entity in range. Block *placement* is correctly reach-limited
+(`blocks.v:147-152 within_place_reach`), but combat is not.
+
+Exploit: a modified client sends `InventoryTransaction` use-item-on-entity attacks against any
+runtime id from anywhere on the map (reach hack / kill-aura / cross-world kill), bounded only by the
+client's own send rate. Weapon damage is taken from the client-supplied held item
+(`combat.v:50`, see finding 9), so damage per hit is also attacker-influenced.
+
+Fix: reject attacks where the victim is outside a server-side reach bound (mirror `within_place_reach`
+using both players' server positions) and where attacker/victim are in different worlds. Rate-limit
+attacks server-side.
+
+### 6. Medium - Concurrency - Unguarded cross-thread reads of shared maps/fields
+`server/session/hub.v` (ops/whitelist), `server/session/blocks.v:217-244`, `server/session/whitelist_admin.v:41-63`
+
+The actor model is followed for writes, but several reads happen on the connection thread while the
+actor thread mutates the same state:
+
+- `ops.is_op(...)` and `whitelist.is_allowed(...)` are read at login on the connection thread
+  (`login.v:42,48`) while `SetOpJob`/`WhitelistAddJob` mutate the same maps on the actor thread
+  (`moderation.v:14-26`, `whitelist_admin.v:7-33`). V maps are not safe for concurrent
+  read/write - this is a data race that can corrupt the map or crash.
+- `whitelist_enabled()`/`whitelist_names()` (`whitelist_admin.v:41-63`) read `h.whitelist` directly
+  off the caller thread.
+- `obstructed_by_entity` (`blocks.v:225-244`) reads every other session's `target.position` without
+  taking that session's `pos_mutex`, while those sessions write it under `pos_mutex`
+  (`session.v:199-203`). Same for `add_player`/broadcast paths reading `position`/`display_name`.
+
+Impact: intermittent crashes or corrupted permission state under concurrent login + `/op` or
+`/whitelist` traffic; torn position reads. Hard to exploit deterministically but a real stability and
+correctness bug that a connection flood makes more likely.
+
+Fix: route ops/whitelist reads through the Hub mutex (or the actor), or make these structures
+internally mutex-guarded. For position, read cross-session positions via a locked accessor
+(`current_position()` exists but is not used in `obstructed_by_entity`).
+
+### 7. Medium - DoS - Unbounded WorldJob submission can stall the actor / block threads
+`server/session/hub.v:31,397-408`; e.g. `combat.v:65`, `blocks.v`, `moderation.v`
+
+`jobs` is a channel with `cap: 256` and `submit()` blocks when full (`hub.v:397-399`). Every
+client action that mutates cross-session state submits a job (attack, respawn, teleport, give,
+clear, world ops). A client that spams attacks/respawns (no server-side rate limit on those - see
+finding 5) can flood the queue. Because `submit` blocks, connection threads back up behind a full
+queue, and `tick_loop` also submits a `TickJob` every tick (`server.v:249`) - if the actor is
+saturated, ticks stall for everyone.
+
+Impact: one or a few malicious clients degrade or freeze the whole server (global DoS) even though
+the per-connection byte/packet limits are respected, because a single small packet can enqueue
+expensive cross-session work.
+
+Fix: rate-limit the gameplay actions that enqueue jobs (per-session token bucket), and/or make
+`submit` non-blocking with a drop/tail policy for non-critical jobs so a full queue cannot stall the
+tick loop.
+
+### 8. Medium - Input - `handle_mob_equipment` trusts client-declared held item
+`server/session/inventory.v:61-70`
+
+`handle_mob_equipment` sets `s.held_item`/`s.held_slot` directly from the packet and broadcasts it,
+without checking the client actually holds that item in the claimed slot. `weapon_damage` in combat
+reads the held item id (`combat.v:50`) to compute damage.
+
+Impact: a client can claim to hold a netherite sword it does not own to maximise attack damage, or
+spoof equipment appearance to other players. Bounded (damage tiers are small) but it is unvalidated
+client trust in the combat path.
+
+Fix: derive the held item from the server-side inventory model at `held_slot`, not from the packet;
+validate the slot index.
+
+### 9. Low - Input - Command name case-sensitivity mismatch in disable/unregister
+`server/cmd/command.v:49-73`, `server/server.v:124-127`
+
+`register` stores commands under `cmd.name()` verbatim, but `unregister` lower-cases the key
+(`command.v:59`) and `resolve` lower-cases lookups (`command.v:76`). If any command name contains an
+uppercase letter, `disabled_commands` in `permissions.yml` (applied via `unregister` at
+`server.v:124`) silently fails to remove it, so an admin who disables a command may still have it
+live. Current built-ins are all lowercase, so it is latent.
+
+Fix: normalise to lower-case in `register` too, so registry keys and lookups agree.
+
+### 10. Low - DoS - Pre-login work bounded by count, not by total bytes over time
+`server/internal/network/session.v:85-90`
+
+The pre-login cap counts packets (`max_prelogin_packets = 64`) and the rate limiter caps bytes/sec,
+which is good. But a single login packet may carry a large `auth_info_json` that is JSON-decoded and
+has ECDSA signatures verified (`chain.v`), and the 64-packet budget still allows a fair amount of
+crypto work per connection before disconnect. Combined with unlimited concurrent `accept`s
+(`server.v:263-269` spawns a thread per connection with no cap on concurrent handshakes), a
+connection flood can drive CPU via signature verification and per-connection thread/goroutine
+allocation.
+
+Impact: pre-auth CPU/thread exhaustion under a connection flood.
+
+Fix: cap the size of `auth_info_json` and the chain length before verifying, and bound the number of
+concurrent un-authenticated handshakes (a semaphore around `spawn s.handle`).
+
+## Things that are actually fine
+
+- **World deletion path traversal**: `safe_world_dir` (`server/world/db/manage.v:11-29`) is a
+  correct, defence-in-depth guard - rejects `/`, `\`, `..`, `.`, absolute paths, and re-checks that
+  the normalised path still sits directly under `worlds_dir`. `delete_world` also refuses the default
+  world and worlds with players, and closes the LevelDB handle first (`hub.v:257-276`). Good.
+- **Command authorization is server-side**: `dispatch` re-checks `visible()` (permission) before
+  `execute` (`command.v:101-104,120`); it does not rely on client-side command visibility. Privileged
+  commands (`/op`, `/world`, `/gamemode`, `/whitelist`, `/kill`, `/tp`) all declare a permission node
+  gated behind op default. A normal player cannot invoke them.
+- **Network frame bounds**: `decode_batch` caps compressed batch, decompressed batch (bomb guard),
+  per-packet size and packet count (`server/internal/network/batch.v:15-18,44-91`); `check_rate`
+  enforces per-connection packet/byte ceilings (`session.v:59-74`). This layer is well done.
+- **Block placement** is reach- and bounds-checked and cooldown-throttled (`blocks.v:85-104`).
+- **Plugin surface** (`server/plugin/*`) is in-tree and compiled, not loaded from disk, so there is no
+  untrusted-plugin loading vector. `ServerView` is a deliberately narrow interface. Fine as long as
+  only trusted plugins are wired in `register_plugins`.
+
+## Quick wins
+
+- Sanitise/replace the player-file key (finding 2) - reuse `safe_world_dir`'s validation or hash the
+  key. Small, self-contained change with high payoff.
+- Lower-case command keys in `register` (finding 9).
+- Route `ops.is_op`/`whitelist.is_allowed` reads through the Hub mutex (finding 6) - a few lines.
+- Cap `auth_info_json` size and chain length before crypto (finding 10).
+- Add a server-side reach check in `handle_attack` mirroring `within_place_reach` (finding 5).
+
+## Must-fix before public production
+
+1. **Anchor the login chain to Mojang's key and validate expiry** (finding 1). Until this is fixed,
+   `xbox_authenticated` is meaningless and any operator can be impersonated.
+2. **Key ops/whitelist/grants and player files on authenticated XUID, not display name**
+   (findings 2, 4).
+3. **Negotiate protocol encryption** (finding 3). Cleartext sessions on a hostile network defeat all
+   of the above.
+4. **Rate-limit gameplay actions that enqueue WorldJobs and bound concurrent handshakes**
+   (findings 5, 7, 10) so a single client cannot stall the tick loop or exhaust CPU.

--- a/tools/loadtest/README.md
+++ b/tools/loadtest/README.md
@@ -1,0 +1,127 @@
+# Vedrock loadtest
+
+A standalone load/stress-test harness for the Vedrock server. It opens many
+concurrent RakNet connections against a running server, drives each one through
+the real Bedrock handshake, holds them for a fixed duration, and reports
+connection and throughput numbers you can line up against the server's own
+tick/load logging.
+
+It is a self-contained `module main` program - it does not touch the server
+package, it only reuses two of its building blocks as a client:
+
+- `raknet.dial_timeout` - the RakNet module's client dial API (outbound conn).
+- `server.internal.network.Session` - the server's own framing/batch/compression
+  transport, used from the client side so the wire format matches exactly.
+
+## Run
+
+From the repo root:
+
+```sh
+v run tools/loadtest/main.v <host> <port> <connections> <seconds> [--login]
+```
+
+Arguments (all optional, sane defaults shown):
+
+- `host` - server address, default `127.0.0.1`
+- `port` - server UDP port, default `19132`
+- `connections` - concurrent clients to open, default `50`
+- `seconds` - how long to hold the connections, default `10`
+- `--login` - also push a Login packet after the handshake (see below)
+
+Examples:
+
+```sh
+v run tools/loadtest/main.v                          # 50 conns, 10s, localhost
+v run tools/loadtest/main.v 127.0.0.1 19132 200 15   # 200 conns, 15s
+v run tools/loadtest/main.v 127.0.0.1 19132 100 5 --login
+```
+
+## What each connection does
+
+1. Dials the server over UDP/RakNet (full offline-ping -> open-connection ->
+   connected handshake, done by the RakNet dialer).
+2. Sends `RequestNetworkSettings` uncompressed.
+3. Waits for the server's `NetworkSettings` reply, then enables flate
+   compression - matching the server's own state transition.
+4. `--login` only: sends a `Login` packet with an offline/empty chain. The
+   server does the real login-stage work and then rejects it at auth, which
+   closes the connection. Use this to exercise the auth path; without it the
+   connection stays parked at the login state.
+5. Holds the connection open until the shared deadline, trickling a
+   `PlayerAuthInput` movement packet every 500ms so the server keeps doing real
+   per-connection read work.
+
+Reaching `NetworkSettings` is the success boundary for a handshake - it proves
+the server ran the version check and settings response for that client.
+
+## What it measures
+
+Printed at the end of the run:
+
+- `wall clock` - actual run duration.
+- `dial ok / fail` - RakNet connections established vs failed.
+- `handshake ok / fail` - clients that reached the NetworkSettings stage.
+- `login packets sent` - only with `--login`.
+- `connections/sec` - established connections divided by wall clock. This is the
+  accept-loop throughput as the load tool saw it.
+- `keepalives sent` - total movement/keepalive packets pushed during the hold.
+- `bytes sent (approx)` - approximate outbound bytes (packet sizes are estimated,
+  not measured post-compression).
+- `throughput` - approx KB/s outbound.
+- `errors` - dial/transport failures.
+
+## Reading the results
+
+- `dial fail` > 0 means the server's RakNet accept loop is dropping or timing
+  out open-connection requests - the accept path is saturated or the server is
+  down. Ramp `connections` up until this starts climbing to find the accept
+  ceiling.
+- `handshake fail` with `dial ok` means connections land but the login/settings
+  path stalls - the per-connection thread or the shared hub is the bottleneck,
+  not RakNet.
+- `connections/sec` falling as you raise `connections` shows where accept
+  throughput flattens out.
+
+## Interpreting server-side tick warnings during a run
+
+Watch the server's stdout while the load runs. The server ticks at 20 TPS and,
+when a tick runs past its 50ms slot, logs a throttled warning (once per ~5s):
+
+```
+Tick <n> over budget by <ms>ms (tps=<x>, load=<y>%)
+```
+
+- `load` is the fraction of each tick spent doing work (100% = a full tick's
+  budget used). Rising `load` as you add connections is the signal that
+  per-connection work is eating into the tick budget.
+- `tps` dropping below 20 means ticks are overrunning and the loop is catching
+  up - the server can no longer keep real time under this load.
+- No warnings + `load` staying low means the server absorbed the connection
+  count without tick-stability impact. Push `connections` higher until warnings
+  appear to find the stability ceiling.
+
+For memory, watch the server process RSS (e.g. `ps -o rss= -p <pid>` or a
+`top`/`htop` on the server pid) across increasing `connections` to see
+per-connection memory cost.
+
+## Smoke run (captured on localhost)
+
+Built the server (`v -o /tmp/vedrock_srv .`) and ran against it:
+
+- 25 connections / 5s: 25/25 dial ok, 25/25 handshake ok, 250 keepalives,
+  5.001s wall clock, 0 errors, 0 tick overruns.
+- 100 connections / 4s: 100/100 dial ok, 100/100 handshake ok, 553 keepalives,
+  0 errors, 0 tick overruns - the tick loop stayed stable at 20 TPS.
+
+## Scope and limits
+
+- This harness stops at the login/auth stage. It does not spawn a player, load
+  chunks, or send gameplay packets, so it exercises the accept loop, RakNet
+  reliability layer, handshake, framing/compression, and (with `--login`) the
+  auth path - but not the full in-world tick cost of active players.
+- Byte counts are approximate outbound estimates, not measured wire bytes.
+- A full client harness would additionally need: a valid (or offline-signed)
+  login chain accepted by auth, the resource-pack handshake responses, a
+  `RequestChunkRadius`, and `SetLocalPlayerAsInitialized` to reach the spawned
+  state and drive real gameplay load. That is out of scope here.

--- a/tools/loadtest/main.v
+++ b/tools/loadtest/main.v
@@ -1,0 +1,255 @@
+module main
+
+import os
+import time
+import sync
+import sync.stdatomic
+import raknet
+import protocol
+import protocol.types
+import server.internal.network
+import server.internal.logger
+
+// LoadTest drives N concurrent RakNet clients through the Bedrock handshake
+// against a running Vedrock server and reports connection/tick behaviour. It
+// reuses the server's own network.Session transport so the framing, batching
+// and flate compression match exactly what the server expects on the wire.
+struct Config {
+mut:
+	host        string
+	port        int
+	connections int
+	seconds     int
+	send_login  bool
+}
+
+// Stats is the shared, atomically-updated result tally. Every worker thread
+// mutates the same instance so the sums are already global when we print them.
+struct Stats {
+mut:
+	dial_ok        &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](0)
+	dial_fail      &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](0)
+	handshake_ok   &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](0)
+	handshake_fail &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](0)
+	login_ok       &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](0)
+	keepalives     &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](0)
+	bytes_sent     &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](0)
+	errors         &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](0)
+}
+
+const dial_timeout = 8 * time.second
+const settings_read_timeout = 5 * time.second
+const keepalive_interval = 500 * time.millisecond
+
+fn main() {
+	cfg := parse_args() or {
+		eprintln('error: ${err}')
+		print_usage()
+		exit(1)
+	}
+	run(cfg)
+}
+
+fn print_usage() {
+	eprintln('usage: v run tools/loadtest/main.v <host> <port> <connections> <seconds> [--login]')
+	eprintln('  host         server address (default 127.0.0.1)')
+	eprintln('  port         server udp port (default 19132)')
+	eprintln('  connections  concurrent clients to open (default 50)')
+	eprintln('  seconds      hold duration in seconds (default 10)')
+	eprintln('  --login      also send a Login packet to push the server into auth')
+}
+
+fn parse_args() !Config {
+	args := os.args[1..]
+	mut positional := []string{}
+	mut send_login := false
+	for a in args {
+		if a == '--login' {
+			send_login = true
+		} else if a == '-h' || a == '--help' {
+			print_usage()
+			exit(0)
+		} else {
+			positional << a
+		}
+	}
+	mut cfg := Config{
+		host:        '127.0.0.1'
+		port:        19132
+		connections: 50
+		seconds:     10
+		send_login:  send_login
+	}
+	if positional.len > 0 {
+		cfg.host = positional[0]
+	}
+	if positional.len > 1 {
+		cfg.port = positional[1].int()
+	}
+	if positional.len > 2 {
+		cfg.connections = positional[2].int()
+	}
+	if positional.len > 3 {
+		cfg.seconds = positional[3].int()
+	}
+	if cfg.connections <= 0 {
+		return error('connections must be > 0')
+	}
+	if cfg.seconds <= 0 {
+		return error('seconds must be > 0')
+	}
+	return cfg
+}
+
+fn run(cfg Config) {
+	address := '${cfg.host}:${cfg.port}'
+	println('Vedrock loadtest -> ${address}')
+	println('  connections=${cfg.connections} duration=${cfg.seconds}s login=${cfg.send_login}')
+
+	// Silent logger - the transport wants one but we don't want per-packet noise.
+	log := logger.new(.error)
+	mut stats := &Stats{}
+	// deadline is shared so every worker stops holding at the same wall-clock moment.
+	deadline := time.now().add(cfg.seconds * time.second)
+
+	mut wg := sync.new_waitgroup()
+	wg.add(cfg.connections)
+	start := time.now()
+	for i in 0 .. cfg.connections {
+		spawn worker(address, cfg, deadline, mut stats, log, mut wg)
+		_ := i
+	}
+	wg.wait()
+	elapsed := (time.now() - start).seconds()
+
+	report(cfg, mut stats, elapsed)
+}
+
+// worker owns one client for the whole run: dial, handshake, then hold and
+// keepalive until the shared deadline. Every failure is counted and the worker
+// returns cleanly so one bad connection never stalls the batch.
+fn worker(address string, cfg Config, deadline time.Time, mut stats Stats, log &logger.Logger, mut wg sync.WaitGroup) {
+	defer {
+		wg.done()
+	}
+	mut conn := raknet.dial_timeout(address, dial_timeout) or {
+		stats.dial_fail.add(1)
+		stats.errors.add(1)
+		return
+	}
+	stats.dial_ok.add(1)
+	mut transport := network.new_session(mut conn, log)
+	defer {
+		transport.close()
+	}
+
+	do_handshake(mut transport, cfg, mut stats) or {
+		stats.handshake_fail.add(1)
+		return
+	}
+	stats.handshake_ok.add(1)
+
+	// Hold the connection open, trickling movement packets so the server keeps
+	// doing per-connection read work for the whole duration.
+	for time.now() < deadline {
+		transport.send(keepalive_packet()) or { break }
+		stats.keepalives.add(1)
+		stats.bytes_sent.add(u64(keepalive_size))
+		remaining := deadline - time.now()
+		sleep := if remaining < keepalive_interval { remaining } else { keepalive_interval }
+		if sleep > 0 {
+			time.sleep(sleep)
+		}
+	}
+}
+
+// do_handshake sends RequestNetworkSettings, waits for NetworkSettings, enables
+// compression, and optionally sends a Login. Reaching NetworkSettings is the
+// success boundary - it proves the server ran the real per-connection protocol
+// path (version check + settings response) for this client.
+fn do_handshake(mut transport network.Session, cfg Config, mut stats Stats) ! {
+	transport.send(&protocol.RequestNetworkSettingsPacket{
+		protocol_version: protocol.current_protocol
+	})!
+	stats.bytes_sent.add(u64(request_settings_size))
+
+	got_settings := wait_for_settings(mut transport) or { return err }
+	if !got_settings {
+		return error('no network settings')
+	}
+	transport.enable_compression(network.default_compression_threshold)
+
+	if cfg.send_login {
+		// An offline/garbage chain - the server will reject it at auth, but only
+		// after doing the real login-stage work we want to exercise.
+		transport.send(&protocol.LoginPacket{
+			protocol:        protocol.current_protocol
+			auth_info_json:  '{"chain":[]}'
+			client_data_jwt: ''
+		}) or {}
+		stats.login_ok.add(1)
+	}
+}
+
+// wait_for_settings reads batches until a NetworkSettings packet arrives or the
+// read times out. read() blocks on the RakNet conn, whose read timeout the
+// dialer already configured, so a stalled server surfaces as a read error.
+fn wait_for_settings(mut transport network.Session) !bool {
+	start := time.now()
+	for time.now() - start < settings_read_timeout {
+		packets := transport.read()!
+		for p in packets {
+			if p is protocol.NetworkSettingsPacket {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+const keepalive_size = 16
+const request_settings_size = 12
+
+// keepalive_packet is a cheap movement packet held constant across sends. The
+// server decodes it as real inbound traffic even before spawn.
+fn keepalive_packet() &protocol.PlayerAuthInputPacket {
+	return &protocol.PlayerAuthInputPacket{
+		pitch:    0.0
+		yaw:      0.0
+		position: types.Vector3{
+			x: 0.0
+			y: 64.0
+			z: 0.0
+		}
+	}
+}
+
+fn report(cfg Config, mut stats Stats, elapsed f64) {
+	dial_ok := stats.dial_ok.load()
+	dial_fail := stats.dial_fail.load()
+	hs_ok := stats.handshake_ok.load()
+	hs_fail := stats.handshake_fail.load()
+	login_ok := stats.login_ok.load()
+	keepalives := stats.keepalives.load()
+	bytes_sent := stats.bytes_sent.load()
+	errors := stats.errors.load()
+
+	conns_per_sec := if elapsed > 0 { f64(dial_ok) / elapsed } else { 0.0 }
+	throughput_kb := if elapsed > 0 { (f64(bytes_sent) / 1024.0) / elapsed } else { 0.0 }
+
+	println('')
+	println('==================== loadtest results ====================')
+	println('wall clock:            ${elapsed:.3f}s')
+	println('target connections:    ${cfg.connections}')
+	println('dial ok / fail:        ${dial_ok} / ${dial_fail}')
+	println('handshake ok / fail:   ${hs_ok} / ${hs_fail}')
+	if cfg.send_login {
+		println('login packets sent:    ${login_ok}')
+	}
+	println('connections/sec:       ${conns_per_sec:.1f}')
+	println('keepalives sent:       ${keepalives}')
+	println('bytes sent (approx):   ${bytes_sent}')
+	println('throughput:            ${throughput_kb:.1f} KB/s')
+	println('errors:                ${errors}')
+	println('==========================================================')
+}


### PR DESCRIPTION
## Summary

Adds project scaffolding with no runtime code changes:
- CI workflow (`v -check`, build, `v test server`), Crowdin upload/download, PR labeler and stale-bot workflows
- Dependabot config for GitHub Actions and Docker
- Issue forms, PR template, CODEOWNERS, FUNDING
- AGENTS.md, CLAUDE.md, CONTRIBUTING.md, SECURITY.md and a security review under docs/
- Claude skill/commands and Codex prompts for scaffolding Vedrock content
- A RakNet load-test harness under tools/loadtest/