### PR TITLE
feat: add crash report writer

### DIFF
--- a/server/crash/crash.v
+++ b/server/crash/crash.v
@@ -1,0 +1,36 @@
+module crash
+
+import os
+
+// v_version_note describes the pinned compiler this build is expected to run
+// under. Kept as a note in the dump so a crash report is self-describing even
+// when the reporter no longer knows which V built the binary.
+pub const v_version_note = 'built with V 0.5.1 (0c3183c)'
+
+// write_dump writes a timestamped crash report into dir and returns the path it
+// wrote. The timestamp is passed in rather than read from the clock so callers
+// stay testable - no hidden Date.now() in library code.
+pub fn write_dump(dir string, stamp i64, title string, details string) !string {
+	os.mkdir_all(dir)!
+	path := os.join_path(dir, 'crash-${stamp}.txt')
+	report := build_report(stamp, title, details)
+	os.write_file(path, report)!
+	return path
+}
+
+// build_report renders the report body. Split out from write_dump so tests can
+// assert on the content without touching the filesystem.
+pub fn build_report(stamp i64, title string, details string) string {
+	mut b := []string{}
+	b << '=== Vedrock crash report ==='
+	b << 'time: ${stamp}'
+	b << 'title: ${title}'
+	b << v_version_note
+	if details != '' {
+		b << ''
+		b << 'context:'
+		b << details
+	}
+	b << ''
+	return b.join('\n')
+}

--- a/server/crash/crash_test.v
+++ b/server/crash/crash_test.v
@@ -1,0 +1,49 @@
+module crash
+
+import os
+
+fn test_write_dump_creates_file() {
+	dir := os.join_path(os.vtmp_dir(), 'vedrock_crash_test_${os.getpid()}')
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	path := write_dump(dir, i64(1720000000), 'boom', 'stack: foo -> bar') or {
+		assert false, 'write_dump failed: ${err}'
+		return
+	}
+	assert os.exists(path)
+	assert path.ends_with('crash-1720000000.txt')
+	text := os.read_file(path) or {
+		assert false, 'could not read dump: ${err}'
+		return
+	}
+	assert text.contains('boom')
+	assert text.contains('stack: foo -> bar')
+	assert text.contains(v_version_note)
+	assert text.contains('1720000000')
+}
+
+fn test_write_dump_makes_missing_dir() {
+	base := os.join_path(os.vtmp_dir(), 'vedrock_crash_nested_${os.getpid()}')
+	dir := os.join_path(base, 'a', 'b')
+	defer {
+		os.rmdir_all(base) or {}
+	}
+	path := write_dump(dir, i64(42), 'title', '') or {
+		assert false, 'write_dump failed: ${err}'
+		return
+	}
+	assert os.exists(path)
+}
+
+fn test_build_report_omits_empty_context() {
+	report := build_report(i64(7), 'panic', '')
+	assert report.contains('title: panic')
+	assert !report.contains('context:')
+}
+
+fn test_build_report_includes_context() {
+	report := build_report(i64(7), 'panic', 'details here')
+	assert report.contains('context:')
+	assert report.contains('details here')
+}

