### PR TITLE
feat: add event bus

### DIFF
--- a/server/event/bus.v
+++ b/server/event/bus.v
@@ -1,0 +1,116 @@
+module event
+
+// registered pairs a handler with the priority it was registered at.
+struct Registered {
+	priority Priority
+	order    int // int(priority), kept so the list can be sorted (enums have no `<`)
+mut:
+	handler Handler
+}
+
+// Bus fans a dispatched Context out to every registered handler in priority
+// order. It is the single event pipe the session code talks to; plugins never
+// touch it directly, they register through the plugin Api.
+@[heap]
+pub struct Bus {
+mut:
+	handlers []Registered
+}
+
+pub fn new_bus() &Bus {
+	return &Bus{}
+}
+
+// register adds a handler at the given priority. Handlers are kept sorted so
+// dispatch always walks lowest -> monitor.
+pub fn (mut b Bus) register(handler Handler, priority Priority) {
+	b.handlers << Registered{
+		priority: priority
+		order:    int(priority)
+		handler:  handler
+	}
+	b.handlers.sort(a.order < b.order)
+}
+
+// len reports how many handlers are registered.
+pub fn (b &Bus) len() int {
+	return b.handlers.len
+}
+
+pub fn (mut b Bus) player_join(mut ctx Context[JoinData]) {
+	for mut r in b.handlers {
+		r.handler.on_player_join(mut ctx)
+	}
+}
+
+pub fn (mut b Bus) player_quit(mut ctx Context[QuitData]) {
+	for mut r in b.handlers {
+		r.handler.on_player_quit(mut ctx)
+	}
+}
+
+pub fn (mut b Bus) player_chat(mut ctx Context[ChatData]) {
+	for mut r in b.handlers {
+		r.handler.on_player_chat(mut ctx)
+	}
+}
+
+pub fn (mut b Bus) player_command(mut ctx Context[CommandData]) {
+	for mut r in b.handlers {
+		r.handler.on_player_command(mut ctx)
+	}
+}
+
+pub fn (mut b Bus) block_break(mut ctx Context[BlockBreakData]) {
+	for mut r in b.handlers {
+		r.handler.on_block_break(mut ctx)
+	}
+}
+
+pub fn (mut b Bus) block_place(mut ctx Context[BlockPlaceData]) {
+	for mut r in b.handlers {
+		r.handler.on_block_place(mut ctx)
+	}
+}
+
+pub fn (mut b Bus) player_interact(mut ctx Context[InteractData]) {
+	for mut r in b.handlers {
+		r.handler.on_player_interact(mut ctx)
+	}
+}
+
+pub fn (mut b Bus) player_attack(mut ctx Context[AttackData]) {
+	for mut r in b.handlers {
+		r.handler.on_player_attack(mut ctx)
+	}
+}
+
+pub fn (mut b Bus) player_hurt(mut ctx Context[HurtData]) {
+	for mut r in b.handlers {
+		r.handler.on_player_hurt(mut ctx)
+	}
+}
+
+pub fn (mut b Bus) player_death(mut ctx Context[DeathData]) {
+	for mut r in b.handlers {
+		r.handler.on_player_death(mut ctx)
+	}
+}
+
+pub fn (mut b Bus) player_respawn(mut ctx Context[RespawnData]) {
+	for mut r in b.handlers {
+		r.handler.on_player_respawn(mut ctx)
+	}
+}
+
+pub fn (mut b Bus) player_move(mut ctx Context[MoveData]) {
+	for mut r in b.handlers {
+		r.handler.on_player_move(mut ctx)
+	}
+}
+
+pub fn (mut b Bus) gamemode_change(mut ctx Context[GameModeChangeData]) {
+	for mut r in b.handlers {
+		r.handler.on_gamemode_change(mut ctx)
+	}
+}

