### PR TITLE
feat: add task scheduler

### DIFF
--- a/server/scheduler/scheduler.v
+++ b/server/scheduler/scheduler.v
@@ -1,0 +1,121 @@
+module scheduler
+
+import sync
+
+// Scheduler runs Tasks against the server tick clock. It is inspired by
+// PocketMine's TaskScheduler but made thread-safe: Vedrock schedules from many
+// session threads and plugins, while heartbeat() runs on the single tick actor
+// thread. A mutex guards the task table; tasks themselves run outside the lock
+// so a task may safely schedule more work.
+@[heap]
+pub struct Scheduler {
+mut:
+	mutex        &sync.Mutex = sync.new_mutex()
+	tasks        map[int]&TaskHandler
+	current_tick i64
+	next_id      int = 1
+}
+
+pub fn new_scheduler() &Scheduler {
+	return &Scheduler{}
+}
+
+// run_task queues task to run on the next tick.
+pub fn (mut s Scheduler) run_task(task Task) &TaskHandler {
+	return s.add(task, 0, 0)
+}
+
+// run_delayed queues task to run once, delay ticks from now.
+pub fn (mut s Scheduler) run_delayed(task Task, delay i64) &TaskHandler {
+	return s.add(task, delay, 0)
+}
+
+// run_repeating queues task to run every period ticks, starting next tick.
+pub fn (mut s Scheduler) run_repeating(task Task, period i64) &TaskHandler {
+	return s.add(task, 0, period)
+}
+
+// run_delayed_repeating queues task to first run after delay ticks, then every
+// period ticks.
+pub fn (mut s Scheduler) run_delayed_repeating(task Task, delay i64, period i64) &TaskHandler {
+	return s.add(task, delay, period)
+}
+
+// add is the single insertion point. delay <= 0 means "next tick"; period <= 0
+// means "run once".
+fn (mut s Scheduler) add(task Task, delay i64, period i64) &TaskHandler {
+	s.mutex.lock()
+	id := s.next_id
+	s.next_id++
+	start := if delay > 0 { s.current_tick + delay } else { s.current_tick }
+	mut handler := &TaskHandler{
+		id:       id
+		delay:    delay
+		period:   period
+		task:     task
+		next_run: start
+	}
+	s.tasks[id] = handler
+	s.mutex.unlock()
+	return handler
+}
+
+// cancel stops and removes the task with the given id, if present.
+pub fn (mut s Scheduler) cancel(id int) {
+	s.mutex.lock()
+	if mut handler := s.tasks[id] {
+		handler.cancelled = true
+		s.tasks.delete(id)
+	}
+	s.mutex.unlock()
+}
+
+// cancel_all cancels and drops every queued task.
+pub fn (mut s Scheduler) cancel_all() {
+	s.mutex.lock()
+	for _, mut handler in s.tasks {
+		handler.cancelled = true
+	}
+	s.tasks.clear()
+	s.mutex.unlock()
+}
+
+// count reports how many tasks are queued.
+pub fn (mut s Scheduler) count() int {
+	s.mutex.lock()
+	defer { s.mutex.unlock() }
+	return s.tasks.len
+}
+
+// heartbeat advances the clock to tick and runs every task due at or before it.
+// Called once per server tick from the tick actor thread. Due tasks are
+// collected under the lock, then run unlocked; repeating tasks are rescheduled
+// and one-shots removed afterwards.
+pub fn (mut s Scheduler) heartbeat(tick i64) {
+	s.mutex.lock()
+	s.current_tick = tick
+	mut due := []&TaskHandler{}
+	for _, handler in s.tasks {
+		if !handler.cancelled && handler.next_run <= tick {
+			due << handler
+		}
+	}
+	s.mutex.unlock()
+
+	for mut handler in due {
+		if handler.is_cancelled() {
+			continue
+		}
+		handler.task.run()
+	}
+
+	s.mutex.lock()
+	for mut handler in due {
+		if handler.cancelled || !handler.is_repeating() {
+			s.tasks.delete(handler.id)
+		} else {
+			handler.next_run = tick + handler.period
+		}
+	}
+	s.mutex.unlock()
+}