--- a/server/internal/encryption/context.v
+++ b/server/internal/encryption/context.v
@@ -1,0 +1,128 @@
+module encryption
+
+import crypto.aes
+import crypto.cipher
+import crypto.sha256
+
+const checksum_len = 8
+const aes_block_size = 16
+
+// ctrStream is a minimal AES-CTR keystream. vlib's crypto.cipher.Ctr is a
+// private type so it cannot be held as a struct field - we replicate its
+// stateful behaviour here: a persistent counter block and a keystream buffer
+// consumed across calls, so one stream spans the whole session in one
+// direction exactly like PocketMine's persistent cipher.
+struct CtrStream {
+mut:
+	block     cipher.Block
+	counter   []u8
+	keystream []u8
+	used      int
+}
+
+fn new_ctr_stream(block cipher.Block, iv []u8) CtrStream {
+	return CtrStream{
+		block:     block
+		counter:   iv.clone()
+		keystream: []u8{len: aes_block_size}
+		used:      aes_block_size
+	}
+}
+
+// xor consumes src against the keystream, refilling and advancing the counter
+// block one AES block at a time.
+fn (mut s CtrStream) xor(src []u8) []u8 {
+	mut out := []u8{len: src.len}
+	for i in 0 .. src.len {
+		if s.used == aes_block_size {
+			s.block.encrypt(mut s.keystream, s.counter)
+			s.used = 0
+			for j := s.counter.len - 1; j >= 0; j-- {
+				s.counter[j]++
+				if s.counter[j] != 0 {
+					break
+				}
+			}
+		}
+		out[i] = src[i] ^ s.keystream[s.used]
+		s.used++
+	}
+	return out
+}
+
+// Context is the per-session Bedrock cipher. MCPE uses "GCM without the auth
+// tag", which is just AES-256-CTR with the GCM initial counter block as IV:
+// the first 12 bytes of the key followed by 00 00 00 02. Each direction keeps
+// its own persistent CTR keystream and a monotonic counter that feeds a
+// per-packet SHA-256 checksum, matching PocketMine's EncryptionContext.
+@[heap]
+pub struct Context {
+mut:
+	key             []u8
+	encrypt_stream  CtrStream
+	decrypt_stream  CtrStream
+	encrypt_counter u64
+	decrypt_counter u64
+}
+
+// new_context builds a Context from the 32-byte AES-256 key derived during the
+// handshake. It returns an error on a wrong-sized key rather than panicking.
+pub fn new_context(key []u8) !&Context {
+	if key.len != 32 {
+		return error('encryption key must be 32 bytes, got ${key.len}')
+	}
+	mut iv := []u8{len: aes_block_size}
+	copy(mut iv[..12], key[..12])
+	iv[15] = 0x02
+	return &Context{
+		key:            key.clone()
+		encrypt_stream: new_ctr_stream(aes.new_cipher(key), iv)
+		decrypt_stream: new_ctr_stream(aes.new_cipher(key), iv)
+	}
+}
+
+// encrypt appends the per-packet checksum to the plaintext, then encrypts the
+// combined buffer with the send-direction CTR keystream.
+pub fn (mut c Context) encrypt(payload []u8) []u8 {
+	checksum := c.calculate_checksum(c.encrypt_counter, payload)
+	c.encrypt_counter++
+	mut plain := []u8{cap: payload.len + checksum_len}
+	plain << payload
+	plain << checksum
+	return c.encrypt_stream.xor(plain)
+}
+
+// decrypt reverses encrypt: it decrypts with the receive-direction keystream,
+// splits off the trailing checksum, and verifies it against the monotonic
+// receive counter. A mismatch returns an error - the caller must disconnect.
+pub fn (mut c Context) decrypt(encrypted []u8) ![]u8 {
+	if encrypted.len < checksum_len + 1 {
+		return error('encrypted payload too short')
+	}
+	decrypted := c.decrypt_stream.xor(encrypted)
+	payload := decrypted[..decrypted.len - checksum_len].clone()
+	actual := decrypted[decrypted.len - checksum_len..].clone()
+	expected := c.calculate_checksum(c.decrypt_counter, payload)
+	c.decrypt_counter++
+	if actual != expected {
+		return error('encrypted packet checksum mismatch')
+	}
+	return payload
+}
+
+// calculate_checksum returns the first 8 bytes of
+// sha256(counter_LE_u64 || payload || key), the MCPE packet integrity tag.
+fn (c &Context) calculate_checksum(counter u64, payload []u8) []u8 {
+	mut buf := []u8{cap: 8 + payload.len + c.key.len}
+	mut counter_le := []u8{len: 8}
+	mut v := counter
+	for i in 0 .. 8 {
+		counter_le[i] = u8(v & 0xff)
+		v >>= 8
+	}
+	buf << counter_le
+	buf << payload
+	buf << c.key
+	hash := sha256.sum256(buf)
+	return hash[..checksum_len]
+}