--- a/server/event/bus_test.v
+++ b/server/event/bus_test.v
@@ -1,0 +1,96 @@
+module event
+
+// TagHandler embeds NopHandler and only records that it ran, appending its tag
+// to the join message so ordering is observable.
+struct TagHandler {
+	NopHandler
+	tag string
+}
+
+fn (mut h TagHandler) on_player_join(mut ctx Context[JoinData]) {
+	ctx.val.message += h.tag
+}
+
+// CancelHandler cancels every chat it sees.
+struct CancelHandler {
+	NopHandler
+}
+
+fn (mut h CancelHandler) on_player_chat(mut ctx Context[ChatData]) {
+	ctx.cancel()
+}
+
+fn test_dispatch_runs_in_priority_order() {
+	mut bus := new_bus()
+	// Register out of order; lowest must still run first.
+	bus.register(&TagHandler{ tag: 'C' }, .high)
+	bus.register(&TagHandler{ tag: 'A' }, .lowest)
+	bus.register(&TagHandler{ tag: 'B' }, .normal)
+
+	mut ctx := new_context(JoinData{ message: '' })
+	bus.player_join(mut ctx)
+	assert ctx.val.message == 'ABC'
+	assert bus.len() == 3
+}
+
+fn test_handler_can_mutate_value() {
+	mut bus := new_bus()
+	bus.register(&TagHandler{ tag: '!' }, .normal)
+
+	mut ctx := new_context(JoinData{ message: 'hi' })
+	bus.player_join(mut ctx)
+	assert ctx.val.message == 'hi!'
+}
+
+fn test_handler_can_cancel() {
+	mut bus := new_bus()
+	bus.register(&CancelHandler{}, .normal)
+
+	mut ctx := new_context(ChatData{ message: 'spam' })
+	assert !ctx.is_cancelled()
+	bus.player_chat(mut ctx)
+	assert ctx.is_cancelled()
+}
+
+// DamageHalver halves attack damage, exercising a mutable non-cancel field.
+struct DamageHalver {
+	NopHandler
+}
+
+fn (mut h DamageHalver) on_player_attack(mut ctx Context[AttackData]) {
+	ctx.val.damage /= 2
+}
+
+fn test_attack_damage_is_mutable() {
+	mut bus := new_bus()
+	bus.register(&DamageHalver{}, .normal)
+	mut ctx := new_context(AttackData{ damage: 10.0 })
+	bus.player_attack(mut ctx)
+	assert ctx.val.damage == 5.0
+	assert !ctx.is_cancelled()
+}
+
+// SpawnGuard cancels every block break, like a lobby protector.
+struct SpawnGuard {
+	NopHandler
+}
+
+fn (mut h SpawnGuard) on_block_break(mut ctx Context[BlockBreakData]) {
+	ctx.cancel()
+}
+
+fn test_block_break_can_be_cancelled() {
+	mut bus := new_bus()
+	bus.register(&SpawnGuard{}, .normal)
+	mut ctx := new_context(BlockBreakData{ x: 1, y: 2, z: 3, block_id: 7 })
+	bus.block_break(mut ctx)
+	assert ctx.is_cancelled()
+}
+
+fn test_empty_bus_is_noop() {
+	mut bus := new_bus()
+	mut ctx := new_context(JoinData{ message: 'unchanged' })
+	bus.player_join(mut ctx)
+	assert ctx.val.message == 'unchanged'
+	assert !ctx.is_cancelled()
+}

