### PR TITLE
feat: add arena snapshot and restore

### DIFF
--- a/server/arena/snapshot.v
+++ b/server/arena/snapshot.v
@@ -43,8 +43,9 @@ pub fn new_box(x1 int, y1 int, z1 int, x2 int, y2 int, z2 int) Box {
 }
 
 // volume is the number of blocks the box covers (inclusive on both corners).
-pub fn (b Box) volume() int {
-	return (b.max_x - b.min_x + 1) * (b.max_y - b.min_y + 1) * (b.max_z - b.min_z + 1)
+// Computed in i64 so a huge box can't overflow int32 and slip past the cap.
+pub fn (b Box) volume() i64 {
+	return i64(b.max_x - b.min_x + 1) * i64(b.max_y - b.min_y + 1) * i64(b.max_z - b.min_z + 1)
 }
 
 // Snapshot holds the block ids of a Box captured at some point in time. It is
@@ -63,7 +64,7 @@ pub fn capture(mut src BlockSource, box Box) !&Snapshot {
 	if box.volume() > max_volume {
 		return error('arena: box volume ${box.volume()} exceeds cap ${max_volume}')
 	}
-	mut ids := []int{cap: box.volume()}
+	mut ids := []int{cap: int(box.volume())}
 	for y := box.min_y; y <= box.max_y; y++ {
 		for x := box.min_x; x <= box.max_x; x++ {
 			for z := box.min_z; z <= box.max_z; z++ {

--- a/server/arena/snapshot.v
+++ b/server/arena/snapshot.v
@@ -1,0 +1,97 @@
+module arena
+
+// BlockSource reads block network ids from a world by absolute coordinates.
+// Hub satisfies it; tests use an in-memory grid.
+pub interface BlockSource {
+mut:
+	get_block(x int, y int, z int) int
+}
+
+// BlockSink writes a block by network id and broadcasts the change to viewers.
+// Restore goes through this so a reset looks identical to normal block edits.
+pub interface BlockSink {
+mut:
+	set_block_id(id int, x int, y int, z int)
+}
+
+// max_volume caps how many blocks a single snapshot may capture so a bad
+// min/max box can't allocate unbounded memory. 256*256*256 is generous for
+// a minigame arena while still bounded.
+pub const max_volume = 256 * 256 * 256
+
+// Box is an axis-aligned block region, normalized so min <= max on every axis.
+pub struct Box {
+pub:
+	min_x int
+	min_y int
+	min_z int
+	max_x int
+	max_y int
+	max_z int
+}
+
+// new_box normalizes the two corners so the caller need not order them.
+pub fn new_box(x1 int, y1 int, z1 int, x2 int, y2 int, z2 int) Box {
+	return Box{
+		min_x: if x1 < x2 { x1 } else { x2 }
+		min_y: if y1 < y2 { y1 } else { y2 }
+		min_z: if z1 < z2 { z1 } else { z2 }
+		max_x: if x1 > x2 { x1 } else { x2 }
+		max_y: if y1 > y2 { y1 } else { y2 }
+		max_z: if z1 > z2 { z1 } else { z2 }
+	}
+}
+
+// volume is the number of blocks the box covers (inclusive on both corners).
+pub fn (b Box) volume() int {
+	return (b.max_x - b.min_x + 1) * (b.max_y - b.min_y + 1) * (b.max_z - b.min_z + 1)
+}
+
+// Snapshot holds the block ids of a Box captured at some point in time. It is
+// a flat array so a full restore is a single linear pass. Memory cost is
+// 4 bytes per block - a 64^3 arena is ~1 MB.
+pub struct Snapshot {
+pub:
+	box Box
+mut:
+	ids []int
+}
+
+// capture reads every block in box from src into a fresh Snapshot. Returns an
+// error if the box exceeds max_volume so a runaway box can't exhaust memory.
+pub fn capture(mut src BlockSource, box Box) !&Snapshot {
+	if box.volume() > max_volume {
+		return error('arena: box volume ${box.volume()} exceeds cap ${max_volume}')
+	}
+	mut ids := []int{cap: box.volume()}
+	for y := box.min_y; y <= box.max_y; y++ {
+		for x := box.min_x; x <= box.max_x; x++ {
+			for z := box.min_z; z <= box.max_z; z++ {
+				ids << src.get_block(x, y, z)
+			}
+		}
+	}
+	return &Snapshot{
+		box: box
+		ids: ids
+	}
+}
+
+// restore writes every captured block back through sink in the same order it
+// was captured, so viewers see the arena reset to its saved state.
+pub fn (s &Snapshot) restore(mut sink BlockSink) {
+	mut i := 0
+	for y := s.box.min_y; y <= s.box.max_y; y++ {
+		for x := s.box.min_x; x <= s.box.max_x; x++ {
+			for z := s.box.min_z; z <= s.box.max_z; z++ {
+				sink.set_block_id(s.ids[i], x, y, z)
+				i++
+			}
+		}
+	}
+}
+
+// len is the number of blocks stored in the snapshot.
+pub fn (s &Snapshot) len() int {
+	return s.ids.len
+}

--- a/server/arena/snapshot_test.v
+++ b/server/arena/snapshot_test.v
@@ -1,0 +1,80 @@
+module arena
+
+// FakeWorld is an in-memory block grid standing in for a real world. It
+// satisfies both BlockSource and BlockSink so a capture-then-restore round
+// trip can be exercised without a LevelDB world or a live Hub.
+struct FakeWorld {
+mut:
+	blocks map[string]int
+	writes int
+}
+
+fn key(x int, y int, z int) string {
+	return '${x}:${y}:${z}'
+}
+
+fn (mut w FakeWorld) get_block(x int, y int, z int) int {
+	return w.blocks[key(x, y, z)] or { 0 }
+}
+
+fn (mut w FakeWorld) set_block_id(id int, x int, y int, z int) {
+	w.blocks[key(x, y, z)] = id
+	w.writes++
+}
+
+fn test_capture_then_restore_round_trip() {
+	mut w := &FakeWorld{}
+	// stamp a distinct id at every cell so a mixed-up order would show up.
+	for x in 0 .. 3 {
+		for y in 0 .. 3 {
+			for z in 0 .. 3 {
+				w.blocks[key(x, y, z)] = x * 100 + y * 10 + z
+			}
+		}
+	}
+	snap := capture(mut w, new_box(0, 0, 0, 2, 2, 2))!
+	assert snap.len() == 27
+
+	// overwrite the whole region, then restore it back.
+	for x in 0 .. 3 {
+		for y in 0 .. 3 {
+			for z in 0 .. 3 {
+				w.blocks[key(x, y, z)] = -1
+			}
+		}
+	}
+	snap.restore(mut w)
+	for x in 0 .. 3 {
+		for y in 0 .. 3 {
+			for z in 0 .. 3 {
+				assert w.get_block(x, y, z) == x * 100 + y * 10 + z
+			}
+		}
+	}
+	assert w.writes == 27
+}
+
+fn test_box_normalizes_corners() {
+	b := new_box(5, 9, 8, 1, 2, 3)
+	assert b.min_x == 1 && b.min_y == 2 && b.min_z == 3
+	assert b.max_x == 5 && b.max_y == 9 && b.max_z == 8
+	assert b.volume() == 5 * 8 * 6
+}
+
+fn test_single_block_box() {
+	mut w := &FakeWorld{}
+	w.blocks[key(10, 20, 30)] = 42
+	snap := capture(mut w, new_box(10, 20, 30, 10, 20, 30))!
+	assert snap.len() == 1
+	w.blocks[key(10, 20, 30)] = 0
+	snap.restore(mut w)
+	assert w.get_block(10, 20, 30) == 42
+}
+
+fn test_capture_rejects_oversized_box() {
+	mut w := &FakeWorld{}
+	// one axis alone past the cap guarantees volume > max_volume.
+	if _ := capture(mut w, new_box(0, 0, 0, max_volume + 1, 0, 0)) {
+		assert false, 'expected oversized box to be rejected'
+	}
+}


### PR DESCRIPTION
## Summary

Adds the software side of arena reset under server/arena/:
- `Box` (normalized axis-aligned region) and `Snapshot` (flat block-id capture)
- `BlockSource`/`BlockSink` interfaces so it reads/writes blocks through an abstract world (Hub satisfies them)
- `capture()` and `Snapshot.restore()` with a volume cap so a bad box can't exhaust memory

Lets a plugin snapshot an arena at round start and restore it at round end. Self-contained module, wired in the integration PR. Unit tested.