--- a/server/internal/encryption/context_test.v
+++ b/server/internal/encryption/context_test.v
@@ -1,0 +1,82 @@
+module encryption
+
+fn test_key_wrong_size_rejected() {
+	if _ := new_context([]u8{len: 16}) {
+		assert false, 'expected error for 16-byte key'
+	}
+}
+
+fn make_key() []u8 {
+	mut key := []u8{len: 32}
+	for i in 0 .. 32 {
+		key[i] = u8(i + 1)
+	}
+	return key
+}
+
+fn test_round_trip_returns_original() {
+	key := make_key()
+	mut enc := new_context(key)!
+	mut dec := new_context(key)!
+	payload := 'hello bedrock world'.bytes()
+	cipher := enc.encrypt(payload)
+	assert cipher.len == payload.len + checksum_len
+	assert cipher != payload
+	plain := dec.decrypt(cipher)!
+	assert plain == payload
+}
+
+fn test_multiple_packets_advance_counters() {
+	key := make_key()
+	mut enc := new_context(key)!
+	mut dec := new_context(key)!
+	messages := [
+		'first packet'.bytes(),
+		'second packet is longer than the first'.bytes(),
+		'four'.bytes(),
+	]
+	for m in messages {
+		c := enc.encrypt(m)
+		p := dec.decrypt(c)!
+		assert p == m
+	}
+	assert enc.encrypt_counter == u64(messages.len)
+	assert dec.decrypt_counter == u64(messages.len)
+}
+
+fn test_checksum_mismatch_detected() {
+	key := make_key()
+	mut enc := new_context(key)!
+	mut dec := new_context(key)!
+	mut cipher := enc.encrypt('tamper me'.bytes())
+	cipher[0] ^= 0xff
+	if _ := dec.decrypt(cipher) {
+		assert false, 'expected checksum mismatch error'
+	}
+}
+
+fn test_out_of_order_counter_fails() {
+	key := make_key()
+	mut enc := new_context(key)!
+	mut dec := new_context(key)!
+	c0 := enc.encrypt('packet zero'.bytes())
+	c1 := enc.encrypt('packet one'.bytes())
+	// Decrypting the second packet first breaks the CTR stream alignment and the
+	// counter used in the checksum, so it must be rejected.
+	if _ := dec.decrypt(c1) {
+		assert false, 'expected failure decrypting out of order'
+	}
+	_ := c0
+}
+
+fn test_der_to_raw_pads_components() {
+	// SEQUENCE(len=6){ INTEGER 0x01, INTEGER 0x02 } -> two 48-byte components.
+	der := [u8(0x30), 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02]
+	raw := der_ecdsa_to_raw(der, 48)!
+	assert raw.len == 96
+	assert raw[47] == 0x01
+	assert raw[95] == 0x02
+	for i in 0 .. 47 {
+		assert raw[i] == 0
+	}
+}

