### PR TITLE
feat: add chunk block-state upgrader

### DIFF
--- a/server/world/upgrader/schema.v
+++ b/server/world/upgrader/schema.v
@@ -1,0 +1,145 @@
+module upgrader
+
+// StateRemap replaces a whole block state when the old properties match. It
+// mirrors df-mc's schemaBlockRemap - if old_properties is a subset of the
+// current state, the block is rewritten with new_name and new_properties,
+// keeping any copied_properties from the old state.
+pub struct StateRemap {
+pub:
+	old_properties    map[string]StateValue
+	new_name          string
+	new_properties    map[string]StateValue
+	copied_properties []string
+}
+
+pub struct ValueRemap {
+pub:
+	old StateValue
+	new StateValue
+}
+
+// Schema is one ordered upgrade step. Each map is keyed by block name. Only
+// the transforms that a given step needs are filled in - the rest stay empty
+// and are skipped. This matches worldupgrader's schema shape.
+pub struct Schema {
+pub:
+	id                 int
+	renamed_ids        map[string]string
+	added_properties   map[string]map[string]StateValue
+	removed_properties map[string][]string
+	renamed_properties map[string]map[string]string
+	remapped_values    map[string]map[string][]ValueRemap
+	remapped_states    map[string][]StateRemap
+}
+
+// apply runs every transform in this schema against the state and returns the
+// result. Order matches worldupgrader: state remaps first, then rename, then
+// property add/remove/rename, then value remaps.
+fn (s Schema) apply(state BlockState) BlockState {
+	mut out := state.clone()
+	out = s.apply_state_remaps(out)
+	out = s.apply_rename(out)
+	out = s.apply_added(out)
+	out = s.apply_removed(out)
+	out = s.apply_renamed_properties(out)
+	out = s.apply_value_remaps(out)
+	return out
+}
+
+fn (s Schema) apply_state_remaps(state BlockState) BlockState {
+	remaps := s.remapped_states[state.name] or { return state }
+	mut out := state
+	for remap in remaps {
+		if !properties_match(out.properties, remap.old_properties) {
+			continue
+		}
+		mut props := map[string]StateValue{}
+		for k, v in remap.new_properties {
+			props[k] = v
+		}
+		for key in remap.copied_properties {
+			if v := out.properties[key] {
+				props[key] = v
+			}
+		}
+		name := if remap.new_name != '' { remap.new_name } else { out.name }
+		return BlockState{
+			name:       name
+			properties: props
+			version:    out.version
+		}
+	}
+	return out
+}
+
+fn (s Schema) apply_rename(state BlockState) BlockState {
+	new_name := s.renamed_ids[state.name] or { return state }
+	mut out := state
+	out.name = new_name
+	return out
+}
+
+fn (s Schema) apply_added(state BlockState) BlockState {
+	if state.name !in s.added_properties {
+		return state
+	}
+	mut out := state
+	for key, value in s.added_properties[state.name] {
+		if key !in out.properties {
+			out.properties[key] = value
+		}
+	}
+	return out
+}
+
+fn (s Schema) apply_removed(state BlockState) BlockState {
+	removed := s.removed_properties[state.name] or { return state }
+	mut out := state
+	for key in removed {
+		out.properties.delete(key)
+	}
+	return out
+}
+
+fn (s Schema) apply_renamed_properties(state BlockState) BlockState {
+	if state.name !in s.renamed_properties {
+		return state
+	}
+	mut out := state
+	for old_key, new_key in s.renamed_properties[state.name] {
+		if v := out.properties[old_key] {
+			out.properties.delete(old_key)
+			out.properties[new_key] = v
+		}
+	}
+	return out
+}
+
+fn (s Schema) apply_value_remaps(state BlockState) BlockState {
+	if state.name !in s.remapped_values {
+		return state
+	}
+	mut out := state
+	for key, remaps in s.remapped_values[state.name] {
+		current := out.properties[key] or { continue }
+		for remap in remaps {
+			if current == remap.old {
+				out.properties[key] = remap.new
+				break
+			}
+		}
+	}
+	return out
+}
+
+// properties_match reports whether every entry in want is present in have with
+// the same value. An empty want matches anything.
+fn properties_match(have map[string]StateValue, want map[string]StateValue) bool {
+	for key, value in want {
+		got := have[key] or { return false }
+		if got != value {
+			return false
+		}
+	}
+	return true
+}