--- a/server/scheduler/scheduler_test.v
+++ b/server/scheduler/scheduler_test.v
@@ -1,0 +1,82 @@
+module scheduler
+
+// CounterTask bumps a shared counter every time it runs.
+struct CounterTask {
+mut:
+	runs &int
+}
+
+fn (t &CounterTask) run() {
+	unsafe {
+		(*t.runs)++
+	}
+}
+
+fn test_delayed_runs_once_after_delay() {
+	mut runs := 0
+	mut s := new_scheduler()
+	s.run_delayed(&CounterTask{ runs: &runs }, 5)
+
+	// Not due before the delay elapses.
+	s.heartbeat(1)
+	s.heartbeat(4)
+	assert runs == 0
+	// Fires on the delay tick, then never again.
+	s.heartbeat(5)
+	assert runs == 1
+	s.heartbeat(6)
+	s.heartbeat(20)
+	assert runs == 1
+	assert s.count() == 0
+}
+
+fn test_repeating_runs_every_period() {
+	mut runs := 0
+	mut s := new_scheduler()
+	s.run_repeating(&CounterTask{ runs: &runs }, 3)
+
+	s.heartbeat(0) // starts next tick, next_run == 0 so fires now
+	s.heartbeat(3)
+	s.heartbeat(6)
+	assert runs == 3
+	assert s.count() == 1
+}
+
+fn test_cancel_stops_task() {
+	mut runs := 0
+	mut s := new_scheduler()
+	handler := s.run_repeating(&CounterTask{ runs: &runs }, 2)
+
+	s.heartbeat(0)
+	assert runs == 1
+	s.cancel(handler.id())
+	s.heartbeat(2)
+	s.heartbeat(4)
+	assert runs == 1
+	assert s.count() == 0
+}
+
+fn test_closure_task() {
+	mut ran := 0
+	p := &ran
+	mut s := new_scheduler()
+	s.run_task(new_closure_task(fn [p] () {
+		unsafe {
+			*p = 1
+		}
+	}))
+	s.heartbeat(1)
+	assert ran == 1
+}
+
+fn test_cancel_all_clears_queue() {
+	mut runs := 0
+	mut s := new_scheduler()
+	s.run_repeating(&CounterTask{ runs: &runs }, 1)
+	s.run_repeating(&CounterTask{ runs: &runs }, 1)
+	assert s.count() == 2
+	s.cancel_all()
+	assert s.count() == 0
+	s.heartbeat(5)
+	assert runs == 0
+}

--- a/server/scheduler/task.v
+++ b/server/scheduler/task.v
@@ -1,0 +1,61 @@
+module scheduler
+
+// Task is the unit of scheduled work, modelled on PocketMine's Task. Implement
+// run() with whatever should happen when the task fires. For one-off callbacks
+// without a dedicated struct, use ClosureTask.
+pub interface Task {
+	run()
+}
+
+// ClosureTask adapts a plain function into a Task so callers can schedule a
+// closure without declaring a struct.
+pub struct ClosureTask {
+	callback fn () @[required]
+}
+
+pub fn (t &ClosureTask) run() {
+	t.callback()
+}
+
+// new_closure_task wraps cb in a Task.
+pub fn new_closure_task(cb fn ()) &ClosureTask {
+	return &ClosureTask{
+		callback: cb
+	}
+}
+
+// TaskHandler is the scheduler's live record of a queued task. It is returned
+// from every schedule_* call so the caller can cancel the task later. Mirrors
+// PocketMine's TaskHandler: delay and period are in ticks, next_run is the tick
+// the task fires on.
+@[heap]
+pub struct TaskHandler {
+	id     int
+	delay  i64
+	period i64
+mut:
+	task      Task
+	next_run  i64
+	cancelled bool
+}
+
+// id returns the scheduler-assigned handle id.
+pub fn (h &TaskHandler) id() int {
+	return h.id
+}
+
+// is_cancelled reports whether the task has been cancelled.
+pub fn (h &TaskHandler) is_cancelled() bool {
+	return h.cancelled
+}
+
+// cancel stops the task from running again. A repeating task will not fire
+// after this; a pending delayed task never fires.
+pub fn (mut h TaskHandler) cancel() {
+	h.cancelled = true
+}
+
+// is_repeating reports whether the task reschedules itself after each run.
+pub fn (h &TaskHandler) is_repeating() bool {
+	return h.period > 0
+}


### PR DESCRIPTION
## Summary

Adds a PocketMine-style tick scheduler under server/scheduler/:
- `Task` interface and `ClosureTask` for closure-based work
- `TaskHandler` with delay and period in ticks, plus cancel
- Delayed, repeating and delayed-repeating scheduling
- Mutex-guarded so tasks can be scheduled from any thread; `heartbeat(tick)` drains due tasks on the actor thread (20 ticks = 1s)

Self-contained module, wired in the integration PR. Unit tested.