### PR TITLE
feat: add entity system

### DIFF
--- a/server/entity/behaviour.v
+++ b/server/entity/behaviour.v
@@ -1,0 +1,40 @@
+module entity
+
+// Behaviour drives an Entity's per-tick logic, mirroring dragonfly's Behaviour
+// interface. identifier() returns the network type id used when the entity is
+// spawned for clients; tick() runs once per server tick before physics is
+// applied. A Behaviour mutates the Entity directly (velocity, kill, etc.).
+pub interface Behaviour {
+	identifier() string
+mut:
+	tick(mut e Entity)
+}
+
+// PassiveBehaviour is a do-nothing behaviour for stationary/idle mobs. Physics
+// still applies, so the entity falls to floor_y and rests there.
+pub struct PassiveBehaviour {
+	network_id string
+}
+
+pub fn (b &PassiveBehaviour) identifier() string {
+	return b.network_id
+}
+
+pub fn (mut b PassiveBehaviour) tick(mut e Entity) {}
+
+// ProjectileBehaviour flies with its initial velocity and despawns when it hits
+// the ground or outlives max_age ticks - the shape of a snowball or egg.
+pub struct ProjectileBehaviour {
+	network_id string
+	max_age    i64 = 100
+}
+
+pub fn (b &ProjectileBehaviour) identifier() string {
+	return b.network_id
+}
+
+pub fn (mut b ProjectileBehaviour) tick(mut e Entity) {
+	if e.age >= b.max_age || (e.on_ground && e.age > 1) {
+		e.kill()
+	}
+}