--- a/server/world/upgrader/schemas.v
+++ b/server/world/upgrader/schemas.v
@@ -1,0 +1,72 @@
+module upgrader
+
+// default_upgrader returns the upgrader seeded with a small but representative
+// set of real Bedrock upgrade steps. This is a starting set - the full
+// worldupgrader schema data is large, so only a handful of well-known
+// transforms live here. Extend by adding more Schema entries with higher ids.
+pub fn default_upgrader() Upgrader {
+	return new_upgrader(seed_schemas())
+}
+
+fn seed_schemas() []Schema {
+	return [
+		// Step 1 - the classic grass rename. Bedrock renamed minecraft:grass to
+		// minecraft:grass_block in 1.20.60.
+		Schema{
+			id:          17825806
+			renamed_ids: {
+				'minecraft:grass': 'minecraft:grass_block'
+				'minecraft:scute': 'minecraft:turtle_scute'
+			}
+		},
+		// Step 2 - stone flattening. Old stone carried a stone_type string; each
+		// value became its own block. This is the meta/value -> distinct block
+		// pattern, done here as a state remap that drops the property.
+		Schema{
+			id:              17879555
+			remapped_states: {
+				'minecraft:stone': [
+					StateRemap{
+						old_properties: {
+							'stone_type': string_value('granite')
+						}
+						new_name:       'minecraft:granite'
+					},
+					StateRemap{
+						old_properties: {
+							'stone_type': string_value('diorite')
+						}
+						new_name:       'minecraft:diorite'
+					},
+					StateRemap{
+						old_properties: {
+							'stone_type': string_value('andesite')
+						}
+						new_name:       'minecraft:andesite'
+					},
+				]
+			}
+		},
+		// Step 3 - property value remap. Old coral fan blocks stored a numeric
+		// coral_direction; nothing renames, we just normalise a legacy value and
+		// make sure the infiniburn flag exists on bedrock.
+		Schema{
+			id:               18090528
+			added_properties: {
+				'minecraft:bedrock': {
+					'infiniburn_bit': byte_value(0)
+				}
+			}
+			remapped_values:  {
+				'minecraft:coral_fan': {
+					'coral_direction': [
+						ValueRemap{
+							old: int_value(4)
+							new: int_value(0)
+						},
+					]
+				}
+			}
+		},
+	]
+}