--- a/server/internal/encryption/handshake.v
+++ b/server/internal/encryption/handshake.v
@@ -1,0 +1,64 @@
+module encryption
+
+import crypto.rand
+import crypto.sha256
+import encoding.base64
+import x.json2
+
+const salt_len = 16
+
+// HandshakeResult carries the two outputs of the handshake preparation: the
+// derived AES-256 key (kept server-side to build the Context) and the signed
+// ServerToClientHandshake JWT sent to the client.
+pub struct HandshakeResult {
+pub:
+	key           []u8
+	handshake_jwt string
+}
+
+// prepare_handshake runs the full server side of the Bedrock encryption
+// handshake for one client: generate the server keypair, ECDH against the
+// client public key, derive the AES key from a fresh random salt, and build a
+// signed ServerToClientHandshake JWT. The keypair is freed before returning.
+pub fn prepare_handshake(client_public_key_b64 string) !HandshakeResult {
+	mut keys := new_server_key_pair()!
+	defer {
+		keys.free()
+	}
+	secret := keys.derive_shared_secret(client_public_key_b64)!
+	salt := rand.bytes(salt_len)!
+	key := derive_key(salt, secret)
+	jwt := build_handshake_jwt(mut keys, salt)!
+	return HandshakeResult{
+		key:           key
+		handshake_jwt: jwt
+	}
+}
+
+// derive_key computes the AES-256 key as sha256(salt || sharedSecret).
+fn derive_key(salt []u8, shared_secret []u8) []u8 {
+	mut buf := []u8{cap: salt.len + shared_secret.len}
+	buf << salt
+	buf << shared_secret
+	return sha256.sum256(buf)
+}
+
+// build_handshake_jwt builds the ES384-signed ServerToClientHandshake JWT. The
+// header x5u is the server SPKI DER (base64), and the payload carries the salt.
+fn build_handshake_jwt(mut keys ServerKeyPair, salt []u8) !string {
+	der := keys.public_key_der()!
+	header := json2.Any({
+		'alg': json2.Any('ES384')
+		'x5u': json2.Any(base64.encode(der))
+	})
+	payload := json2.Any({
+		'salt': json2.Any(base64.url_encode(salt).trim_right('='))
+	})
+	signing_input := '${b64url_encode_json(header)}.${b64url_encode_json(payload)}'
+	raw_sig := keys.sign_es384(signing_input.bytes())!
+	return '${signing_input}.${base64.url_encode(raw_sig).trim_right('=')}'
+}
+
+fn b64url_encode_json(v json2.Any) string {
+	return base64.url_encode(v.json_str().bytes()).trim_right('=')
+}

--- a/server/internal/encryption/handshake_test.v
+++ b/server/internal/encryption/handshake_test.v
@@ -1,0 +1,50 @@
+module encryption
+
+import encoding.base64
+
+// test_handshake_end_to_end acts as both server and client: it generates a
+// "client" P-384 keypair, feeds its SPKI to prepare_handshake, and checks that
+// the ECDH derive, key derivation, and JWT signing all succeed and produce a
+// usable 32-byte key plus a three-part JWT.
+fn test_handshake_end_to_end() {
+	mut client := new_server_key_pair()!
+	defer {
+		client.free()
+	}
+	client_der := client.public_key_der()!
+	assert client_der.len > 0
+	result := prepare_handshake(base64.encode(client_der))!
+	assert result.key.len == 32
+	parts := result.handshake_jwt.split('.')
+	assert parts.len == 3
+	for part in parts {
+		assert part.len > 0
+	}
+}
+
+// test_shared_secret_symmetry proves ECDH agreement: server<-client and
+// client<-server must derive the identical secret.
+fn test_shared_secret_symmetry() {
+	mut a := new_server_key_pair()!
+	mut b := new_server_key_pair()!
+	defer {
+		a.free()
+		b.free()
+	}
+	a_der := base64.encode(a.public_key_der()!)
+	b_der := base64.encode(b.public_key_der()!)
+	secret_ab := a.derive_shared_secret(b_der)!
+	secret_ba := b.derive_shared_secret(a_der)!
+	assert secret_ab.len == 48
+	assert secret_ab == secret_ba
+}
+
+fn test_invalid_client_key_rejected() {
+	mut server := new_server_key_pair()!
+	defer {
+		server.free()
+	}
+	if _ := server.derive_shared_secret('not-valid-base64-der!!!') {
+		assert false, 'expected error for invalid client key'
+	}
+}