--- a/server/event/context.v
+++ b/server/event/context.v
@@ -1,0 +1,41 @@
+module event
+
+// Context is a homage to dragonfly's event.Context[T]. It wraps the subject of
+// an event and lets handlers cancel the outcome or mutate the subject in place.
+// Callers dispatch a Context through the Bus, then read back is_cancelled() and
+// the possibly-modified val to decide what actually happens.
+pub struct Context[T] {
+pub mut:
+	cancelled bool
+	val       T
+}
+
+// new_context wraps val in a fresh, uncancelled Context.
+pub fn new_context[T](val T) Context[T] {
+	return Context[T]{
+		val: val
+	}
+}
+
+// cancel marks the event as cancelled. Whether that stops anything is up to the
+// code that dispatched the Context.
+pub fn (mut c Context[T]) cancel() {
+	c.cancelled = true
+}
+
+// is_cancelled reports whether any handler cancelled the event.
+pub fn (c &Context[T]) is_cancelled() bool {
+	return c.cancelled
+}
+
+// Priority orders handlers on the Bus. Lowest runs first so that highest and
+// monitor see the final, already-modified state - monitor handlers are expected
+// to only observe, never mutate. Mirrors PocketMine's EventPriority.
+pub enum Priority {
+	lowest
+	low
+	normal
+	high
+	highest
+	monitor
+}

--- a/server/event/events.v
+++ b/server/event/events.v
@@ -1,0 +1,139 @@
+module event
+
+import server.cmd
+
+// Every event carries the player it originated from as a cmd.Sender - the same
+// interface commands use - so handlers can message, kick or query the player
+// without the event package ever importing the session package. Coordinates and
+// ids are plain primitives for the same reason.
+
+// JoinData is dispatched right after a player finishes spawning. Cancelling it
+// suppresses the broadcast join message; editing message changes it.
+pub struct JoinData {
+pub mut:
+	player  cmd.Sender
+	message string
+}
+
+// QuitData is dispatched when a spawned player leaves. Same rules as JoinData.
+pub struct QuitData {
+pub mut:
+	player  cmd.Sender
+	message string
+}
+
+// ChatData is dispatched for a public chat message. Cancelling it drops the
+// message; editing message rewrites what everyone sees.
+pub struct ChatData {
+pub mut:
+	player  cmd.Sender
+	message string
+}
+
+// CommandData is dispatched before a player command runs. Cancelling it stops
+// the command; editing command rewrites what is executed.
+pub struct CommandData {
+pub mut:
+	player  cmd.Sender
+	command string
+}
+
+// BlockBreakData is dispatched before a block is broken. block_id is the block
+// being removed. Cancelling it leaves the block in place.
+pub struct BlockBreakData {
+pub:
+	x        int
+	y        int
+	z        int
+	block_id int
+pub mut:
+	player cmd.Sender
+}
+
+// BlockPlaceData is dispatched before a block is placed. block_id is the block
+// being placed. Cancelling it stops the placement.
+pub struct BlockPlaceData {
+pub:
+	x        int
+	y        int
+	z        int
+	block_id int
+pub mut:
+	player cmd.Sender
+}
+
+// InteractData is dispatched when a player right-clicks a block, before any
+// placement is decided. Useful for lobby signs and NPC-style interactions.
+// Cancelling it stops the interaction (and any place that would follow).
+pub struct InteractData {
+pub:
+	x    int
+	y    int
+	z    int
+	face int
+pub mut:
+	player cmd.Sender
+}
+
+// AttackData is dispatched when a player attacks an entity. player is the
+// attacker, victim_runtime_id the target. Editing damage changes the hit;
+// cancelling it deals no damage and no knockback.
+pub struct AttackData {
+pub:
+	victim_runtime_id u64
+	critical          bool
+pub mut:
+	player cmd.Sender
+	damage f32
+}
+
+// HurtData is dispatched when a player takes damage. player is the victim,
+// attacker_name the source. Editing amount changes the damage; cancelling it
+// negates the damage entirely.
+pub struct HurtData {
+pub:
+	attacker_name string
+pub mut:
+	player cmd.Sender
+	amount f32
+}
+
+// DeathData is dispatched when a player dies. message_key/params are the death
+// broadcast; cancelling it suppresses the broadcast, editing message_key
+// rewrites it.
+pub struct DeathData {
+pub:
+	params []string
+pub mut:
+	player      cmd.Sender
+	message_key string
+}
+
+// RespawnData is dispatched before a player respawns. Handlers may move the
+// respawn point by editing x/y/z (e.g. to send players back to a lobby).
+pub struct RespawnData {
+pub mut:
+	player cmd.Sender
+	x      f32
+	y      f32
+	z      f32
+}
+
+// MoveData is dispatched when a player moves. Editing x/y/z is ignored; cancel
+// rejects the movement and snaps the player back to where they were.
+pub struct MoveData {
+pub:
+	x f32
+	y f32
+	z f32
+pub mut:
+	player cmd.Sender
+}
+
+// GameModeChangeData is dispatched before a player's gamemode changes. Editing
+// mode changes the target gamemode; cancelling it keeps the current one.
+pub struct GameModeChangeData {
+pub mut:
+	player cmd.Sender
+	mode   int
+}