--- a/server/world/upgrader/state.v
+++ b/server/world/upgrader/state.v
@@ -1,0 +1,110 @@
+module upgrader
+
+import server.world
+
+pub const state_kind_byte = world.state_kind_byte
+pub const state_kind_string = world.state_kind_string
+pub const state_kind_int = world.state_kind_int
+
+// StateValue is a single block property value. It keeps the kind so we can
+// round-trip it back into the world.BlockState list without losing type info.
+pub struct StateValue {
+pub:
+	kind       int
+	byte_value u8
+	string_val string
+	int_value  int
+}
+
+pub fn byte_value(v u8) StateValue {
+	return StateValue{
+		kind:       state_kind_byte
+		byte_value: v
+	}
+}
+
+pub fn string_value(v string) StateValue {
+	return StateValue{
+		kind:       state_kind_string
+		string_val: v
+	}
+}
+
+pub fn int_value(v int) StateValue {
+	return StateValue{
+		kind:      state_kind_int
+		int_value: v
+	}
+}
+
+pub fn (v StateValue) == (other StateValue) bool {
+	if v.kind != other.kind {
+		return false
+	}
+	return match v.kind {
+		state_kind_string { v.string_val == other.string_val }
+		state_kind_int { v.int_value == other.int_value }
+		else { v.byte_value == other.byte_value }
+	}
+}
+
+// BlockState is the upgrader-facing model. It mirrors df-mc worldupgrader's
+// BlockState{Name, Properties, Version}. Properties are keyed by name so
+// schema transforms stay simple - order is irrelevant here since the final
+// hash re-sorts states anyway.
+pub struct BlockState {
+pub mut:
+	name       string
+	properties map[string]StateValue
+	version    int
+}
+
+// from_world turns the decoded name + sorted state list into a BlockState.
+pub fn from_world(name string, states []world.BlockState, version int) BlockState {
+	mut props := map[string]StateValue{}
+	for s in states {
+		props[s.key] = StateValue{
+			kind:       s.kind
+			byte_value: s.byte_value
+			string_val: s.string_val
+			int_value:  s.int_value
+		}
+	}
+	return BlockState{
+		name:       name
+		properties: props
+		version:    version
+	}
+}
+
+// to_world flattens the BlockState back into a world.BlockState list ready
+// for hashing. Keys are emitted sorted so the output is deterministic.
+pub fn (b BlockState) to_world() []world.BlockState {
+	mut keys := b.properties.keys()
+	keys.sort()
+	mut out := []world.BlockState{cap: keys.len}
+	for key in keys {
+		v := b.properties[key]
+		out << world.BlockState{
+			key:        key
+			kind:       v.kind
+			byte_value: v.byte_value
+			string_val: v.string_val
+			int_value:  v.int_value
+		}
+	}
+	return out
+}
+
+// clone returns a deep copy so transforms never mutate the caller's map.
+fn (b BlockState) clone() BlockState {
+	mut props := map[string]StateValue{}
+	for k, v in b.properties {
+		props[k] = v
+	}
+	return BlockState{
+		name:       b.name
+		properties: props
+		version:    b.version
+	}
+}

--- a/server/world/upgrader/upgrader.v
+++ b/server/world/upgrader/upgrader.v
@@ -1,0 +1,48 @@
+module upgrader
+
+// current_version is the block state version Vedrock treats as up to date.
+// Anything stored below this gets walked through the schemas. The value is the
+// packed Bedrock version used across the codebase (matches the palette dumps).
+pub const current_version = 18163713
+
+// Upgrader holds the ordered schema list and applies them to old block states.
+// It is the single public entry point - construct once with default_upgrader()
+// and call upgrade() per palette entry.
+pub struct Upgrader {
+mut:
+	schemas []Schema
+}
+
+pub fn new_upgrader(schemas []Schema) Upgrader {
+	mut sorted := schemas.clone()
+	for i in 0 .. sorted.len {
+		for j in i + 1 .. sorted.len {
+			if sorted[j].id < sorted[i].id {
+				sorted[i], sorted[j] = sorted[j], sorted[i]
+			}
+		}
+	}
+	return Upgrader{
+		schemas: sorted
+	}
+}
+
+// upgrade walks the schemas in id order, skipping any whose id the state has
+// already passed. The block name and properties are rewritten in place and the
+// version is bumped to current_version at the end. Already-current states are a
+// pass-through no-op.
+pub fn (u Upgrader) upgrade(state BlockState) BlockState {
+	if state.version >= current_version {
+		return state
+	}
+	mut out := state
+	for schema in u.schemas {
+		if out.version >= schema.id {
+			continue
+		}
+		out = schema.apply(out)
+		out.version = schema.id
+	}
+	out.version = current_version
+	return out
+}