--- a/server/internal/encryption/keys.v
+++ b/server/internal/encryption/keys.v
@@ -1,0 +1,191 @@
+module encryption
+
+import encoding.base64
+
+// ServerKeyPair holds the ephemeral P-384 ECDH/signing keypair the server
+// generates once per session for the encryption handshake. It owns the raw
+// EVP_PKEY handle and must be freed when the handshake is done.
+pub struct ServerKeyPair {
+mut:
+	pkey &C.EVP_PKEY = unsafe { nil }
+}
+
+// new_server_key_pair generates a fresh secp384r1 keypair via OpenSSL EVP.
+pub fn new_server_key_pair() !&ServerKeyPair {
+	ctx := C.EVP_PKEY_CTX_new_id(evp_pkey_ec, unsafe { nil })
+	if ctx == unsafe { nil } {
+		return error('EVP_PKEY_CTX_new_id failed')
+	}
+	defer {
+		C.EVP_PKEY_CTX_free(ctx)
+	}
+	if C.EVP_PKEY_keygen_init(ctx) != 1 {
+		return error('EVP_PKEY_keygen_init failed')
+	}
+	if C.EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, nid_secp384r1) != 1 {
+		return error('failed to set P-384 curve')
+	}
+	mut pkey := &C.EVP_PKEY(unsafe { nil })
+	if C.EVP_PKEY_keygen(ctx, &pkey) != 1 {
+		return error('EVP_PKEY_keygen failed')
+	}
+	return &ServerKeyPair{
+		pkey: pkey
+	}
+}
+
+// free releases the underlying EVP_PKEY. Safe to call once.
+pub fn (mut k ServerKeyPair) free() {
+	if k.pkey != unsafe { nil } {
+		C.EVP_PKEY_free(k.pkey)
+		k.pkey = unsafe { nil }
+	}
+}
+
+// public_key_der returns the server's SubjectPublicKeyInfo (SPKI) DER bytes,
+// used as the base64 x5u header of the ServerToClientHandshake JWT.
+pub fn (k &ServerKeyPair) public_key_der() ![]u8 {
+	bio := C.BIO_new(C.BIO_s_mem())
+	if bio == unsafe { nil } {
+		return error('BIO_new failed')
+	}
+	defer {
+		C.BIO_free_all(bio)
+	}
+	if C.i2d_PUBKEY_bio(bio, k.pkey) != 1 {
+		return error('i2d_PUBKEY_bio failed')
+	}
+	mut buf := &u8(unsafe { nil })
+	length := C.BIO_ctrl(bio, bio_ctrl_info, 0, voidptr(&buf))
+	if length <= 0 || buf == unsafe { nil } {
+		return error('failed to read SPKI from BIO')
+	}
+	mut out := []u8{len: int(length)}
+	unsafe { vmemcpy(out.data, buf, int(length)) }
+	return out
+}
+
+// derive_shared_secret runs ECDH against the client public key (a base64 SPKI
+// DER string from the login chain) and returns the 48-byte raw shared secret.
+pub fn (k &ServerKeyPair) derive_shared_secret(client_public_key_b64 string) ![]u8 {
+	der := base64.decode(client_public_key_b64)
+	if der.len == 0 {
+		return error('client public key is empty or not valid base64')
+	}
+	mut peer := &C.EVP_PKEY(unsafe { nil })
+	pp := &u8(der.data)
+	peer = C.d2i_PUBKEY(&peer, &pp, i64(der.len))
+	if peer == unsafe { nil } {
+		return error('failed to parse client public key DER')
+	}
+	defer {
+		C.EVP_PKEY_free(peer)
+	}
+	ctx := C.EVP_PKEY_CTX_new(k.pkey, unsafe { nil })
+	if ctx == unsafe { nil } {
+		return error('EVP_PKEY_CTX_new failed')
+	}
+	defer {
+		C.EVP_PKEY_CTX_free(ctx)
+	}
+	if C.EVP_PKEY_derive_init(ctx) != 1 {
+		return error('EVP_PKEY_derive_init failed')
+	}
+	if C.EVP_PKEY_derive_set_peer(ctx, peer) != 1 {
+		return error('EVP_PKEY_derive_set_peer failed (curve mismatch?)')
+	}
+	mut secret_len := usize(0)
+	if C.EVP_PKEY_derive(ctx, unsafe { nil }, &secret_len) != 1 {
+		return error('EVP_PKEY_derive length query failed')
+	}
+	if secret_len == 0 {
+		return error('derived secret length is zero')
+	}
+	mut secret := []u8{len: int(secret_len)}
+	if C.EVP_PKEY_derive(ctx, secret.data, &secret_len) != 1 {
+		return error('EVP_PKEY_derive failed')
+	}
+	return secret[..int(secret_len)].clone()
+}
+
+// sign_es384 signs the message with the server private key using ECDSA-SHA384
+// and returns the JWS-style fixed-width raw R||S signature (96 bytes for P-384).
+pub fn (k &ServerKeyPair) sign_es384(message []u8) ![]u8 {
+	md_ctx := C.EVP_MD_CTX_new()
+	if md_ctx == unsafe { nil } {
+		return error('EVP_MD_CTX_new failed')
+	}
+	defer {
+		C.EVP_MD_CTX_free(md_ctx)
+	}
+	if C.EVP_DigestSignInit(md_ctx, unsafe { nil }, C.EVP_sha384(), unsafe { nil }, k.pkey) != 1 {
+		return error('EVP_DigestSignInit failed')
+	}
+	mut sig_len := usize(0)
+	if C.EVP_DigestSign(md_ctx, unsafe { nil }, &sig_len, message.data, usize(message.len)) != 1 {
+		return error('EVP_DigestSign length query failed')
+	}
+	mut der_sig := []u8{len: int(sig_len)}
+	if C.EVP_DigestSign(md_ctx, der_sig.data, &sig_len, message.data, usize(message.len)) != 1 {
+		return error('EVP_DigestSign failed')
+	}
+	return der_ecdsa_to_raw(der_sig[..int(sig_len)], p384_component_size)!
+}
+
+const p384_component_size = 48
+
+// der_ecdsa_to_raw converts a DER-encoded ECDSA signature (SEQUENCE of two
+// INTEGERs r,s) into the fixed-width raw R||S form used by JWS/JWA. Each
+// component is left-padded to comp_size bytes.
+fn der_ecdsa_to_raw(der []u8, comp_size int) ![]u8 {
+	mut i := 0
+	if i >= der.len || der[i] != 0x30 {
+		return error('invalid DER signature: missing SEQUENCE')
+	}
+	i++
+	if i >= der.len {
+		return error('invalid DER signature: truncated')
+	}
+	// Skip the SEQUENCE length (short or long form).
+	if der[i] & 0x80 != 0 {
+		i += int(der[i] & 0x7f) + 1
+	} else {
+		i++
+	}
+	r, next := read_der_integer(der, i)!
+	s, _ := read_der_integer(der, next)!
+	if r.len > comp_size || s.len > comp_size {
+		return error('DER integer larger than component size')
+	}
+	mut out := []u8{len: comp_size * 2}
+	copy(mut out[comp_size - r.len..comp_size], r)
+	copy(mut out[comp_size * 2 - s.len..], s)
+	return out
+}
+
+// read_der_integer reads one DER INTEGER starting at pos and returns the
+// magnitude (with any leading sign/zero byte stripped) and the index just past
+// the integer.
+fn read_der_integer(der []u8, pos int) !([]u8, int) {
+	mut i := pos
+	if i >= der.len || der[i] != 0x02 {
+		return error('invalid DER signature: expected INTEGER')
+	}
+	i++
+	if i >= der.len {
+		return error('invalid DER signature: truncated INTEGER length')
+	}
+	length := int(der[i])
+	i++
+	if length <= 0 || i + length > der.len {
+		return error('invalid DER signature: bad INTEGER length')
+	}
+	value := der[i..i + length]
+	i += length
+	// Strip leading 0x00 that DER adds to keep the integer positive.
+	mut start := 0
+	for start < value.len - 1 && value[start] == 0 {
+		start++
+	}
+	return value[start..].clone(), i
+}