--- a/server/event/handler.v
+++ b/server/event/handler.v
@@ -1,0 +1,52 @@
+module event
+
+// Handler is the dragonfly-style listener interface: one method per event, each
+// receiving a mutable Context. A plugin embeds NopHandler and overrides only the
+// events it cares about.
+pub interface Handler {
+mut:
+	on_player_join(mut ctx Context[JoinData])
+	on_player_quit(mut ctx Context[QuitData])
+	on_player_chat(mut ctx Context[ChatData])
+	on_player_command(mut ctx Context[CommandData])
+	on_block_break(mut ctx Context[BlockBreakData])
+	on_block_place(mut ctx Context[BlockPlaceData])
+	on_player_interact(mut ctx Context[InteractData])
+	on_player_attack(mut ctx Context[AttackData])
+	on_player_hurt(mut ctx Context[HurtData])
+	on_player_death(mut ctx Context[DeathData])
+	on_player_respawn(mut ctx Context[RespawnData])
+	on_player_move(mut ctx Context[MoveData])
+	on_gamemode_change(mut ctx Context[GameModeChangeData])
+}
+
+// NopHandler is an embeddable no-op implementation of Handler. Embed it so a
+// listener satisfies the whole interface while only defining the handlers it
+// actually needs.
+pub struct NopHandler {}
+
+pub fn (mut h NopHandler) on_player_join(mut ctx Context[JoinData]) {}
+
+pub fn (mut h NopHandler) on_player_quit(mut ctx Context[QuitData]) {}
+
+pub fn (mut h NopHandler) on_player_chat(mut ctx Context[ChatData]) {}
+
+pub fn (mut h NopHandler) on_player_command(mut ctx Context[CommandData]) {}
+
+pub fn (mut h NopHandler) on_block_break(mut ctx Context[BlockBreakData]) {}
+
+pub fn (mut h NopHandler) on_block_place(mut ctx Context[BlockPlaceData]) {}
+
+pub fn (mut h NopHandler) on_player_interact(mut ctx Context[InteractData]) {}
+
+pub fn (mut h NopHandler) on_player_attack(mut ctx Context[AttackData]) {}
+
+pub fn (mut h NopHandler) on_player_hurt(mut ctx Context[HurtData]) {}
+
+pub fn (mut h NopHandler) on_player_death(mut ctx Context[DeathData]) {}
+
+pub fn (mut h NopHandler) on_player_respawn(mut ctx Context[RespawnData]) {}
+
+pub fn (mut h NopHandler) on_player_move(mut ctx Context[MoveData]) {}
+
+pub fn (mut h NopHandler) on_gamemode_change(mut ctx Context[GameModeChangeData]) {}


### PR DESCRIPTION
## Summary

Adds a dragonfly-style event system under server/event/:
- Generic `Context[T]` carrying a cancellable, mutable event value
- A `Handler` interface with one method per event plus an embeddable `NopHandler` so listeners override only what they need
- Priority-ordered `Bus` dispatch (lowest to monitor)
- Event payloads for join, quit, chat, command, block break/place, interact, attack, hurt, death, respawn, move and gamemode change

Self-contained module, not yet wired into sessions (see the integration PR). Unit tested.