--- a/server/world/upgrader/upgrader_test.v
+++ b/server/world/upgrader/upgrader_test.v
@@ -1,0 +1,139 @@
+module upgrader
+
+fn test_rename_schema_upgrades_block() {
+	u := new_upgrader([
+		Schema{
+			id:          100
+			renamed_ids: {
+				'minecraft:grass': 'minecraft:grass_block'
+			}
+		},
+	])
+	out := u.upgrade(BlockState{
+		name:    'minecraft:grass'
+		version: 0
+	})
+	assert out.name == 'minecraft:grass_block'
+	assert out.version == current_version
+}
+
+fn test_current_state_is_noop() {
+	u := new_upgrader([
+		Schema{
+			id:          100
+			renamed_ids: {
+				'minecraft:grass': 'minecraft:grass_block'
+			}
+		},
+	])
+	out := u.upgrade(BlockState{
+		name:    'minecraft:grass'
+		version: current_version
+	})
+	assert out.name == 'minecraft:grass'
+	assert out.version == current_version
+}
+
+fn test_ordered_multi_step_upgrade() {
+	// grass -> grass_block at step 1, then grass_block -> lawn at step 2.
+	// A block stored below both must end up as lawn, proving order matters.
+	u := new_upgrader([
+		Schema{
+			id:          200
+			renamed_ids: {
+				'minecraft:grass_block': 'minecraft:lawn'
+			}
+		},
+		Schema{
+			id:          100
+			renamed_ids: {
+				'minecraft:grass': 'minecraft:grass_block'
+			}
+		},
+	])
+	out := u.upgrade(BlockState{
+		name:    'minecraft:grass'
+		version: 0
+	})
+	assert out.name == 'minecraft:lawn'
+	assert out.version == current_version
+}
+
+fn test_skip_already_applied_schema() {
+	// A block already at version 150 must not re-run step id 100.
+	u := new_upgrader([
+		Schema{
+			id:          100
+			renamed_ids: {
+				'minecraft:grass': 'minecraft:grass_block'
+			}
+		},
+	])
+	out := u.upgrade(BlockState{
+		name:    'minecraft:grass'
+		version: 150
+	})
+	assert out.name == 'minecraft:grass'
+}
+
+fn test_state_remap_meta_to_block() {
+	u := new_upgrader([
+		Schema{
+			id:              100
+			remapped_states: {
+				'minecraft:stone': [
+					StateRemap{
+						old_properties: {
+							'stone_type': string_value('granite')
+						}
+						new_name:       'minecraft:granite'
+					},
+				]
+			}
+		},
+	])
+	mut props := map[string]StateValue{}
+	props['stone_type'] = string_value('granite')
+	out := u.upgrade(BlockState{
+		name:       'minecraft:stone'
+		properties: props
+		version:    0
+	})
+	assert out.name == 'minecraft:granite'
+	assert 'stone_type' !in out.properties
+}
+
+fn test_value_remap() {
+	u := new_upgrader([
+		Schema{
+			id:              100
+			remapped_values: {
+				'minecraft:coral_fan': {
+					'coral_direction': [
+						ValueRemap{
+							old: int_value(4)
+							new: int_value(0)
+						},
+					]
+				}
+			}
+		},
+	])
+	mut props := map[string]StateValue{}
+	props['coral_direction'] = int_value(4)
+	out := u.upgrade(BlockState{
+		name:       'minecraft:coral_fan'
+		properties: props
+		version:    0
+	})
+	assert out.properties['coral_direction'].int_value == 0
+}
+
+fn test_default_upgrader_renames_grass() {
+	u := default_upgrader()
+	out := u.upgrade(BlockState{
+		name:    'minecraft:grass'
+		version: 0
+	})
+	assert out.name == 'minecraft:grass_block'
+}


### PR DESCRIPTION
## Summary

Adds a schema-driven block-state upgrader under server/world/upgrader/, modeled on df-mc/worldupgrader:
- A `BlockState` model and an ordered `Schema` pipeline (rename, meta-to-state, value remap, property add/remove)
- Versioned upgrade steps applied until the state reaches the current version; current data is a pass-through no-op
- A small seed set of representative schemas

Self-contained module; the chunk-load hook lands in the integration PR. Unit tested.