--- a/server/entity/entity.v
+++ b/server/entity/entity.v
@@ -1,0 +1,194 @@
+module entity
+
+import protocol
+import protocol.types
+import server.world
+
+// gravity and drag are applied per tick to any entity that is not marked
+// no_gravity. Values are in blocks/tick, matching Bedrock's ~0.08 gravity and
+// light air drag.
+const gravity = f32(0.08)
+const drag = f32(0.02)
+
+// entity_half_width and entity_height approximate the collision box shared by
+// most mobs. Position is the box centre on x/z and the feet on y, matching the
+// AddActorPacket convention. Kept as a single size - per-type boxes can come
+// later.
+const entity_half_width = f32(0.3)
+const entity_height = f32(1.8)
+
+// Entity is a non-player actor living in the world - a mob, item or projectile.
+// It is the Vedrock counterpart to dragonfly's Ent: shared state plus a pluggable
+// Behaviour that drives its per-tick logic. Players stay as NetworkSession; this
+// system covers everything else the client renders as an actor.
+@[heap]
+pub struct Entity {
+pub:
+	unique_id  i64
+	runtime_id u64
+	identifier string // network type id, e.g. 'minecraft:pig'
+pub mut:
+	pos        types.Vector3
+	velocity   types.Vector3
+	pitch      f32
+	yaw        f32
+	head_yaw   f32
+	floor_y    f32
+	on_ground  bool
+	no_gravity bool
+	health     f32 = 20.0
+	dead       bool
+	age        i64
+	behaviour  Behaviour
+}
+
+// position returns the entity's current position.
+pub fn (e &Entity) position() types.Vector3 {
+	return e.pos
+}
+
+// is_dead reports whether the entity is scheduled for removal.
+pub fn (e &Entity) is_dead() bool {
+	return e.dead
+}
+
+// kill marks the entity dead. The Manager removes and despawns it on the next
+// tick.
+pub fn (mut e Entity) kill() {
+	e.dead = true
+}
+
+// set_velocity replaces the entity's velocity (blocks/tick).
+pub fn (mut e Entity) set_velocity(v types.Vector3) {
+	e.velocity = v
+}
+
+// teleport moves the entity to pos and resets its ground clamp there.
+pub fn (mut e Entity) teleport(pos types.Vector3) {
+	e.pos = pos
+	e.floor_y = pos.y
+}
+
+// apply_physics integrates velocity into position, applying gravity and drag,
+// then resolves collision against the solid blocks around the entity's box using
+// the Host's block query. Called by the Manager after the Behaviour ticks.
+//
+// Collision is axis-separated AABB vs the block grid: each axis moves
+// independently and a move that would enter a solid block is cancelled and its
+// velocity zeroed. Landing on a block below sets on_ground and snaps the feet to
+// the block top. floor_y stays as a hard fallback floor for entities spawned
+// over ungenerated terrain.
+fn (mut e Entity) apply_physics(mut host Host) {
+	if !e.no_gravity {
+		e.velocity.y -= gravity
+	}
+	e.velocity.x *= (1.0 - drag)
+	e.velocity.y *= (1.0 - drag)
+	e.velocity.z *= (1.0 - drag)
+
+	e.pos.x += e.velocity.x
+	if e.collides(mut host) {
+		e.pos.x -= e.velocity.x
+		e.velocity.x = 0.0
+	}
+
+	e.pos.z += e.velocity.z
+	if e.collides(mut host) {
+		e.pos.z -= e.velocity.z
+		e.velocity.z = 0.0
+	}
+
+	e.on_ground = false
+	e.pos.y += e.velocity.y
+	if e.collides(mut host) {
+		if e.velocity.y <= 0.0 {
+			// landed - snap feet to the top of the block underneath
+			e.pos.y = math_floor(e.pos.y) + 1.0
+			e.on_ground = true
+		} else {
+			// hit a ceiling - undo the upward move
+			e.pos.y -= e.velocity.y
+		}
+		e.velocity.y = 0.0
+	}
+
+	if e.pos.y <= e.floor_y {
+		e.pos.y = e.floor_y
+		e.velocity.y = 0.0
+		e.on_ground = true
+	}
+}
+
+// collides reports whether the entity's AABB overlaps any solid block. Air is
+// the only guaranteed-passable id; everything else is treated as solid, which is
+// a coarse first pass - non-solid blocks like grass or water are not special
+// cased yet.
+fn (e &Entity) collides(mut host Host) bool {
+	min_x := int(math_floor(e.pos.x - entity_half_width))
+	max_x := int(math_floor(e.pos.x + entity_half_width))
+	min_z := int(math_floor(e.pos.z - entity_half_width))
+	max_z := int(math_floor(e.pos.z + entity_half_width))
+	min_y := int(math_floor(e.pos.y))
+	max_y := int(math_floor(e.pos.y + entity_height))
+	for bx := min_x; bx <= max_x; bx++ {
+		for bz := min_z; bz <= max_z; bz++ {
+			for by := min_y; by <= max_y; by++ {
+				if host.get_block(bx, by, bz) != world.air.network_id {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// math_floor is an integer floor that also handles negative coordinates, where a
+// plain int() cast truncates toward zero and would misplace the block cell.
+fn math_floor(v f32) f32 {
+	i := f32(int(v))
+	return if v < i { i - 1.0 } else { i }
+}
+
+// spawn_packet builds the AddActorPacket that makes this entity appear for a
+// viewer. Public so the session layer can send it to players joining late.
+pub fn (e &Entity) spawn_packet() &protocol.AddActorPacket {
+	return &protocol.AddActorPacket{
+		actor_unique_id:   e.unique_id
+		actor_runtime_id:  e.runtime_id
+		type:              e.identifier
+		position:          e.pos
+		motion:            e.velocity
+		pitch:             e.pitch
+		yaw:               e.yaw
+		head_yaw:          e.head_yaw
+		body_yaw:          e.yaw
+		attributes:        []types.ActorAttribute{}
+		metadata:          []types.MetadataEntry{}
+		synced_properties: types.PropertySyncData{}
+		links:             []types.EntityLink{}
+	}
+}
+
+// move_packet builds the movement update broadcast each tick the entity moves.
+pub fn (e &Entity) move_packet() &protocol.MoveActorAbsolutePacket {
+	mut flags := 0
+	if e.on_ground {
+		flags = protocol.move_actor_flag_on_ground
+	}
+	return &protocol.MoveActorAbsolutePacket{
+		actor_runtime_id: e.runtime_id
+		flags:            flags
+		position:         e.pos
+		pitch:            e.pitch
+		yaw:              e.yaw
+		head_yaw:         e.head_yaw
+	}
+}
+
+// despawn_packet builds the RemoveActorPacket that removes this entity from a
+// viewer.
+pub fn (e &Entity) despawn_packet() &protocol.RemoveActorPacket {
+	return &protocol.RemoveActorPacket{
+		actor_unique_id: e.unique_id
+	}
+}

--- a/server/entity/manager.v
+++ b/server/entity/manager.v
@@ -1,0 +1,120 @@
+module entity
+
+import sync
+import protocol
+import protocol.types
+
+// view_radius is the distance in blocks within which an entity's spawn and move
+// packets are sent to a player. Beyond it the client never hears about the
+// entity, so idle mobs on the far side of the world cost no bandwidth.
+const view_radius = f32(64.0)
+
+// Host is the slice of the server the entity Manager needs: a broadcaster to
+// send actor packets to every viewer, a radius-limited broadcaster for
+// view-distance culling, the shared runtime-id allocator so entities and players
+// never collide in id space, and a block query for collision. Hub satisfies it.
+pub interface Host {
+mut:
+	broadcast(p protocol.Packet)
+	broadcast_near(x f32, y f32, z f32, radius f32, p protocol.Packet)
+	allocate_runtime_id() u64
+	get_block(x int, y int, z int) int
+}
+
+// Manager owns every live non-player Entity. spawn/despawn are safe from any
+// thread (mutex-guarded); tick() runs once per server tick on the Hub actor
+// thread, the same place player state is mutated.
+@[heap]
+pub struct Manager {
+mut:
+	mutex    &sync.Mutex = sync.new_mutex()
+	entities map[u64]&Entity
+	host     Host
+}
+
+pub fn new_manager(host Host) &Manager {
+	return &Manager{
+		host: host
+	}
+}
+
+// spawn creates an entity driven by behaviour at pos, registers it and
+// broadcasts its appearance to all viewers. Returns the live Entity.
+pub fn (mut m Manager) spawn(behaviour Behaviour, pos types.Vector3) &Entity {
+	rid := m.host.allocate_runtime_id()
+	mut e := &Entity{
+		unique_id:  i64(rid)
+		runtime_id: rid
+		identifier: behaviour.identifier()
+		pos:        pos
+		floor_y:    pos.y
+		behaviour:  behaviour
+	}
+	m.mutex.lock()
+	m.entities[rid] = e
+	m.mutex.unlock()
+	m.host.broadcast_near(e.pos.x, e.pos.y, e.pos.z, view_radius, e.spawn_packet())
+	return e
+}
+
+// despawn removes the entity with runtime_id and tells viewers to drop it.
+pub fn (mut m Manager) despawn(runtime_id u64) {
+	m.mutex.lock()
+	e := m.entities[runtime_id] or {
+		m.mutex.unlock()
+		return
+	}
+	m.entities.delete(runtime_id)
+	m.mutex.unlock()
+	m.host.broadcast(e.despawn_packet())
+}
+
+// count reports how many entities are alive.
+pub fn (mut m Manager) count() int {
+	m.mutex.lock()
+	defer { m.mutex.unlock() }
+	return m.entities.len
+}
+
+// snapshot returns a stable copy of the live entity list. Used to send existing
+// entities to a player who just joined.
+pub fn (mut m Manager) snapshot() []&Entity {
+	m.mutex.lock()
+	defer { m.mutex.unlock() }
+	mut list := []&Entity{cap: m.entities.len}
+	for _, e in m.entities {
+		list << e
+	}
+	return list
+}
+
+// tick advances every entity one server tick: run its Behaviour, apply physics,
+// remove the dead, and broadcast movement for the ones that moved.
+pub fn (mut m Manager) tick() {
+	for mut e in m.snapshot() {
+		if e.dead {
+			continue
+		}
+		e.age++
+		before := e.pos
+		e.behaviour.tick(mut e)
+		e.apply_physics(mut m.host)
+		if e.dead {
+			m.despawn(e.runtime_id)
+			continue
+		}
+		if moved(before, e.pos) {
+			m.host.broadcast_near(e.pos.x, e.pos.y, e.pos.z, view_radius, e.move_packet())
+		}
+	}
+}
+
+// moved reports whether two positions differ enough to be worth a broadcast.
+fn moved(a types.Vector3, b types.Vector3) bool {
+	eps := f32(0.0001)
+	return abs_f32(a.x - b.x) > eps || abs_f32(a.y - b.y) > eps || abs_f32(a.z - b.z) > eps
+}
+
+fn abs_f32(v f32) f32 {
+	return if v < 0 { -v } else { v }
+}

--- a/server/entity/manager.v
+++ b/server/entity/manager.v
@@ -92,7 +92,10 @@ pub fn (mut m Manager) snapshot() []&Entity {
 // remove the dead, and broadcast movement for the ones that moved.
 pub fn (mut m Manager) tick() {
 	for mut e in m.snapshot() {
+		// Killed between ticks via Entity.kill() - despawn here so it leaves
+		// m.entities and a RemoveActorPacket goes out, same as an in-tick death.
 		if e.dead {
+			m.despawn(e.runtime_id)
 			continue
 		}
 		e.age++

--- a/server/entity/manager_test.v
+++ b/server/entity/manager_test.v
@@ -1,0 +1,133 @@
+module entity
+
+import protocol
+import protocol.types
+import server.world
+
+// FakeHost stands in for Hub: it hands out ids, counts broadcasts and backs a
+// small in-memory block grid so collision can be tested without a real world.
+// Any coordinate not in solids reads as air.
+struct FakeHost {
+mut:
+	next       u64 = 1
+	broadcasts int
+	near       int
+	solids     map[string]int
+}
+
+fn block_key(x int, y int, z int) string {
+	return '${x},${y},${z}'
+}
+
+fn (mut h FakeHost) set_solid(x int, y int, z int) {
+	h.solids[block_key(x, y, z)] = 1
+}
+
+fn (mut h FakeHost) broadcast(p protocol.Packet) {
+	h.broadcasts++
+}
+
+fn (mut h FakeHost) broadcast_near(x f32, y f32, z f32, radius f32, p protocol.Packet) {
+	h.near++
+}
+
+fn (mut h FakeHost) allocate_runtime_id() u64 {
+	id := h.next
+	h.next++
+	return id
+}
+
+fn (mut h FakeHost) get_block(x int, y int, z int) int {
+	if _ := h.solids[block_key(x, y, z)] {
+		return 1
+	}
+	return world.air.network_id
+}
+
+fn test_spawn_registers_and_broadcasts() {
+	mut host := &FakeHost{}
+	mut m := new_manager(host)
+	e := m.spawn(&PassiveBehaviour{ network_id: 'minecraft:pig' }, types.Vector3{0, 10, 0})
+	assert m.count() == 1
+	assert e.identifier == 'minecraft:pig'
+	assert e.runtime_id == 1
+	assert host.near == 1 // AddActor routed through broadcast_near
+	assert host.broadcasts == 0
+}
+
+fn test_despawn_removes_and_broadcasts() {
+	mut host := &FakeHost{}
+	mut m := new_manager(host)
+	e := m.spawn(&PassiveBehaviour{ network_id: 'minecraft:cow' }, types.Vector3{0, 0, 0})
+	m.despawn(e.runtime_id)
+	assert m.count() == 0
+	assert host.near == 1 // AddActor via broadcast_near
+	assert host.broadcasts == 1 // RemoveActor via broadcast
+}
+
+fn test_gravity_pulls_entity_down() {
+	mut host := &FakeHost{}
+	mut m := new_manager(host)
+	mut e := m.spawn(&PassiveBehaviour{ network_id: 'minecraft:pig' }, types.Vector3{0, 10, 0})
+	e.floor_y = 0 // let it fall
+	m.tick()
+	assert e.pos.y < 10
+	assert !e.on_ground
+}
+
+fn test_entity_rests_on_floor() {
+	mut host := &FakeHost{}
+	mut m := new_manager(host)
+	mut e := m.spawn(&PassiveBehaviour{ network_id: 'minecraft:pig' }, types.Vector3{0, 5, 0})
+	// floor_y defaults to spawn y, so it should not sink.
+	m.tick()
+	assert e.pos.y == 5
+	assert e.on_ground
+}
+
+fn test_entity_lands_on_solid_block() {
+	mut host := &FakeHost{}
+	host.set_solid(0, 4, 0) // block top at y=5
+	mut m := new_manager(host)
+	mut e := m.spawn(&PassiveBehaviour{ network_id: 'minecraft:pig' }, types.Vector3{0.5, 10, 0.5})
+	e.floor_y = -64 // let real block detection do the work, not the fallback
+	for _ in 0 .. 40 {
+		m.tick()
+	}
+	assert e.on_ground
+	assert e.pos.y == 5.0 // feet snapped to block top
+}
+
+fn test_entity_does_not_pass_through_wall() {
+	mut host := &FakeHost{}
+	host.set_solid(1, 5, 0) // wall east of the entity
+	mut m := new_manager(host)
+	mut e := m.spawn(&PassiveBehaviour{ network_id: 'minecraft:pig' }, types.Vector3{0.5, 5, 0.5})
+	e.floor_y = 5
+	e.no_gravity = true
+	e.set_velocity(types.Vector3{0.5, 0, 0}) // push toward the wall
+	for _ in 0 .. 10 {
+		e.set_velocity(types.Vector3{0.5, 0, 0})
+		m.tick()
+	}
+	assert e.pos.x < 1.0 // blocked before entering the wall block at x=1
+}
+
+fn test_spawn_uses_near_broadcast() {
+	mut host := &FakeHost{}
+	mut m := new_manager(host)
+	m.spawn(&PassiveBehaviour{ network_id: 'minecraft:pig' }, types.Vector3{0, 10, 0})
+	assert host.near == 1 // AddActor routed through broadcast_near
+}
+
+fn test_projectile_despawns_after_max_age() {
+	mut host := &FakeHost{}
+	mut m := new_manager(host)
+	mut e := m.spawn(&ProjectileBehaviour{ network_id: 'minecraft:snowball', max_age: 5 },
+		types.Vector3{0, 10, 0})
+	e.no_gravity = true // isolate the age check from the ground check
+	for _ in 0 .. 6 {
+		m.tick()
+	}
+	assert m.count() == 0
+}

--- a/server/entity/registry.v
+++ b/server/entity/registry.v
@@ -1,0 +1,65 @@
+module entity
+
+// BehaviourFactory builds a fresh Behaviour for a registered entity type. Each
+// spawn gets its own instance so per-entity behaviour state stays isolated.
+pub type BehaviourFactory = fn () Behaviour
+
+// Registry maps short type names (e.g. 'pig') to Behaviour factories. It is the
+// lookup /summon and plugins use to spawn entities by name.
+pub struct Registry {
+mut:
+	factories map[string]BehaviourFactory
+}
+
+pub fn new_registry() Registry {
+	return Registry{}
+}
+
+// register adds a named entity type. Re-registering a name overwrites it.
+pub fn (mut r Registry) register(name string, factory BehaviourFactory) {
+	r.factories[name.to_lower()] = factory
+}
+
+// create builds a new Behaviour for name, or none if the type is unknown.
+pub fn (r &Registry) create(name string) ?Behaviour {
+	factory := r.factories[name.to_lower()] or { return none }
+	return factory()
+}
+
+// names lists every registered type name.
+pub fn (r &Registry) names() []string {
+	mut out := []string{cap: r.factories.len}
+	for name, _ in r.factories {
+		out << name
+	}
+	return out
+}
+
+// register_defaults registers the entity types Vedrock ships with.
+pub fn register_defaults(mut r Registry) {
+	r.register('pig', fn () Behaviour {
+		return &PassiveBehaviour{
+			network_id: 'minecraft:pig'
+		}
+	})
+	r.register('cow', fn () Behaviour {
+		return &PassiveBehaviour{
+			network_id: 'minecraft:cow'
+		}
+	})
+	r.register('chicken', fn () Behaviour {
+		return &PassiveBehaviour{
+			network_id: 'minecraft:chicken'
+		}
+	})
+	r.register('zombie', fn () Behaviour {
+		return &PassiveBehaviour{
+			network_id: 'minecraft:zombie'
+		}
+	})
+	r.register('snowball', fn () Behaviour {
+		return &ProjectileBehaviour{
+			network_id: 'minecraft:snowball'
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds non-player entities (mobs, projectiles) under server/entity/, following dragonfly's Ent + Behaviour model:
- `Entity` with position, velocity, rotation and health, plus AddActor/MoveActor/RemoveActor packet builders
- Axis-separated AABB block collision and simple gravity/drag physics
- A pluggable `Behaviour` interface (`PassiveBehaviour`, `ProjectileBehaviour`) and a name-to-factory `Registry`
- A mutex-guarded `Manager` with view-distance culling via a `Host` abstraction (Hub satisfies it)

Self-contained module, wired in the integration PR. Unit tested.