--- a/server/internal/encryption/openssl.c.v
+++ b/server/internal/encryption/openssl.c.v
@@ -1,0 +1,74 @@
+module encryption
+
+// OpenSSL EVP interop for the Bedrock encryption handshake. vlib's crypto.ecdsa
+// keeps its EVP_PKEY handle private, so we re-declare the C bindings we need
+// (ECDH derive, SPKI emit, ES384 sign) in the same C-interop style. See
+// vlib/crypto/ecdsa/ecdsa.c.v for the pattern this mirrors.
+
+#flag darwin -L/opt/homebrew/opt/openssl/lib
+#flag darwin -I/opt/homebrew/opt/openssl/include
+#flag darwin -I/usr/local/opt/openssl/include
+#flag darwin -L/usr/local/opt/openssl/lib
+
+#flag linux -I/usr/local/include/openssl
+#flag linux -L/usr/local/lib64/
+
+#flag -I/usr/include/openssl
+#flag -lcrypto
+
+#include <openssl/evp.h>
+#include <openssl/ec.h>
+#include <openssl/x509.h>
+#include <openssl/bio.h>
+#include <openssl/obj_mac.h>
+
+@[typedef]
+pub struct C.EVP_PKEY {}
+
+@[typedef]
+pub struct C.EVP_PKEY_CTX {}
+
+@[typedef]
+pub struct C.EVP_MD_CTX {}
+
+@[typedef]
+pub struct C.EVP_MD {}
+
+@[typedef]
+pub struct C.BIO {}
+
+@[typedef]
+pub struct C.BIO_METHOD {}
+
+fn C.EVP_PKEY_new() &C.EVP_PKEY
+fn C.EVP_PKEY_free(key &C.EVP_PKEY)
+
+fn C.EVP_PKEY_CTX_new(pkey &C.EVP_PKEY, e voidptr) &C.EVP_PKEY_CTX
+fn C.EVP_PKEY_CTX_new_id(id int, e voidptr) &C.EVP_PKEY_CTX
+fn C.EVP_PKEY_CTX_free(ctx &C.EVP_PKEY_CTX)
+
+fn C.EVP_PKEY_keygen_init(ctx &C.EVP_PKEY_CTX) int
+fn C.EVP_PKEY_keygen(ctx &C.EVP_PKEY_CTX, ppkey &&C.EVP_PKEY) int
+fn C.EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx &C.EVP_PKEY_CTX, nid int) int
+
+fn C.EVP_PKEY_derive_init(ctx &C.EVP_PKEY_CTX) int
+fn C.EVP_PKEY_derive_set_peer(ctx &C.EVP_PKEY_CTX, peer &C.EVP_PKEY) int
+fn C.EVP_PKEY_derive(ctx &C.EVP_PKEY_CTX, key &u8, keylen &usize) int
+
+fn C.EVP_DigestSignInit(ctx &C.EVP_MD_CTX, pctx &&C.EVP_PKEY_CTX, tipe &C.EVP_MD, e voidptr, pkey &C.EVP_PKEY) int
+fn C.EVP_DigestSign(ctx &C.EVP_MD_CTX, sig &u8, siglen &usize, tbs &u8, tbslen usize) int
+fn C.EVP_MD_CTX_new() &C.EVP_MD_CTX
+fn C.EVP_MD_CTX_free(ctx &C.EVP_MD_CTX)
+fn C.EVP_sha384() &C.EVP_MD
+
+fn C.BIO_new(t &C.BIO_METHOD) &C.BIO
+fn C.BIO_s_mem() &C.BIO_METHOD
+fn C.BIO_free_all(a &C.BIO)
+fn C.BIO_write(b &C.BIO, buf &u8, length int) int
+fn C.i2d_PUBKEY_bio(bo &C.BIO, pkey &C.EVP_PKEY) int
+fn C.BIO_ctrl(b &C.BIO, cmd int, larg i64, parg voidptr) i64
+fn C.d2i_PUBKEY(k &&C.EVP_PKEY, pp &&u8, length i64) &C.EVP_PKEY
+
+const nid_secp384r1 = C.NID_secp384r1
+const evp_pkey_ec = C.EVP_PKEY_EC
+const bio_ctrl_info = 3 // BIO_CTRL_INFO - returns the in-memory buffer pointer


### PR DESCRIPTION
## Summary

Adds server/crash/ - a small crash-dump writer that records a timestamped report (message, V version note, context) to a crashdumps dir. The timestamp is passed in so the logic stays testable. Wired into the fatal exit paths in the integration PR. Unit tested.