### PR TITLE
feat: add liquid (water flow) engine

### DIFF
--- a/lang/en.toml
+++ b/lang/en.toml
@@ -120,3 +120,33 @@ other = "§cUsage: /say <message>§r"
 
 [cmd.title.usage]
 other = "§cUsage: /title <player|@a> <title|subtitle|actionbar> <text>§r"
+
+[cmd.world.usage]
+other = "§cUsage: /world <list|info|create|delete|tp> [name]§r"
+
+[cmd.world.none]
+other = "§eNo worlds are loaded§r"
+
+[cmd.world.list]
+other = "§6Worlds ({{.Count}}): §a{{.Worlds}}§r"
+
+[cmd.world.not_found]
+other = "§cWorld \"{{.Name}}\" is not loaded§r"
+
+[cmd.world.created]
+other = "§aCreated world \"{{.Name}}\"§r"
+
+[cmd.world.create_failed]
+other = "§cFailed to create \"{{.Name}}\": {{.Reason}}§r"
+
+[cmd.world.deleted]
+other = "§aDeleted world \"{{.Name}}\"§r"
+
+[cmd.world.delete_failed]
+other = "§cFailed to delete \"{{.Name}}\": {{.Reason}}§r"
+
+[cmd.world.tp]
+other = "§aTeleported to world \"{{.Name}}\"§r"
+
+[cmd.world.tp_failed]
+other = "§cFailed to teleport to \"{{.Name}}\": {{.Reason}}§r"

--- a/lang/tr.toml
+++ b/lang/tr.toml
@@ -117,3 +117,33 @@ other = "§cKullanım: /say <mesaj>§r"
 
 [cmd.title.usage]
 other = "§cKullanım: /title <oyuncu|@a> <title|subtitle|actionbar> <metin>§r"
+
+[cmd.world.usage]
+other = "§cKullanım: /world <list|info|create|delete|tp> [isim]§r"
+
+[cmd.world.none]
+other = "§eHiç dünya yüklü değil§r"
+
+[cmd.world.list]
+other = "§6Dünyalar ({{.Count}}): §a{{.Worlds}}§r"
+
+[cmd.world.not_found]
+other = "§c\"{{.Name}}\" dünyası yüklü değil§r"
+
+[cmd.world.created]
+other = "§a\"{{.Name}}\" dünyası oluşturuldu§r"
+
+[cmd.world.create_failed]
+other = "§c\"{{.Name}}\" oluşturulamadı: {{.Reason}}§r"
+
+[cmd.world.deleted]
+other = "§a\"{{.Name}}\" dünyası silindi§r"
+
+[cmd.world.delete_failed]
+other = "§c\"{{.Name}}\" silinemedi: {{.Reason}}§r"
+
+[cmd.world.tp]
+other = "§a\"{{.Name}}\" dünyasına ışınlandınız§r"
+
+[cmd.world.tp_failed]
+other = "§c\"{{.Name}}\" dünyasına ışınlanılamadı: {{.Reason}}§r"

--- a/main.v
+++ b/main.v
@@ -1,8 +1,12 @@
 module main
 
 import os
+import time
 import server.conf
 import server
+import server.crash
+
+const crashdumps_dir = 'crashdumps'
 
 fn main() {
 	cfg := conf.load() or {
@@ -16,6 +20,13 @@ fn main() {
 	}) or {}
 	srv.start() or {
 		srv.log.error('Server stopped: ${err}')
+		// A fatal startup/run error is our last chance to leave a trace before
+		// exiting - drop a crash report so the failure is recoverable post-mortem.
+		if path := crash.write_dump(crashdumps_dir, time.now().unix(), 'server stopped',
+			err.msg())
+		{
+			srv.log.error('Wrote crash report to ${path}')
+		}
 		exit(1)
 	}
 }

--- a/server/cmd/command.v
+++ b/server/cmd/command.v
@@ -47,13 +47,17 @@ pub fn new_registry() Registry {
 }
 
 pub fn (mut r Registry) register(cmd Command) {
-	r.commands[cmd.name()] = cmd
+	// Keys are stored lower-cased so unregister and resolve (which both
+	// lower-case) agree - otherwise a command with any uppercase in its name
+	// could never be disabled via permissions.yml.
+	key := cmd.name().to_lower()
+	r.commands[key] = cmd
 	for alias in cmd.aliases() {
-		r.aliases[alias] = cmd.name()
+		r.aliases[alias.to_lower()] = key
 	}
 }
 
-// unregister removes a previously registered command 
+// unregister removes a previously registered command
 // (and any aliases pointing to it) by name.
 pub fn (mut r Registry) unregister(name string) {
 	key := name.to_lower()

--- a/server/cmd/default/command_test.v
+++ b/server/cmd/default/command_test.v
@@ -48,6 +48,11 @@ mut:
 	broadcast_titles []string
 	is_player_val    bool = true
 	sent_form        ?form.Form
+	worlds           []string
+	tp_world         string
+	scoreboard_title string
+	scoreboard_lines []string
+	scoreboard_shown bool
 }
 
 fn (mut s RecordingSender) send_message(message string) ! {
@@ -89,6 +94,8 @@ fn (mut s RecordingSender) kill() {
 fn (mut s RecordingSender) position() (f32, f32, f32) {
 	return s.pos_x, s.pos_y, s.pos_z
 }
+
+fn (mut s RecordingSender) place_water(x int, y int, z int) {}
 
 fn (mut s RecordingSender) teleport(x f32, y f32, z f32) {
 	s.pos_x = x
@@ -146,8 +153,43 @@ fn (mut s RecordingSender) broadcast_title(kind int, text string) {
 	s.broadcast_titles << text
 }
 
+fn (mut s RecordingSender) show_scoreboard(title string, lines []string) {
+	s.scoreboard_title = title
+	s.scoreboard_lines = lines
+	s.scoreboard_shown = true
+}
+
+fn (mut s RecordingSender) clear_scoreboard() {
+	s.scoreboard_shown = false
+}
+
 fn (mut s RecordingSender) send_form(f form.Form) ! {
 	s.sent_form = f
+}
+
+fn (mut s RecordingSender) world_names() []string {
+	return s.worlds
+}
+
+fn (mut s RecordingSender) world_info(name string) ?cmd.WorldSummary {
+	if name !in s.worlds {
+		return none
+	}
+	return cmd.WorldSummary{
+		name: name
+	}
+}
+
+fn (mut s RecordingSender) world_create(name string) ! {
+	s.worlds << name
+}
+
+fn (mut s RecordingSender) world_delete(name string) ! {
+	s.worlds = s.worlds.filter(it != name)
+}
+
+fn (mut s RecordingSender) world_teleport(name string) ! {
+	s.tp_world = name
 }
 
 fn test_version_command() {
@@ -301,19 +343,55 @@ fn test_available_commands_roundtrip() {
 	mut sender := RecordingSender{}
 	sender.perm.set_op(true)
 	pkt := r.available_commands(sender)
-	assert pkt.commands.len == 13
+	assert pkt.commands.len == 15
 	encoded := protocol.encode_packet_to_bytes(&pkt)
 	mut pool := protocol.new_packet_pool()
 	mut reader := serializer.new_reader(encoded)
 	decoded := pool.decode(mut reader)!
 	assert decoded.name() == 'AvailableCommandsPacket'
 	if decoded is protocol.AvailableCommandsPacket {
-		assert decoded.commands.len == 13
+		assert decoded.commands.len == 15
 		assert decoded.commands[0].alias_enum_index == -1
 		assert decoded.commands[0].overloads.len == 1
 	} else {
 		assert false
 	}
+}
+
+fn test_world_list_reports_loaded_worlds() {
+	r := full_registry()
+	mut sender := RecordingSender{
+		worlds: ['world', 'nether']
+	}
+	sender.perm.set_op(true)
+	r.dispatch('/world list', mut sender, base_ctx())!
+	assert sender.messages[0].contains('world')
+	assert sender.messages[0].contains('nether')
+}
+
+fn test_world_create_and_delete() {
+	r := full_registry()
+	mut sender := RecordingSender{}
+	sender.perm.set_op(true)
+	r.dispatch('/world create arena', mut sender, base_ctx())!
+	assert 'arena' in sender.worlds
+	r.dispatch('/world delete arena', mut sender, base_ctx())!
+	assert 'arena' !in sender.worlds
+}
+
+fn test_world_denied_without_op() {
+	r := full_registry()
+	mut sender := RecordingSender{}
+	r.dispatch('/world list', mut sender, base_ctx())!
+	assert sender.messages[0].contains('permission')
+}
+
+fn test_world_missing_name_shows_usage() {
+	r := full_registry()
+	mut sender := RecordingSender{}
+	sender.perm.set_op(true)
+	r.dispatch('/world create', mut sender, base_ctx())!
+	assert sender.messages[0].contains('Usage')
 }
 
 fn test_available_commands_filtered() {

--- a/server/cmd/default/difficulty.v
+++ b/server/cmd/default/difficulty.v
@@ -26,7 +26,8 @@ pub fn (c DifficultyCommand) arguments() []cmd.Argument {
 	return [
 		cmd.StringEnumArgument{
 			arg_name: 'difficulty'
-			values:   ['peaceful', 'p', '0', 'easy', 'e', '1', 'normal', 'n', '2', 'hard', 'h', '3']
+			values:   ['peaceful', 'p', '0', 'easy', 'e', '1', 'normal', 'n', '2', 'hard', 'h',
+				'3']
 		},
 	]
 }

--- a/server/cmd/default/register.v
+++ b/server/cmd/default/register.v
@@ -1,8 +1,10 @@
 module default
 
 import server.cmd
+import server.permission
 
 pub fn register_all(mut r cmd.Registry) {
+	permission.set_default(water_permission, .op)
 	r.register(VersionCommand{})
 	r.register(StatusCommand{})
 	r.register(GamemodeCommand{})
@@ -16,4 +18,6 @@ pub fn register_all(mut r cmd.Registry) {
 	r.register(DifficultyCommand{})
 	r.register(SayCommand{})
 	r.register(TitleCommand{})
+	r.register(WorldCommand{})
+	r.register(WaterCommand{})
 }

--- a/server/cmd/default/water.v
+++ b/server/cmd/default/water.v
@@ -1,0 +1,41 @@
+module default
+
+import server.cmd
+
+// water_permission gates /water. Registered as an operator-only default from
+// register_all so it lines up with the other command nodes.
+pub const water_permission = 'vedrock.cmd.water'
+
+// WaterCommand places a water source at the sender's feet and lets it flow.
+// Handy for testing the liquid spread engine in-world.
+pub struct WaterCommand {}
+
+pub fn (c WaterCommand) name() string {
+	return 'water'
+}
+
+pub fn (c WaterCommand) description() string {
+	return 'Places flowing water at your position'
+}
+
+pub fn (c WaterCommand) aliases() []string {
+	return []
+}
+
+pub fn (c WaterCommand) permission() string {
+	return water_permission
+}
+
+pub fn (c WaterCommand) arguments() []cmd.Argument {
+	return []
+}
+
+pub fn (c WaterCommand) execute(mut sender cmd.Sender, ctx cmd.Context) ! {
+	if !sender.is_player() {
+		sender.send_message(ctx.lang.t('cmd.player_only'))!
+		return
+	}
+	x, y, z := sender.position()
+	sender.place_water(int(x), int(y), int(z))
+	sender.send_message('Placed water.')!
+}

--- a/server/cmd/default/world.v
+++ b/server/cmd/default/world.v
@@ -1,0 +1,158 @@
+module default
+
+import server.permission
+import server.cmd
+
+pub struct WorldCommand {}
+
+pub fn (c WorldCommand) name() string {
+	return 'world'
+}
+
+pub fn (c WorldCommand) description() string {
+	return 'Manages worlds - list, info, create, delete, tp'
+}
+
+pub fn (c WorldCommand) aliases() []string {
+	return ['worlds']
+}
+
+pub fn (c WorldCommand) permission() string {
+	return permission.command_world
+}
+
+pub fn (c WorldCommand) arguments() []cmd.Argument {
+	return [
+		cmd.StringEnumArgument{
+			arg_name: 'action'
+			values:   ['list', 'info', 'create', 'delete', 'tp']
+		},
+		cmd.StringArgument{
+			arg_name:     'name'
+			arg_optional: true
+		},
+	]
+}
+
+pub fn (c WorldCommand) execute(mut sender cmd.Sender, ctx cmd.Context) ! {
+	if ctx.args.len == 0 {
+		sender.send_message(ctx.lang.t('cmd.world.usage'))!
+		return
+	}
+	action := ctx.args[0].to_lower()
+	match action {
+		'list' {
+			c.list(mut sender, ctx)!
+		}
+		'info' {
+			c.info(mut sender, ctx)!
+		}
+		'create' {
+			c.create(mut sender, ctx)!
+		}
+		'delete' {
+			c.delete(mut sender, ctx)!
+		}
+		'tp' {
+			c.teleport(mut sender, ctx)!
+		}
+		else {
+			sender.send_message(ctx.lang.t('cmd.world.usage'))!
+		}
+	}
+}
+
+fn (c WorldCommand) list(mut sender cmd.Sender, ctx cmd.Context) ! {
+	names := sender.world_names()
+	if names.len == 0 {
+		sender.send_message(ctx.lang.t('cmd.world.none'))!
+		return
+	}
+	sender.send_message(ctx.lang.tf('cmd.world.list', {
+		'Count':  names.len.str()
+		'Worlds': names.join(', ')
+	}))!
+}
+
+fn (c WorldCommand) info(mut sender cmd.Sender, ctx cmd.Context) ! {
+	name := c.name_arg(ctx) or {
+		sender.send_message(ctx.lang.t('cmd.world.usage'))!
+		return
+	}
+	info := sender.world_info(name) or {
+		sender.send_message(ctx.lang.tf('cmd.world.not_found', {
+			'Name': name
+		}))!
+		return
+	}
+	mut lines := []string{}
+	lines << '§6World: §a${info.name}§r'
+	lines << '§6Generator: §f${info.generator}§r'
+	lines << '§6Block overrides: §f${info.overrides}§r'
+	lines << '§6Players: §f${info.players}§r'
+	lines << '§6Default: §f${info.is_default}§r'
+	sender.send_message(lines.join('\n'))!
+}
+
+fn (c WorldCommand) create(mut sender cmd.Sender, ctx cmd.Context) ! {
+	name := c.name_arg(ctx) or {
+		sender.send_message(ctx.lang.t('cmd.world.usage'))!
+		return
+	}
+	sender.world_create(name) or {
+		sender.send_message(ctx.lang.tf('cmd.world.create_failed', {
+			'Name':   name
+			'Reason': err.msg()
+		}))!
+		return
+	}
+	sender.send_message(ctx.lang.tf('cmd.world.created', {
+		'Name': name
+	}))!
+}
+
+fn (c WorldCommand) delete(mut sender cmd.Sender, ctx cmd.Context) ! {
+	name := c.name_arg(ctx) or {
+		sender.send_message(ctx.lang.t('cmd.world.usage'))!
+		return
+	}
+	sender.world_delete(name) or {
+		sender.send_message(ctx.lang.tf('cmd.world.delete_failed', {
+			'Name':   name
+			'Reason': err.msg()
+		}))!
+		return
+	}
+	sender.send_message(ctx.lang.tf('cmd.world.deleted', {
+		'Name': name
+	}))!
+}
+
+fn (c WorldCommand) teleport(mut sender cmd.Sender, ctx cmd.Context) ! {
+	if !sender.is_player() {
+		sender.send_message(ctx.lang.t('cmd.player_only'))!
+		return
+	}
+	name := c.name_arg(ctx) or {
+		sender.send_message(ctx.lang.t('cmd.world.usage'))!
+		return
+	}
+	sender.world_teleport(name) or {
+		sender.send_message(ctx.lang.tf('cmd.world.tp_failed', {
+			'Name':   name
+			'Reason': err.msg()
+		}))!
+		return
+	}
+	sender.send_message(ctx.lang.tf('cmd.world.tp', {
+		'Name': name
+	}))!
+}
+
+// name_arg returns the second argument, or none when it's missing/blank.
+fn (c WorldCommand) name_arg(ctx cmd.Context) ?string {
+	if ctx.args.len < 2 || ctx.args[1].trim_space() == '' {
+		return none
+	}
+	return ctx.args[1]
+}

--- a/server/cmd/sender.v
+++ b/server/cmd/sender.v
@@ -20,6 +20,8 @@ mut:
 	kill()
 	position() (f32, f32, f32)
 	teleport(x f32, y f32, z f32)
+	// place_water sets a water source at the block position and starts its spread.
+	place_water(x int, y int, z int)
 	clear_inventory()
 	give_item(id string, count int) bool
 	whitelist_add(name string)
@@ -31,5 +33,28 @@ mut:
 	show_title(kind int, text string)
 	// broadcast_title sends to every connected player (for /title @a).
 	broadcast_title(kind int, text string)
+	// show_scoreboard displays a sidebar scoreboard to this sender with the
+	// given title and lines rendered top-to-bottom.
+	show_scoreboard(title string, lines []string)
+	// clear_scoreboard removes the sidebar scoreboard from this sender.
+	clear_scoreboard()
 	send_form(f form.Form) !
+	// world management. Mutating ops return an error the command relays to the
+	// sender; list/info are read-only snapshots.
+	world_names() []string
+	world_info(name string) ?WorldSummary
+	world_create(name string) !
+	world_delete(name string) !
+	world_teleport(name string) !
+}
+
+// WorldSummary is a read-only snapshot of a loaded world, built for command
+// output so the cmd layer never depends on the db types directly.
+pub struct WorldSummary {
+pub:
+	name       string
+	generator  string
+	overrides  int
+	is_default bool
+	players    int
 }

--- a/server/conf/conf.v
+++ b/server/conf/conf.v
@@ -12,13 +12,17 @@ pub mut:
 	view_distance         int    = 8
 	gamemode              string = 'survival'
 	xbox_auth             bool   = true
+	// encryption negotiates Bedrock protocol encryption. Off by default - the
+	// implementation is spec-complete but not yet verified against a real client,
+	// so leaving it off keeps sessions cleartext and connectable.
+	encryption            bool
 	compression_threshold int    = 256
 	generator             string = 'flat'
 	language              string = 'en'
 	resource_packs        bool   = true
 	resource_packs_dir    string = 'resource_packs'
 	force_resource_packs  bool
-	allow_client_packs    bool   = true
+	allow_client_packs    bool = true
 	cdn_packs             string
 	default_world         string = 'world'
 	load_all_worlds       bool
@@ -48,6 +52,7 @@ pub fn load_from(path string) !Config {
 	cfg.view_distance = (values['view-distance'] or { cfg.view_distance.str() }).int()
 	cfg.gamemode = values['gamemode'] or { cfg.gamemode }
 	cfg.xbox_auth = to_bool(values['xbox-auth'] or { cfg.xbox_auth.str() })
+	cfg.encryption = to_bool(values['encryption'] or { cfg.encryption.str() })
 	cfg.compression_threshold = (values['compression-threshold'] or {
 		cfg.compression_threshold.str()
 	}).int()
@@ -63,7 +68,9 @@ pub fn load_from(path string) !Config {
 	cfg.force_resource_packs = to_bool(values['force-resource-packs'] or {
 		cfg.force_resource_packs.str()
 	})
-	cfg.allow_client_packs = to_bool(values['allow-client-packs'] or { cfg.allow_client_packs.str() })
+	cfg.allow_client_packs = to_bool(values['allow-client-packs'] or {
+		cfg.allow_client_packs.str()
+	})
 	cfg.cdn_packs = values['cdn-packs'] or { cfg.cdn_packs }
 	cfg.default_world = values['default-world'] or { cfg.default_world }
 	cfg.load_all_worlds = to_bool(values['load-all-worlds'] or { cfg.load_all_worlds.str() })
@@ -104,6 +111,7 @@ max-players: ${cfg.max_players}
 view-distance: ${cfg.view_distance}
 gamemode: "${cfg.gamemode}"
 xbox-auth: ${cfg.xbox_auth}
+encryption: ${cfg.encryption}
 compression-threshold: ${cfg.compression_threshold}
 generator: "${cfg.generator}"
 language: "${cfg.language}"

--- a/server/form/button.v
+++ b/server/form/button.v
@@ -1,6 +1,6 @@
 module form
 
-// ButtonImage is the optional icon shown next to a Button on a SimpleForm or ModalForm. 
+// ButtonImage is the optional icon shown next to a Button on a SimpleForm or ModalForm.
 // typ is path for a builtin game asset or url for a remote image.
 pub struct ButtonImage {
 pub:

--- a/server/form/custom.v
+++ b/server/form/custom.v
@@ -47,6 +47,7 @@ pub fn (f &CustomForm) submit(raw ?string) ! {
 		}
 		return
 	}
+
 	response := parse_response(data)!
 	if response.len() != f.elements.len {
 		return error('form: expected ${f.elements.len} response values, got ${response.len()}')

--- a/server/form/elements.v
+++ b/server/form/elements.v
@@ -6,13 +6,14 @@ pub type Element = Divider | Dropdown | Header | Input | Label | Slider | StepSl
 
 pub struct Divider {
 pub:
-	typ string = 'divider' @[json: 'type']
+	typ  string = 'divider' @[json: 'type']
 	text string
 }
 
 pub fn divider() Element {
 	return Divider{}
 }
+
 pub struct Header {
 pub:
 	typ  string = 'header' @[json: 'type']
@@ -108,7 +109,7 @@ pub:
 	typ           string = 'step_slider' @[json: 'type']
 	text          string
 	options       []string @[json: 'steps']
-	default_index int @[json: 'default']
+	default_index int      @[json: 'default']
 }
 
 pub fn step_slider(text string, options []string, default_index int) Element {

--- a/server/form/form.v
+++ b/server/form/form.v
@@ -8,8 +8,8 @@ pub interface Form {
 	submit(raw ?string) !
 	// has_network_image reports whether this form has a button image fetched
 	// over the network (type url), as opposed to a bundled resource pack
-	// asset (type path). The Bedrock client can get stuck showing a loading 
-	// spinner on that image well after it has actually finished loading; 
+	// asset (type path). The Bedrock client can get stuck showing a loading
+	// spinner on that image well after it has actually finished loading;
 	// assending the player an attribute update afterwards clears it. (see https://github.com/muqsit/FormImagesFix)
 	has_network_image() bool
 }

--- a/server/form/modal.v
+++ b/server/form/modal.v
@@ -6,8 +6,8 @@ pub struct ModalForm {
 mut:
 	title      string
 	content    string
-	button1    string = 'gui.yes'
-	button2    string = 'gui.no'
+	button1    string  = 'gui.yes'
+	button2    string  = 'gui.no'
 	on_button1 fn () ! = unsafe { nil }
 	on_button2 fn () ! = unsafe { nil }
 	on_close   ?fn ()
@@ -53,6 +53,7 @@ pub fn (f &ModalForm) submit(raw ?string) ! {
 		}
 		return
 	}
+
 	if data == 'true' {
 		f.on_button1()!
 		return

--- a/server/form/simple.v
+++ b/server/form/simple.v
@@ -64,6 +64,7 @@ pub fn (f &SimpleForm) submit(raw ?string) ! {
 		}
 		return
 	}
+
 	index := data.int()
 	if index < 0 || index >= f.on_click.len {
 		return error('form: button index ${index} out of range (${f.on_click.len} buttons)')

--- a/server/internal/auth/auth_test.v
+++ b/server/internal/auth/auth_test.v
@@ -118,6 +118,46 @@ fn test_identity_token_offline_rejected_when_xbox_required() {
 	assert identity.xbox_authenticated == false
 }
 
+// A self-signed single-token chain is the closed exploit: the attacker signs
+// with their own key and cannot make is_trusted_key true, so authenticated stays
+// false even if the payload claims to be Mojang's.
+fn test_self_signed_chain_not_authenticated() {
+	priv := ecdsa.privkey_from_string(test_private_key_pem)!
+	header := '{"alg":"ES384","x5u":"${test_public_key_spki}"}'
+	payload := '{"extraData":{"displayName":"Notch","identity":"00000000-0000-0000-0000-0000000000ff","XUID":"2535400000000000"},"identityPublicKey":"${mojang_public_key}"}'
+	token := make_token(header, payload, priv)!
+	chain_json := '{"chain":["${token}"]}'
+	identity := parse_login_chain(chain_json, false)!
+	assert identity.display_name == 'Notch'
+	assert identity.xbox_authenticated == false
+	if _ := parse_login_chain(chain_json, true) {
+		assert false
+	}
+}
+
+// Trust anchor: authenticated is true only when a token was verified using the
+// Mojang key, regardless of any payload field.
+fn test_trust_anchor_is_verifying_key() {
+	assert is_trusted_key(mojang_public_key) == true
+	assert is_trusted_key(test_public_key_spki) == false
+	assert is_trusted_key('') == false
+}
+
+// A mis-linked chain - the second token is not signed by the key the first token
+// hands off - must fail verification, not silently continue.
+fn test_broken_chain_returns_error() {
+	priv := ecdsa.privkey_from_string(test_private_key_pem)!
+	header := '{"alg":"ES384","x5u":"${test_public_key_spki}"}'
+	first_payload := '{"identityPublicKey":"${mojang_public_key}"}'
+	first := make_token(header, first_payload, priv)!
+	second_payload := '{"extraData":{"displayName":"Steve","XUID":"1"},"identityPublicKey":"${test_public_key_spki}"}'
+	second := make_token(header, second_payload, priv)!
+	chain_json := '{"chain":["${first}","${second}"]}'
+	if _ := parse_login_chain(chain_json, false) {
+		assert false
+	}
+}
+
 fn test_tampered_signature_fails() {
 	priv := ecdsa.privkey_from_string(test_private_key_pem)!
 	header := '{"alg":"ES384","x5u":"${test_public_key_spki}"}'

--- a/server/internal/auth/chain.v
+++ b/server/internal/auth/chain.v
@@ -13,6 +13,11 @@ pub:
 	client_public_key  string
 }
 
+// parse_login_chain verifies the JWT signature chain and returns the client
+// identity. Trust boundary: when the chain is self-signed (offline mode) the
+// signatures are valid but prove nothing about who the player is -
+// xbox_authenticated is only true when the chain roots in Mojang's public key.
+// Callers must treat display_name/xuid as unverified unless xbox_authenticated.
 pub fn parse_login_chain(auth_info_json string, require_xbox bool) !Identity {
 	root := json2.decode[json2.Any](auth_info_json)!.as_map()
 	chain := extract_chain(root)!
@@ -66,6 +71,19 @@ fn to_string_array(value json2.Any) []string {
 	return result
 }
 
+// is_trusted_key reports whether a token verified with this key roots the chain
+// in Mojang's authority. Only a key equal to the pinned Mojang public key is
+// trusted - this is the trust anchor and must never be derived from a payload
+// field the client controls.
+fn is_trusted_key(current_key string) bool {
+	return current_key == mojang_public_key
+}
+
+// verify_chain walks the login chain in order, tracking the key that verifies
+// the current token. Token[0] is checked against its own x5u header; every later
+// token is checked against the identityPublicKey carried in the previous token.
+// A chain is Xbox-authenticated only when some token was actually verified using
+// the Mojang public key - never because a payload field claims to be Mojang's.
 fn verify_chain(chain []string) !Identity {
 	first := decode_jwt(chain[0])!
 	if 'x5u' !in first.header {
@@ -79,12 +97,12 @@ fn verify_chain(chain []string) !Identity {
 		if !verify_jwt(token, current_key)! {
 			return error('signature verification failed for chain token ${i}')
 		}
+		if is_trusted_key(current_key) {
+			authenticated = true
+		}
 		payload := decode_jwt(token)!.payload
 		if 'identityPublicKey' in payload {
 			next_key := (payload['identityPublicKey'] or { json2.Any('') }).str()
-			if i == 0 {
-				authenticated = next_key == mojang_public_key
-			}
 			client_key = next_key
 			current_key = next_key
 		}

--- a/server/internal/gamedata/data.v
+++ b/server/internal/gamedata/data.v
@@ -56,8 +56,7 @@ pub fn load(data_dir string) !GameData {
 	mut entries := []ItemEntry{}
 	mut id_by_name := map[string]int{}
 	mut component_by_name := map[string]bool{}
-	palette_doc :=
-		json2.decode[json2.Any](os.read_file(os.join_path(data_dir, 'item_palette.json'))!)!.as_map()
+	palette_doc := json2.decode[json2.Any](os.read_file(os.join_path(data_dir, 'item_palette.json'))!)!.as_map()
 	for any_item in (palette_doc['items'] or { json2.Any('') }).as_array() {
 		m := any_item.as_map()
 		name := any_str(m, 'name')
@@ -75,8 +74,7 @@ pub fn load(data_dir string) !GameData {
 
 	mut groups := []CreativeGroup{}
 	mut creative := []CreativeItem{}
-	creative_doc := json2.decode[json2.Any](os.read_file(os.join_path(data_dir,
-		'creative_items.json'))!)!.as_map()
+	creative_doc := json2.decode[json2.Any](os.read_file(os.join_path(data_dir, 'creative_items.json'))!)!.as_map()
 	for any_group in (creative_doc['groups'] or { json2.Any('') }).as_array() {
 		g := any_group.as_map()
 		mut icon_id := 0

--- a/server/internal/network/batch.v
+++ b/server/internal/network/batch.v
@@ -8,6 +8,15 @@ pub const game_packet_header = u8(0xfe)
 pub const compression_flate = u8(0x00)
 pub const compression_none = u8(0xff)
 
+// Inbound frame bounds - a malformed or hostile peer must never drive
+// unbounded work. All values are hard limits; a violation aborts decode and
+// the caller disconnects the peer. Sized generously above vanilla traffic so
+// legitimate clients are unaffected.
+pub const max_compressed_batch = 2 * 1024 * 1024 // wire bytes accepted per read
+pub const max_decompressed_batch = 8 * 1024 * 1024 // guards against decompression bombs
+pub const max_packets_per_batch = 512
+pub const max_single_packet = 2 * 1024 * 1024
+
 pub fn encode_batch(packets [][]u8, compression_enabled bool, threshold int) ![]u8 {
 	mut bw := serializer.new_writer()
 	for pkt in packets {
@@ -36,6 +45,9 @@ pub fn decode_batch(payload []u8, compression_enabled bool) ![][]u8 {
 	if payload.len == 0 {
 		return error('empty batch payload')
 	}
+	if payload.len > max_compressed_batch {
+		return error('batch payload too large: ${payload.len} bytes')
+	}
 	if payload[0] != game_packet_header {
 		return error('invalid game packet header 0x${payload[0].hex()}')
 	}
@@ -55,6 +67,12 @@ pub fn decode_batch(payload []u8, compression_enabled bool) ![][]u8 {
 			else { return error('unknown compression algorithm 0x${algorithm.hex()}') }
 		}
 	}
+	// Guard against decompression bombs - a small flate frame can inflate to
+	// gigabytes. We cannot cap the decompressor itself, so we reject after the
+	// fact before doing any parsing work.
+	if batch.len > max_decompressed_batch {
+		return error('decompressed batch too large: ${batch.len} bytes')
+	}
 	mut r := serializer.new_reader(batch)
 	mut packets := [][]u8{}
 	for r.remaining() > 0 {
@@ -62,7 +80,13 @@ pub fn decode_batch(payload []u8, compression_enabled bool) ![][]u8 {
 		if length == 0 {
 			return error('empty packet in batch')
 		}
+		if length > max_single_packet {
+			return error('packet in batch too large: ${length} bytes')
+		}
 		packets << r.read_raw(length)!
+		if packets.len > max_packets_per_batch {
+			return error('too many packets in batch (> ${max_packets_per_batch})')
+		}
 	}
 	return packets
 }

--- a/server/internal/network/batch_test.v
+++ b/server/internal/network/batch_test.v
@@ -1,5 +1,7 @@
 module network
 
+import protocol.serializer
+
 fn test_batch_roundtrip_uncompressed() {
 	packets := [
 		[u8(0x01), 0x02, 0x03],
@@ -38,6 +40,36 @@ fn test_batch_roundtrip_flate_above_threshold() {
 fn test_decode_rejects_bad_header() {
 	bad := [u8(0x00), 0x01]
 	if _ := decode_batch(bad, false) {
+		assert false
+	}
+}
+
+fn test_decode_rejects_oversized_compressed_payload() {
+	mut huge := []u8{len: max_compressed_batch + 1, init: game_packet_header}
+	if _ := decode_batch(huge, false) {
+		assert false
+	}
+}
+
+fn test_decode_rejects_oversized_single_packet() {
+	mut bw := serializer.new_writer()
+	bw.write_varuint32(u32(max_single_packet + 1))
+	mut payload := [game_packet_header]
+	payload << bw.bytes()
+	if _ := decode_batch(payload, false) {
+		assert false
+	}
+}
+
+fn test_decode_rejects_too_many_packets() {
+	mut bw := serializer.new_writer()
+	for _ in 0 .. max_packets_per_batch + 1 {
+		bw.write_varuint32(1)
+		bw.write_raw([u8(0x00)])
+	}
+	mut payload := [game_packet_header]
+	payload << bw.bytes()
+	if _ := decode_batch(payload, false) {
 		assert false
 	}
 }

--- a/server/internal/network/session.v
+++ b/server/internal/network/session.v
@@ -1,12 +1,25 @@
 module network
 
+import time
 import raknet
 import sync
 import protocol
 import protocol.serializer
 import server.internal.logger
+import server.internal.encryption
 
 pub const default_compression_threshold = 256
+
+// Inbound rate limits, enforced per connection over a 1s sliding window. A peer
+// that exceeds either bound is disconnected. Bedrock clients burst on chunk
+// requests and movement but stay well under these ceilings.
+pub const max_packets_per_second = 1000
+pub const max_bytes_per_second = 8 * 1024 * 1024
+
+// A connection that has not finished logging in may only send a handful of
+// packets (network settings, login, resource-pack handshake). This caps the
+// work an unauthenticated peer can force before we know who it is.
+pub const max_prelogin_packets = 64
 
 @[heap]
 pub struct Session {
@@ -14,19 +27,51 @@ mut:
 	conn                &raknet.Conn = unsafe { nil }
 	pool                protocol.PacketPool
 	compression_enabled bool
-	threshold           int = default_compression_threshold
+	threshold           int                 = default_compression_threshold
+	cipher              &encryption.Context = unsafe { nil }
 	send_queue          [][]u8
 	write_mutex         &sync.Mutex = sync.new_mutex()
+	logged_in           bool
+	prelogin_packets    int
+	window_start        time.Time = time.now()
+	window_packets      int
+	window_bytes        int
 pub mut:
 	log &logger.Logger = unsafe { nil }
 }
 
 pub fn new_session(mut conn raknet.Conn, log &logger.Logger) &Session {
 	return &Session{
-		conn:        conn
-		pool:        protocol.new_packet_pool()
-		write_mutex: sync.new_mutex()
-		log:         log
+		conn:         conn
+		pool:         protocol.new_packet_pool()
+		write_mutex:  sync.new_mutex()
+		window_start: time.now()
+		log:          log
+	}
+}
+
+// mark_logged_in lifts the pre-login packet cap once authentication completes.
+pub fn (mut s Session) mark_logged_in() {
+	s.logged_in = true
+}
+
+// check_rate enforces the per-connection inbound rate limit over a sliding 1s
+// window. Returns an error - which the read loop treats as a disconnect - when
+// a peer exceeds the packet or byte ceiling. Fails closed, never panics.
+fn (mut s Session) check_rate(raw_len int, packet_count int) ! {
+	now := time.now()
+	if now - s.window_start >= time.second {
+		s.window_start = now
+		s.window_packets = 0
+		s.window_bytes = 0
+	}
+	s.window_packets += packet_count
+	s.window_bytes += raw_len
+	if s.window_packets > max_packets_per_second {
+		return error('inbound packet rate exceeded (${s.window_packets}/s)')
+	}
+	if s.window_bytes > max_bytes_per_second {
+		return error('inbound byte rate exceeded (${s.window_bytes}/s)')
 	}
 }
 
@@ -35,9 +80,31 @@ pub fn (mut s Session) enable_compression(threshold int) {
 	s.threshold = threshold
 }
 
+// enable_encryption installs the per-session cipher once the handshake has
+// completed. From this point every batch body (after the 0xfe header) is
+// encrypted outbound and decrypted inbound. Guarded by write_mutex so it never
+// races an in-flight flush.
+pub fn (mut s Session) enable_encryption(mut ctx encryption.Context) {
+	s.write_mutex.lock()
+	s.cipher = ctx
+	s.write_mutex.unlock()
+}
+
+pub fn (s &Session) encryption_enabled() bool {
+	return s.cipher != unsafe { nil }
+}
+
 pub fn (mut s Session) read() ![]protocol.Packet {
-	raw := s.conn.read_packet()!
+	mut raw := s.conn.read_packet()!
+	raw = s.decrypt_frame(raw)!
 	batch := decode_batch(raw, s.compression_enabled)!
+	s.check_rate(raw.len, batch.len)!
+	if !s.logged_in {
+		s.prelogin_packets += batch.len
+		if s.prelogin_packets > max_prelogin_packets {
+			return error('too many packets before login (${s.prelogin_packets})')
+		}
+	}
 	mut packets := []protocol.Packet{}
 	for b in batch {
 		mut head_reader := serializer.new_reader(b)
@@ -67,6 +134,39 @@ fn decode_auth_input_prefix(mut r serializer.Reader) !protocol.Packet {
 	}
 }
 
+// decrypt_frame decrypts the batch body of an inbound wire frame when the
+// cipher is active. The 0xfe game-packet header stays in cleartext - only the
+// bytes after it are encrypted, matching the Bedrock framing. Called only from
+// the single read thread, so the decrypt keystream needs no extra lock.
+fn (mut s Session) decrypt_frame(raw []u8) ![]u8 {
+	if s.cipher == unsafe { nil } {
+		return raw
+	}
+	if raw.len == 0 || raw[0] != game_packet_header {
+		return error('invalid game packet header on encrypted frame')
+	}
+	body := unsafe { raw[1..] }
+	plain := s.cipher.decrypt(body)!
+	mut out := []u8{cap: plain.len + 1}
+	out << game_packet_header
+	out << plain
+	return out
+}
+
+// encrypt_frame encrypts the batch body of an outbound frame when the cipher is
+// active, leaving the 0xfe header in cleartext. Callers must hold write_mutex.
+fn (mut s Session) encrypt_frame(frame []u8) []u8 {
+	if s.cipher == unsafe { nil } {
+		return frame
+	}
+	body := frame[1..]
+	cipher := s.cipher.encrypt(body)
+	mut out := []u8{cap: cipher.len + 1}
+	out << game_packet_header
+	out << cipher
+	return out
+}
+
 fn (mut s Session) queue_locked(p protocol.Packet) {
 	s.send_queue << protocol.encode_packet_to_bytes(p)
 }
@@ -76,7 +176,7 @@ fn (mut s Session) flush_locked() ! {
 		return
 	}
 	out := encode_batch(s.send_queue, s.compression_enabled, s.threshold)!
-	s.conn.write(out)!
+	s.conn.write(s.encrypt_frame(out))!
 	s.send_queue.clear()
 }
 

--- a/server/liquid/manager.v
+++ b/server/liquid/manager.v
@@ -1,0 +1,259 @@
+module liquid
+
+import server.world
+
+// BlockSource reads block network ids from a world by absolute coordinates.
+// Hub satisfies it structurally; tests use an in-memory grid.
+pub interface BlockSource {
+mut:
+	get_block(x int, y int, z int) int
+}
+
+// BlockSink writes a block by network id and broadcasts the change to viewers.
+// Every liquid write routes through this so a spread looks like a normal edit.
+pub interface BlockSink {
+mut:
+	set_block_id(id int, x int, y int, z int)
+}
+
+// Host is what the LiquidManager needs from its world: read and write blocks.
+// Hub satisfies it via get_block/set_block_id, so this module never imports
+// session and stays unit-testable against a fake grid.
+pub interface Host {
+	BlockSource
+	BlockSink
+}
+
+// max_cells_per_tick caps how many pending cells the manager drains in a single
+// tick so a large flood can never stall the actor thread. Cells left over stay
+// queued and are processed on later ticks - the flow just spreads a bit slower
+// under heavy load instead of blocking the whole server. 4096 is generous: a
+// flat pool spreading 7 cells in every direction is well under this.
+pub const max_cells_per_tick = 4096
+
+// Pos is an absolute block coordinate used as a queue key.
+struct Pos {
+	x int
+	y int
+	z int
+}
+
+// LiquidManager owns the set of block positions that still need a liquid
+// update and processes them on the actor thread each tick. It holds no world
+// of its own - the Host it is handed reads and writes blocks.
+@[heap]
+pub struct LiquidManager {
+mut:
+	host    Host
+	pending map[string]Pos
+	// water_states maps every known water network id to its resolved cell so the
+	// manager can tell water apart from other blocks when it reads the world.
+	water_states map[int]WaterState
+	air_id       int
+}
+
+// new_manager builds a LiquidManager bound to host and precomputes the water id
+// table (all source, flowing and falling states) once.
+pub fn new_manager(host Host) &LiquidManager {
+	mut states := map[int]WaterState{}
+	src := new_source()
+	states[src.network_id()] = src
+	fall := new_falling()
+	states[fall.network_id()] = fall
+	for depth := 1; depth <= max_flow_depth; depth++ {
+		w := new_flowing(depth)
+		states[w.network_id()] = w
+	}
+	return &LiquidManager{
+		host:         host
+		water_states: states
+		air_id:       world.air.network_id
+	}
+}
+
+fn key(x int, y int, z int) string {
+	return '${x},${y},${z}'
+}
+
+// place_source sets a water source at the position and queues it for spreading.
+pub fn (mut m LiquidManager) place_source(x int, y int, z int) {
+	m.host.set_block_id(new_source().network_id(), x, y, z)
+	m.enqueue(x, y, z)
+}
+
+// enqueue marks a cell as needing a liquid update on a later tick.
+pub fn (mut m LiquidManager) enqueue(x int, y int, z int) {
+	m.pending[key(x, y, z)] = Pos{x, y, z}
+}
+
+// on_block_changed re-evaluates a cell and its neighbours after a block edit -
+// placing water starts its flow, breaking a block frees a path for adjacent
+// water to spread into. Only water cells actually do anything when processed.
+pub fn (mut m LiquidManager) on_block_changed(x int, y int, z int) {
+	m.enqueue(x, y, z)
+	m.enqueue_neighbours(x, y, z)
+}
+
+// pending_count is the number of cells still queued. Used by tests.
+pub fn (m &LiquidManager) pending_count() int {
+	return m.pending.len
+}
+
+// water_at returns the resolved water cell at a position, or none if the block
+// there is not water.
+fn (mut m LiquidManager) water_at(x int, y int, z int) ?WaterState {
+	id := m.host.get_block(x, y, z)
+	return m.water_states[id] or { return none }
+}
+
+// is_water reports whether the block at a position is any water cell.
+fn (mut m LiquidManager) is_water(x int, y int, z int) bool {
+	if _ := m.water_at(x, y, z) {
+		return true
+	}
+	return false
+}
+
+// can_flow_into reports whether water may spread into the cell. For now only
+// air and existing water are replaceable - solid terrain blocks the flow.
+fn (mut m LiquidManager) can_flow_into(x int, y int, z int) bool {
+	id := m.host.get_block(x, y, z)
+	if id == m.air_id {
+		return true
+	}
+	return id in m.water_states
+}
+
+// tick drains up to max_cells_per_tick queued cells and processes each. Cells a
+// processed cell touches (neighbours it fills, or itself when it changes) are
+// re-queued for the next tick, so the flow advances one ring per tick like
+// vanilla. Runs on the actor thread from TickJob.
+pub fn (mut m LiquidManager) tick() {
+	if m.pending.len == 0 {
+		return
+	}
+	mut batch := []Pos{cap: m.pending.len}
+	for _, p in m.pending {
+		batch << p
+		if batch.len >= max_cells_per_tick {
+			break
+		}
+	}
+	for p in batch {
+		m.pending.delete(key(p.x, p.y, p.z))
+	}
+	for p in batch {
+		m.process(p.x, p.y, p.z)
+	}
+}
+
+// process runs one cell's flow step: dry up if unfed, fall straight down, then
+// spread outwards with decayed depth.
+fn (mut m LiquidManager) process(x int, y int, z int) {
+	cur := m.water_at(x, y, z) or { return }
+
+	// A flowing cell with no feeding source nearby dries up toward air.
+	if !cur.is_source() && !m.source_around(cur, x, y, z) {
+		mut next_depth := 0
+		if cur.depth - 2 * spread_decay > 0 {
+			next_depth = cur.depth - 2 * spread_decay
+		}
+		if next_depth <= 0 {
+			m.set_air(x, y, z)
+		} else {
+			m.set_water(new_flowing(next_depth), x, y, z)
+			m.enqueue_neighbours(x, y, z)
+		}
+		return
+	}
+
+	// Falling: pour straight down into air/water below.
+	below_falls := m.can_flow_into(x, y - 1, z)
+	if below_falls {
+		m.flow_into(new_falling(), x, y - 1, z)
+	}
+
+	// Once resting on ground (or a source), spread outwards with decayed depth.
+	if cur.is_source() || !below_falls {
+		spread_depth := cur.depth - spread_decay
+		if spread_depth <= 0 {
+			return
+		}
+		m.spread_outwards(new_flowing(spread_depth), x, y, z)
+	}
+}
+
+// spread_outwards flows the decayed water into each horizontal neighbour.
+fn (mut m LiquidManager) spread_outwards(w WaterState, x int, y int, z int) {
+	m.flow_into(w, x + 1, y, z)
+	m.flow_into(w, x - 1, y, z)
+	m.flow_into(w, x, y, z + 1)
+	m.flow_into(w, x, y, z - 1)
+}
+
+// flow_into writes w into the target cell if it may flow there and the target
+// isn't already an equal-or-fuller water cell, then queues the target.
+fn (mut m LiquidManager) flow_into(w WaterState, x int, y int, z int) {
+	if !m.can_flow_into(x, y, z) {
+		return
+	}
+	if existing := m.water_at(x, y, z) {
+		// Don't overwrite an equal-or-fuller cell, and never demote a source.
+		if existing.is_source() {
+			return
+		}
+		if !w.falling && existing.depth >= w.depth && !existing.falling {
+			return
+		}
+	}
+	m.set_water(w, x, y, z)
+	m.enqueue(x, y, z)
+}
+
+// source_around reports whether a horizontally adjacent or overhead water cell
+// feeds this one. A cell fed from above (falling) or by a fuller neighbour stays
+// wet; otherwise it dries up. Also counts adjacent sources for source-forming.
+fn (mut m LiquidManager) source_around(cur WaterState, x int, y int, z int) bool {
+	// Water directly above feeds this cell (it is falling into it).
+	if m.is_water(x, y + 1, z) {
+		return true
+	}
+	mut adjacent_sources := 0
+	mut fed := false
+	offsets := [[1, 0], [-1, 0], [0, 1], [0, -1]]
+	for o in offsets {
+		side := m.water_at(x + o[0], y, z + o[1]) or { continue }
+		if side.is_source() {
+			adjacent_sources++
+		}
+		if side.depth > cur.depth {
+			fed = true
+		}
+	}
+	// Two adjacent sources form a new source here if there is solid ground below.
+	if adjacent_sources >= min_adjacent_sources && !m.can_flow_into(x, y - 1, z) {
+		m.set_water(new_source(), x, y, z)
+		m.enqueue_neighbours(x, y, z)
+		return true
+	}
+	return fed
+}
+
+// enqueue_neighbours queues the six face neighbours of a cell for update.
+fn (mut m LiquidManager) enqueue_neighbours(x int, y int, z int) {
+	m.enqueue(x + 1, y, z)
+	m.enqueue(x - 1, y, z)
+	m.enqueue(x, y, z + 1)
+	m.enqueue(x, y, z - 1)
+	m.enqueue(x, y + 1, z)
+	m.enqueue(x, y - 1, z)
+}
+
+fn (mut m LiquidManager) set_water(w WaterState, x int, y int, z int) {
+	m.host.set_block_id(w.network_id(), x, y, z)
+}
+
+fn (mut m LiquidManager) set_air(x int, y int, z int) {
+	m.host.set_block_id(m.air_id, x, y, z)
+	m.enqueue_neighbours(x, y, z)
+}

--- a/server/liquid/manager.v
+++ b/server/liquid/manager.v
@@ -198,8 +198,12 @@ fn (mut m LiquidManager) flow_into(w WaterState, x int, y int, z int) {
 		return
 	}
 	if existing := m.water_at(x, y, z) {
-		// Don't overwrite an equal-or-fuller cell, and never demote a source.
+		// Don't overwrite an equal or fuller cell and never demote a source or
+		// a falling column
 		if existing.is_source() {
+			return
+		}
+		if existing.falling && !w.falling {
 			return
 		}
 		if !w.falling && existing.depth >= w.depth && !existing.falling {

--- a/server/liquid/manager_test.v
+++ b/server/liquid/manager_test.v
@@ -143,3 +143,15 @@ fn test_per_tick_cap_is_respected() {
 	// A tick drains at most the cap; the extras stay queued for next tick.
 	assert m.pending_count() >= 50
 }
+
+fn test_falling_column_survives_weaker_horizontal_spread() {
+	mut wld := &FakeWorld{}
+	mut m := new_manager(wld)
+	m.set_water(new_falling(), 0, 0, 0)
+
+	m.flow_into(new_flowing(3), 0, 0, 0)
+
+	after := m.water_at(0, 0, 0) or { panic('expected water') }
+	assert after.falling
+	assert after.depth == source_depth
+}

--- a/server/liquid/manager_test.v
+++ b/server/liquid/manager_test.v
@@ -1,0 +1,145 @@
+module liquid
+
+import server.world
+
+// FakeWorld is an in-memory block grid standing in for Hub. Any coordinate not
+// written reads as air, and set_block_id overwrites in place - enough to drive
+// and assert the spread engine without a real world.
+struct FakeWorld {
+mut:
+	blocks map[string]int
+}
+
+fn (mut w FakeWorld) get_block(x int, y int, z int) int {
+	return w.blocks[key(x, y, z)] or { world.air.network_id }
+}
+
+fn (mut w FakeWorld) set_block_id(id int, x int, y int, z int) {
+	w.blocks[key(x, y, z)] = id
+}
+
+fn (mut w FakeWorld) set_solid(x int, y int, z int) {
+	w.blocks[key(x, y, z)] = world.stone.network_id
+}
+
+// run_ticks drains the manager for up to n ticks or until nothing is pending.
+fn run_ticks(mut m LiquidManager, n int) {
+	for _ in 0 .. n {
+		if m.pending_count() == 0 {
+			break
+		}
+		m.tick()
+	}
+}
+
+// water_depth returns the internal depth at a cell, or 0 if it isn't water.
+fn depth_at(mut m LiquidManager, x int, y int, z int) int {
+	w := m.water_at(x, y, z) or { return 0 }
+	return w.depth
+}
+
+fn test_source_spreads_to_horizontal_neighbours() {
+	mut wld := &FakeWorld{}
+	// Solid floor under the source and its ring so water rests and spreads out.
+	for dx in -8 .. 9 {
+		for dz in -8 .. 9 {
+			wld.set_solid(dx, -1, dz)
+		}
+	}
+	mut m := new_manager(wld)
+	m.place_source(0, 0, 0)
+	run_ticks(mut m, 20)
+
+	assert m.is_water(0, 0, 0)
+	assert m.is_water(1, 0, 0)
+	assert m.is_water(-1, 0, 0)
+	assert m.is_water(0, 0, 1)
+	assert m.is_water(0, 0, -1)
+}
+
+fn test_flowing_depth_decays_with_distance() {
+	mut wld := &FakeWorld{}
+	for dx in -8 .. 9 {
+		for dz in -8 .. 9 {
+			wld.set_solid(dx, -1, dz)
+		}
+	}
+	mut m := new_manager(wld)
+	m.place_source(0, 0, 0)
+	run_ticks(mut m, 30)
+
+	// Source is full (8), each horizontal step loses one level.
+	assert depth_at(mut m, 0, 0, 0) == source_depth
+	d1 := depth_at(mut m, 1, 0, 0)
+	d2 := depth_at(mut m, 2, 0, 0)
+	assert d1 == source_depth - spread_decay
+	assert d2 == d1 - spread_decay
+	assert d2 < d1
+}
+
+fn test_water_flows_down() {
+	mut wld := &FakeWorld{}
+	// No floor: water should fall straight down as a falling column.
+	mut m := new_manager(wld)
+	m.place_source(0, 5, 0)
+	run_ticks(mut m, 20)
+
+	assert m.is_water(0, 4, 0)
+	assert m.is_water(0, 3, 0)
+	below := m.water_at(0, 4, 0) or { WaterState{} }
+	assert below.falling
+}
+
+fn test_flowing_dries_up_when_source_removed() {
+	mut wld := &FakeWorld{}
+	for dx in -8 .. 9 {
+		for dz in -8 .. 9 {
+			wld.set_solid(dx, -1, dz)
+		}
+	}
+	mut m := new_manager(wld)
+	m.place_source(0, 0, 0)
+	run_ticks(mut m, 30)
+	assert m.is_water(1, 0, 0)
+
+	// Remove the source and re-notify the region.
+	wld.set_block_id(world.air.network_id, 0, 0, 0)
+	m.on_block_changed(0, 0, 0)
+	run_ticks(mut m, 60)
+
+	assert !m.is_water(1, 0, 0)
+	assert !m.is_water(2, 0, 0)
+	assert !m.is_water(0, 0, 0)
+}
+
+fn test_two_sources_form_new_source() {
+	mut wld := &FakeWorld{}
+	for dx in -4 .. 5 {
+		for dz in -4 .. 5 {
+			wld.set_solid(dx, -1, dz)
+		}
+	}
+	mut m := new_manager(wld)
+	// Two sources one cell apart. The gap between them is fed from both sides by
+	// full-depth flow, so it should promote to a source.
+	m.place_source(0, 0, 0)
+	m.place_source(2, 0, 0)
+	run_ticks(mut m, 40)
+
+	mid := m.water_at(1, 0, 0) or { WaterState{} }
+	assert mid.is_source()
+}
+
+fn test_per_tick_cap_is_respected() {
+	mut wld := &FakeWorld{}
+	mut m := new_manager(wld)
+	// Queue more cells than the cap and confirm one tick leaves a remainder.
+	for i in 0 .. max_cells_per_tick + 50 {
+		m.enqueue(i, 0, 0)
+	}
+	before := m.pending_count()
+	m.tick()
+	assert before == max_cells_per_tick + 50
+	// A tick drains at most the cap; the extras stay queued for next tick.
+	assert m.pending_count() >= 50
+}

--- a/server/liquid/water.v
+++ b/server/liquid/water.v
@@ -1,0 +1,77 @@
+module liquid
+
+import server.world
+
+// Water depth model, adapted from dragonfly and PocketMine.
+//
+// depth runs 1..8 internally: 8 is a source, 1..7 are flowing levels where a
+// higher number is a fuller (taller) cell, and a falling cell behaves like a
+// full column. Each horizontal step loses spread_decay levels, so a source
+// reaches at most 7 cells away before the flow is exhausted.
+//
+// Bedrock encodes this in the liquid_depth block state as liquid_depth = 8 -
+// depth, with +8 added when the cell is falling. A source is minecraft:water
+// (still); anything flowing is minecraft:flowing_water.
+pub const source_depth = 8
+pub const max_flow_depth = 7
+pub const spread_decay = 1
+pub const min_adjacent_sources = 2
+
+// WaterState is a resolved water cell: its internal depth and whether it is
+// falling. It knows how to encode itself into a Bedrock network id.
+pub struct WaterState {
+pub:
+	depth   int
+	falling bool
+}
+
+// is_source reports whether this cell is a full still source.
+pub fn (w WaterState) is_source() bool {
+	return w.depth == source_depth && !w.falling
+}
+
+// liquid_depth_value returns the Bedrock liquid_depth state value for this cell.
+fn (w WaterState) liquid_depth_value() int {
+	mut v := source_depth - w.depth
+	if w.falling {
+		v += 8
+	}
+	return v
+}
+
+// network_id resolves this water cell to its Bedrock runtime id. Source cells
+// use minecraft:water, flowing/falling cells use minecraft:flowing_water.
+pub fn (w WaterState) network_id() int {
+	name := if w.is_source() { 'minecraft:water' } else { 'minecraft:flowing_water' }
+	return world.new_block_with_states(name, [
+		world.BlockState{
+			key:       'liquid_depth'
+			kind:      world.state_kind_int
+			int_value: w.liquid_depth_value()
+		},
+	]).network_id
+}
+
+// new_source is the full still water source.
+pub fn new_source() WaterState {
+	return WaterState{
+		depth:   source_depth
+		falling: false
+	}
+}
+
+// new_flowing builds a flowing cell at the given depth.
+pub fn new_flowing(depth int) WaterState {
+	return WaterState{
+		depth:   depth
+		falling: false
+	}
+}
+
+// new_falling is a falling column - it appears full but spreads like flowing.
+pub fn new_falling() WaterState {
+	return WaterState{
+		depth:   source_depth
+		falling: true
+	}
+}

--- a/server/permission/config.v
+++ b/server/permission/config.v
@@ -57,7 +57,7 @@ fn parse_default_value(s string) ?DefaultValue {
 fn write_default_permissions_config(path string) ! {
 	mut lines := []string{}
 	lines << '# Vedrock permissions configuration'
-	lines << "# Override the default access level for any permission node below."
+	lines << '# Override the default access level for any permission node below.'
 	lines << '# Edit it and restart to change who can use a command.'
 	lines << '# Values: granted (everyone) | denied (nobody, unless granted per-player in-game) | op (operators only) | not_op (everyone except operators)'
 	lines << ''

--- a/server/permission/permission.v
+++ b/server/permission/permission.v
@@ -40,6 +40,7 @@ pub const command_give = 'vedrock.cmd.give'
 pub const command_difficulty = 'vedrock.cmd.difficulty'
 pub const command_say = 'vedrock.cmd.say'
 pub const command_title = 'vedrock.cmd.title'
+pub const command_world = 'vedrock.cmd.world'
 
 // Registry is a mutable set of known permissions. The shared `registry`
 // below is the one every Permissible checks against; register() may be
@@ -106,7 +107,7 @@ fn new_registry() &Registry {
 	})
 	r.register(Permission{
 		name:        command_clear_self
-		description: "Allows clearing your own inventory"
+		description: 'Allows clearing your own inventory'
 		default:     .op
 	})
 	r.register(Permission{
@@ -132,6 +133,11 @@ fn new_registry() &Registry {
 	r.register(Permission{
 		name:        command_title
 		description: 'Allows sending titles to players'
+		default:     .op
+	})
+	r.register(Permission{
+		name:        command_world
+		description: 'Allows managing worlds (list/info/create/delete/tp)'
 		default:     .op
 	})
 	return r

--- a/server/player/playerdb/player.v
+++ b/server/player/playerdb/player.v
@@ -22,8 +22,28 @@ pub mut:
 	items    []InvItem
 }
 
+// safe_key strips anything that could let a key (which may come from an
+// unauthenticated display name) escape dir - path separators, drive colons and
+// parent-dir dots. The result is always a plain file stem inside dir.
+fn safe_key(key string) string {
+	mut out := []u8{cap: key.len}
+	for c in key.bytes() {
+		if c == `/` || c == `\\` || c == `:` || c == 0 {
+			out << `_`
+		} else {
+			out << c
+		}
+	}
+	mut cleaned := out.bytestr().replace('..', '_')
+	cleaned = cleaned.trim_left('.')
+	if cleaned == '' {
+		return 'unknown'
+	}
+	return cleaned
+}
+
 fn player_path(dir string, key string) string {
-	return os.join_path(dir, '${key}.json')
+	return os.join_path(dir, '${safe_key(key)}.json')
 }
 
 pub fn load_player(dir string, key string) ?PlayerData {
@@ -35,7 +55,19 @@ pub fn load_player(dir string, key string) ?PlayerData {
 	return json.decode(PlayerData, text) or { return none }
 }
 
+// save_player writes player data atomically - the JSON goes to a temp file
+// first, then a rename swaps it over the target. A crash mid-write can only
+// ever leave a stale but valid save behind, never a truncated one.
 pub fn save_player(dir string, key string, data PlayerData) ! {
 	os.mkdir_all(dir)!
-	os.write_file(player_path(dir, key), json.encode(data))!
+	path := player_path(dir, key)
+	tmp := '${path}.tmp.${os.getpid()}'
+	os.write_file(tmp, json.encode(data)) or {
+		os.rm(tmp) or {}
+		return err
+	}
+	os.rename(tmp, path) or {
+		os.rm(tmp) or {}
+		return err
+	}
 }

--- a/server/player/playerdb/player_test.v
+++ b/server/player/playerdb/player_test.v
@@ -1,0 +1,70 @@
+module playerdb
+
+import os
+
+fn test_save_then_load_roundtrip() {
+	dir := os.join_path(os.vtmp_dir(), 'vedrock_playerdb_${os.getpid()}')
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	data := PlayerData{
+		x:        1.5
+		y:        64.0
+		z:        -3.25
+		gamemode: 1
+		items:    [InvItem{
+			id:    5
+			count: 12
+		}]
+	}
+	save_player(dir, 'abc', data) or {
+		assert false, 'save failed: ${err}'
+		return
+	}
+	loaded := load_player(dir, 'abc') or {
+		assert false, 'load returned none'
+		return
+	}
+	assert loaded.x == 1.5
+	assert loaded.y == 64.0
+	assert loaded.items.len == 1
+	assert loaded.items[0].id == 5
+}
+
+fn test_save_leaves_no_temp_file() {
+	dir := os.join_path(os.vtmp_dir(), 'vedrock_playerdb_tmp_${os.getpid()}')
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	save_player(dir, 'key', PlayerData{}) or {
+		assert false, 'save failed: ${err}'
+		return
+	}
+	entries := os.ls(dir) or {
+		assert false, 'ls failed'
+		return
+	}
+	for e in entries {
+		assert !e.contains('.tmp.'), 'temp file left behind: ${e}'
+	}
+	assert os.exists(os.join_path(dir, 'key.json'))
+}
+
+fn test_safe_key_blocks_path_traversal() {
+	// A malicious display name must never escape the players dir - the result
+	// carries no separator, parent-dir sequence, or drive colon.
+	for evil in ['../../ops', 'a/b/c', 'C:\\evil', '..\\..\\x', '/etc/passwd'] {
+		k := safe_key(evil)
+		assert !k.contains('/')
+		assert !k.contains('\\')
+		assert !k.contains('..')
+		assert !k.contains(':')
+		assert k != ''
+	}
+	// Normal keys pass through unchanged.
+	assert safe_key('Steve') == 'Steve'
+	assert safe_key('2535412345678901') == '2535412345678901'
+	// Empty / dot-only degrade to a non-empty safe stem.
+	assert safe_key('') == 'unknown'
+	assert safe_key('...') != ''
+}

--- a/server/plugin/api.v
+++ b/server/plugin/api.v
@@ -1,0 +1,69 @@
+module plugin
+
+import server.cmd
+import server.event
+import server.scheduler
+import server.arena
+import server.internal.logger
+
+// ServerView is the narrow slice of the running server a plugin is allowed to
+// poke. Hub satisfies it structurally, so the plugin package never imports the
+// session package and no import cycle forms.
+pub interface ServerView {
+mut:
+	broadcast_message(text string)
+	online_count() int
+	player_names() []string
+	// spawn_entity spawns a registered entity type by name at a position,
+	// returning false if the type is unknown.
+	spawn_entity(name string, x f32, y f32, z f32) bool
+	entity_type_names() []string
+	// set_block sets a block by namespaced id in the default world and broadcasts
+	// the change, returning false if the block name is unknown.
+	set_block(name string, x int, y int, z int) bool
+	// get_block returns the block network id at a position in the default world.
+	get_block(x int, y int, z int) int
+	// place_water sets a water source at the position and starts it spreading.
+	place_water(x int, y int, z int)
+	// capture_area snapshots the block ids over the box between the two corners,
+	// or none if the region is too large. Restore it with restore_area.
+	capture_area(x1 int, y1 int, z1 int, x2 int, y2 int, z2 int) ?&arena.Snapshot
+	// restore_area writes a snapshot back so viewers see the arena reset.
+	restore_area(snapshot &arena.Snapshot)
+}
+
+// Api is the single handle handed to a plugin on enable. Everything a plugin can
+// do to the server goes through here: register commands, register event
+// listeners, reach the ServerView, or log.
+@[heap]
+pub struct Api {
+mut:
+	commands  &cmd.Registry        = unsafe { nil }
+	events    &event.Bus           = unsafe { nil }
+	scheduler &scheduler.Scheduler = unsafe { nil }
+pub mut:
+	server ServerView
+	log    &logger.Logger = unsafe { nil }
+}
+
+// register_command adds a command to the shared registry, exactly like a
+// built-in command.
+pub fn (mut a Api) register_command(c cmd.Command) {
+	a.commands.register(c)
+}
+
+// register_listener subscribes a Handler to the event Bus at the given
+// priority.
+pub fn (mut a Api) register_listener(h event.Handler, priority event.Priority) {
+	a.events.register(h, priority)
+}
+
+// run_delayed schedules task to run once after delay server ticks (20 ticks = 1s).
+pub fn (mut a Api) run_delayed(task scheduler.Task, delay i64) &scheduler.TaskHandler {
+	return a.scheduler.run_delayed(task, delay)
+}
+
+// run_repeating schedules task to run every period ticks.
+pub fn (mut a Api) run_repeating(task scheduler.Task, period i64) &scheduler.TaskHandler {
+	return a.scheduler.run_repeating(task, period)
+}

--- a/server/plugin/manager.v
+++ b/server/plugin/manager.v
@@ -1,0 +1,65 @@
+module plugin
+
+import server.cmd
+import server.event
+import server.scheduler
+import server.internal.logger
+
+// Manager owns the plugin lifecycle: register plugins at boot, enable them all
+// once the server is wired, disable them all on shutdown. Loosely mirrors
+// PocketMine's PluginManager, minus the disk loading a compiled server can't do.
+@[heap]
+pub struct Manager {
+mut:
+	plugins []Plugin
+	api     &Api           = unsafe { nil }
+	log     &logger.Logger = unsafe { nil }
+}
+
+// new_manager builds a Manager sharing the server's command registry, event bus
+// and a ServerView. Plugins registered later enable against this same Api.
+pub fn new_manager(commands &cmd.Registry, events &event.Bus, sched &scheduler.Scheduler, server ServerView, log &logger.Logger) &Manager {
+	return &Manager{
+		api: &Api{
+			commands:  commands
+			events:    events
+			scheduler: sched
+			server:    server
+			log:       log
+		}
+		log: log
+	}
+}
+
+// register queues a plugin. It is not enabled until enable_all runs.
+pub fn (mut m Manager) register(p Plugin) {
+	m.plugins << p
+}
+
+// count reports how many plugins are registered.
+pub fn (m &Manager) count() int {
+	return m.plugins.len
+}
+
+// enable_all enables every registered plugin in registration order, giving each
+// a logger scoped to its name.
+pub fn (mut m Manager) enable_all() {
+	for mut p in m.plugins {
+		info := p.meta()
+		m.api.log = m.log.with_prefix(info.name)
+		p.set_log(m.api.log)
+		m.log.info('Enabling ${info.name} v${info.version}')
+		p.on_enable(mut m.api)
+	}
+	m.log.info('${m.plugins.len} plugin(s) enabled, ${m.api.events.len()} listener(s) registered')
+}
+
+// disable_all disables every plugin in reverse order so later plugins tear down
+// before the ones they may depend on.
+pub fn (mut m Manager) disable_all() {
+	for i := m.plugins.len - 1; i >= 0; i-- {
+		mut p := m.plugins[i]
+		p.on_disable()
+		m.log.info('Disabled ${p.meta().name}')
+	}
+}

--- a/server/plugin/manager_test.v
+++ b/server/plugin/manager_test.v
@@ -1,0 +1,75 @@
+module plugin
+
+import server.cmd
+import server.event
+import server.scheduler
+import server.arena
+import server.internal.logger
+
+struct FakeView {}
+
+fn (mut v FakeView) broadcast_message(text string) {}
+
+fn (mut v FakeView) online_count() int {
+	return 0
+}
+
+fn (mut v FakeView) player_names() []string {
+	return []
+}
+
+fn (mut v FakeView) spawn_entity(name string, x f32, y f32, z f32) bool {
+	return false
+}
+
+fn (mut v FakeView) entity_type_names() []string {
+	return []
+}
+
+fn (mut v FakeView) set_block(name string, x int, y int, z int) bool {
+	return false
+}
+
+fn (mut v FakeView) get_block(x int, y int, z int) int {
+	return 0
+}
+
+fn (mut v FakeView) place_water(x int, y int, z int) {}
+
+fn (mut v FakeView) capture_area(x1 int, y1 int, z1 int, x2 int, y2 int, z2 int) ?&arena.Snapshot {
+	return none
+}
+
+fn (mut v FakeView) restore_area(snapshot &arena.Snapshot) {}
+
+struct LoggingPlugin {
+	Base
+mut:
+	enabled bool
+}
+
+fn (p &LoggingPlugin) meta() Meta {
+	return Meta{
+		name:    'Logging'
+		version: '1.0.0'
+	}
+}
+
+fn (mut p LoggingPlugin) on_enable(mut api Api) {
+	p.log.info('enabled via embedded Base.log')
+	p.enabled = true
+}
+
+fn (mut p LoggingPlugin) on_disable() {}
+
+fn test_enable_all_wires_embedded_base_log_before_on_enable() {
+	commands := &cmd.Registry{}
+	events := &event.Bus{}
+	sched := &scheduler.Scheduler{}
+	log := logger.new(.info)
+	mut m := new_manager(commands, events, sched, &FakeView{}, log)
+	mut p := &LoggingPlugin{}
+	m.register(p)
+	m.enable_all()
+	assert p.enabled
+}

--- a/server/plugin/plugin.v
+++ b/server/plugin/plugin.v
@@ -1,0 +1,37 @@
+module plugin
+
+import server.internal.logger
+
+// Meta is the static identity of a plugin. Inspired by PocketMine's
+// PluginDescription but kept to what a compiled, in-tree plugin needs.
+pub struct Meta {
+pub:
+	name    string
+	version string
+	authors []string
+}
+
+// Plugin is implemented by every plugin. on_enable runs once at
+// startup with an Api handle for registering commands and listeners;
+// on_disable runs at shutdown so a plugin can flush state.
+pub interface Plugin {
+	meta() Meta
+mut:
+	set_log(l &logger.Logger)
+	on_enable(mut api Api)
+	on_disable()
+}
+
+// Base is an embeddable helper carrying a scoped logger. A plugin embeds it,
+// keeps its own Meta, and gets log for free. Manager calls set_log before
+// on_enable, so log is never the zero value nil by the time a plugin can
+// observe it. It does not implement the rest of the Plugin interface itself -
+// the concrete plugin still defines meta/on_enable/on_disable.
+pub struct Base {
+pub mut:
+	log &logger.Logger = unsafe { nil }
+}
+
+pub fn (mut b Base) set_log(l &logger.Logger) {
+	b.log = l
+}

--- a/server/plugin/sample/greeter.v
+++ b/server/plugin/sample/greeter.v
@@ -1,0 +1,164 @@
+module sample
+
+import server.cmd
+import server.event
+import server.plugin
+import server.scheduler
+
+// GreeterPlugin is a worked example of the plugin API: it registers a command,
+// an event listener and a repeating scheduled task on enable. Use it as a
+// template for real plugins.
+pub struct GreeterPlugin {
+	plugin.Base
+mut:
+	heartbeat_task &scheduler.TaskHandler = unsafe { nil }
+}
+
+pub fn (p &GreeterPlugin) meta() plugin.Meta {
+	return plugin.Meta{
+		name:    'Greeter'
+		version: '1.0.0'
+		authors: ['Vedrock']
+	}
+}
+
+pub fn (mut p GreeterPlugin) on_enable(mut api plugin.Api) {
+	api.register_command(HelloCommand{})
+	api.register_command(SummonCommand{
+		server: api.server
+	})
+	api.register_listener(&GreeterListener{
+		server: api.server
+	}, event.Priority.normal)
+
+	log := api.log
+	server := api.server
+	// One-shot 5s after boot.
+	api.run_delayed(scheduler.new_closure_task(fn [log] () {
+		log.info('Greeter warmed up')
+	}), 100)
+	// Every 60s: report how many players are online.
+	p.heartbeat_task = api.run_repeating(scheduler.new_closure_task(fn [log, server] () {
+		mut s := server
+		log.info('${s.online_count()} player(s) online')
+	}), 1200)
+}
+
+pub fn (mut p GreeterPlugin) on_disable() {
+	if p.heartbeat_task != unsafe { nil } {
+		p.heartbeat_task.cancel()
+	}
+}
+
+// GreeterListener embeds NopHandler so it only has to define the events it uses.
+struct GreeterListener {
+	event.NopHandler
+mut:
+	server plugin.ServerView
+}
+
+// on_player_join replaces the default join line with a custom welcome.
+pub fn (mut l GreeterListener) on_player_join(mut ctx event.Context[event.JoinData]) {
+	ctx.val.message = '§a[+] §f${ctx.val.player.name()} §7joined - welcome!'
+}
+
+// on_player_chat blocks messages containing a banned word, showing the cancel
+// path, and otherwise tags the message with the online count.
+pub fn (mut l GreeterListener) on_player_chat(mut ctx event.Context[event.ChatData]) {
+	if ctx.val.message.contains('badword') {
+		ctx.val.player.send_message('§cThat word is not allowed here.') or {}
+		ctx.cancel()
+		return
+	}
+	ctx.val.message = '§7[${l.server.online_count()}]§r ${ctx.val.message}'
+}
+
+// on_block_break protects the spawn area (a 16x16 column around origin) from
+// being mined - a typical minigame lobby guard.
+pub fn (mut l GreeterListener) on_block_break(mut ctx event.Context[event.BlockBreakData]) {
+	if ctx.val.x >= -8 && ctx.val.x <= 8 && ctx.val.z >= -8 && ctx.val.z <= 8 {
+		ctx.val.player.send_message('§cYou cannot break blocks in spawn.') or {}
+		ctx.cancel()
+	}
+}
+
+// on_player_death rewrites the death broadcast with a custom format.
+pub fn (mut l GreeterListener) on_player_death(mut ctx event.Context[event.DeathData]) {
+	l.server.broadcast_message('§7[§c☠§7] §f${ctx.val.player.name()} §7died.')
+	ctx.cancel() // suppress the default vanilla death message
+}
+
+// HelloCommand is a trivial command registered by the plugin.
+struct HelloCommand {}
+
+pub fn (c HelloCommand) name() string {
+	return 'hello'
+}
+
+pub fn (c HelloCommand) description() string {
+	return 'Greet the sender - added by the Greeter plugin'
+}
+
+pub fn (c HelloCommand) aliases() []string {
+	return ['hi']
+}
+
+pub fn (c HelloCommand) permission() string {
+	return ''
+}
+
+pub fn (c HelloCommand) arguments() []cmd.Argument {
+	return []
+}
+
+pub fn (c HelloCommand) execute(mut sender cmd.Sender, ctx cmd.Context) ! {
+	sender.send_message('§bHello, ${sender.name()}! §7(from the Greeter plugin)')!
+}
+
+// SummonCommand spawns an entity by type name at the sender's position, using
+// the entity system through the plugin ServerView.
+struct SummonCommand {
+mut:
+	server plugin.ServerView
+}
+
+pub fn (c SummonCommand) name() string {
+	return 'summon'
+}
+
+pub fn (c SummonCommand) description() string {
+	return 'Spawn an entity at your position - added by the Greeter plugin'
+}
+
+pub fn (c SummonCommand) aliases() []string {
+	return []
+}
+
+pub fn (c SummonCommand) permission() string {
+	return ''
+}
+
+pub fn (c SummonCommand) arguments() []cmd.Argument {
+	return [
+		cmd.StringArgument{
+			arg_name: 'type'
+		},
+	]
+}
+
+pub fn (c SummonCommand) execute(mut sender cmd.Sender, ctx cmd.Context) ! {
+	if !sender.is_player() {
+		sender.send_message('§cOnly players can summon entities.')!
+		return
+	}
+	// ServerView's methods are mut; copy the interface value to a mut local so
+	// the call lands on the underlying server.
+	mut server := c.server
+	kind := ctx.args[0]
+	x, y, z := sender.position()
+	if server.spawn_entity(kind, x, y, z) {
+		sender.send_message('§aSummoned §f${kind}§a.')!
+	} else {
+		sender.send_message('§cUnknown entity type "${kind}". Available: ${server.entity_type_names().join(', ')}')!
+	}
+}

--- a/server/resource/pack.v
+++ b/server/resource/pack.v
@@ -16,11 +16,11 @@ pub const pack_type_resources = 6
 @[heap]
 pub struct ResourcePack {
 pub:
-	uuid       string
-	version    string
-	size       u64
-	sha256     string
-	cdn_url    string
+	uuid    string
+	version string
+	size    u64
+	sha256  string
+	cdn_url string
 mut:
 	uuid_raw []u8
 	data     []u8
@@ -161,7 +161,7 @@ fn uuid_to_bytes(uuid string) ?[]u8 {
 	for i in 0 .. 16 {
 		high := hex_val(hex[i * 2]) or { return none }
 		low := hex_val(hex[i * 2 + 1]) or { return none }
-		out[i] = u8(high << 4 | low)
+		out[i] = (u8(high) << 4) | u8(low)
 	}
 	return out
 }

--- a/server/server.v
+++ b/server/server.v
@@ -15,15 +15,23 @@ import server.internal.gamedata
 import server.world.db
 import server.resource
 import server.permission
+import server.plugin
+import server.plugin.sample
+import server.crash
 import sync.stdatomic
 
 pub const ticks_per_second = 20
 pub const day_length_ticks = 24000
 pub const worlds_dir = 'worlds'
+pub const crashdumps_dir = 'crashdumps'
+// tick_overrun_log_interval throttles the "tick over budget" warning so a slow
+// stretch logs once per this many ticks instead of spamming every tick.
+const tick_overrun_log_interval = u64(ticks_per_second) * 5
 
 // load_worlds always loads the configured default world, plus every other
 // world found under worlds/ when load-all-worlds is enabled.
 fn load_worlds(mut hub session.Hub, cfg conf.Config, log &logger.Logger) {
+	hub.set_world_config(worlds_dir, cfg.generator)
 	mut names := [cfg.default_world]
 	if cfg.load_all_worlds {
 		for name in db.discover_worlds(worlds_dir) {
@@ -53,8 +61,12 @@ mut:
 	listener &raknet.Listener = unsafe { nil }
 	hub      &session.Hub     = unsafe { nil }
 	guid     i64
-	running    &stdatomic.AtomicVal[bool] = stdatomic.new_atomic[bool](false)
-	created_at time.Time
+	plugins  &plugin.Manager            = unsafe { nil }
+	running  &stdatomic.AtomicVal[bool] = stdatomic.new_atomic[bool](false)
+	// active_conns bounds concurrent connection handlers so a flood of
+	// half-open/pre-login peers can't exhaust threads and CPU.
+	active_conns &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](0)
+	created_at   time.Time
 pub mut:
 	log  &logger.Logger
 	lang &language.Lang
@@ -99,6 +111,11 @@ pub fn new(cfg conf.Config) &Server {
 		log.warn('Failed to load language "${cfg.language}", falling back to en: ${err}')
 		language.load('en') or {
 			log.error('Failed to load fallback language: ${err}')
+			if path := crash.write_dump(crashdumps_dir, time.now().unix(), 'fatal: language load failed',
+				err.msg())
+			{
+				log.error('Wrote crash report to ${path}')
+			}
 			panic(err)
 		}
 	}
@@ -131,14 +148,24 @@ pub fn new(cfg conf.Config) &Server {
 	}
 	load_worlds(mut hub, cfg, log)
 	hub.packs = load_resource_packs(cfg, log)
+	mut plugins := plugin.new_manager(&hub.commands, hub.events, hub.scheduler, hub, log)
+	register_plugins(mut plugins)
+	plugins.enable_all()
 	return &Server{
 		log:        log
 		lang:       lang
 		cfg:        cfg
 		hub:        hub
+		plugins:    plugins
 		guid:       rand.i64()
 		created_at: boot_start
 	}
+}
+
+// register_plugins is the single place built-in plugins are wired in. Add a
+// plugins.register(...) line here for every plugin that ships with the server.
+fn register_plugins(mut plugins plugin.Manager) {
+	plugins.register(&sample.GreeterPlugin{})
 }
 
 pub fn (mut s Server) start() ! {
@@ -206,6 +233,7 @@ fn (mut s Server) tick_loop() {
 	// the 19 out of 20 ticks that don't recompute the window.
 	mut tps := f64(ticks_per_second)
 	mut load := f64(0)
+	mut last_overrun_log := u64(0)
 	for s.running.load() {
 		tick_start := time.now()
 		tick++
@@ -218,6 +246,11 @@ fn (mut s Server) tick_loop() {
 				s.log.warn('Failed to update pong data: ${err}')
 			}
 		}
+		// TODO(persistence): a periodic world flush (e.g. every N seconds via
+		// World.flush) would bound crash data loss between shutdowns, but it needs
+		// a hub method to walk loaded worlds. World.flush/WorldStore.flush already
+		// exist - wire the driver in once hub.v exposes an iterator. Shutdown flush
+		// is already durable: stop() closes worlds after disconnect_all.
 		work := time.now() - tick_start
 		window_ticks++
 		window_work += work.nanoseconds()
@@ -233,6 +266,7 @@ fn (mut s Server) tick_loop() {
 		// world_time/tps/load are Hub's, not tick_loop's own. This is the
 		// only place that writes them via the actor.
 		s.hub.submit(session.TickJob{
+			tick:       i64(tick)
 			world_time: world_time
 			tps:        tps
 			load:       load
@@ -241,22 +275,53 @@ fn (mut s Server) tick_loop() {
 		sleep_for := deadline - time.now()
 		if sleep_for > 0 {
 			time.sleep(sleep_for)
+		} else {
+			// The tick ran past its 50ms slot. We don't sleep, so the loop
+			// catches up on the next iterations. The deadline is anchored to
+			// loop_start, so a burst of slow ticks can't compound into runaway
+			// drift - once work speeds up, sleep_for goes positive again and the
+			// cadence self-corrects. Warn (throttled) so operators see the stall.
+			if tick - last_overrun_log >= tick_overrun_log_interval {
+				over := -sleep_for
+				s.log.warn('Tick ${tick} over budget by ${over.milliseconds()}ms (tps=${tps:.1f}, load=${load:.0f}%)')
+				last_overrun_log = tick
+			}
 		}
 	}
 }
 
+// max_concurrent_connections caps how many connection handlers run at once.
+const max_concurrent_connections = u64(1024)
+
 fn (mut s Server) accept_loop() {
 	for s.running.load() {
 		mut conn := s.listener.accept_timeout(time.second) or { continue }
+		if s.active_conns.load() >= max_concurrent_connections {
+			s.log.warn('Rejecting connection from ${conn.remote_addr()} - at capacity (${max_concurrent_connections})')
+			conn.close() or {}
+			continue
+		}
+		s.active_conns.add(1)
 		s.log.info('Incoming connection from ${conn.remote_addr()}')
 		spawn s.handle(mut conn)
 	}
 }
 
+// handle runs one connection on its own spawned thread. It is the isolation
+// boundary for a single client: every error path inside handle_loop ends in a
+// disconnect for that session only, and nothing here propagates back out of the
+// thread, so one misbehaving connection can never take the server down. The
+// remote address is captured up front so a failure setting up the session still
+// has something to log against.
 fn (mut s Server) handle(mut conn raknet.Conn) {
+	defer {
+		s.active_conns.sub(1)
+	}
+	addr := conn.remote_addr()
 	mut transport := network.new_session(mut conn, s.log)
 	mut net_session := session.new(mut transport, mut s.hub, s.cfg, s.log)
 	net_session.handle_loop()
+	s.log.debug('Connection handler for ${addr} finished')
 }
 
 fn (s &Server) pong_data(online int) string {
@@ -283,6 +348,9 @@ pub fn (mut s Server) stop() {
 	}
 	s.log.info('Stopping server')
 	s.running.store(false)
+	if s.plugins != unsafe { nil } {
+		s.plugins.disable_all()
+	}
 	if s.hub != unsafe { nil } {
 		s.hub.disconnect_all('Server closed')
 		s.hub.close_worlds()

--- a/server/session/blocks.v
+++ b/server/session/blocks.v
@@ -4,6 +4,7 @@ import time
 import protocol
 import protocol.types
 import protocol.enums
+import server.event
 import server.world
 
 // place_cooldown_ms throttles placement to at most one accepted block per
@@ -48,7 +49,7 @@ fn (mut s NetworkSession) handle_inventory_transaction(p protocol.InventoryTrans
 	if p.transaction_type == protocol.inventory_transaction_type_use_item_on_entity {
 		ue := p.use_item_on_entity
 		if ue.action_type == protocol.item_use_on_entity_action_attack {
-			s.handle_attack(ue.target_entity_runtime_id, ue.held_item)!
+			s.handle_attack(ue.target_entity_runtime_id)!
 		}
 		return
 	}
@@ -63,6 +64,18 @@ fn (mut s NetworkSession) handle_inventory_transaction(p protocol.InventoryTrans
 				return
 			}
 			if s.dead || !s.can_interact() {
+				return
+			}
+			mut ictx := event.new_context(event.InteractData{
+				player: s
+				x:      ut.block_position.x
+				y:      ut.block_position.y
+				z:      ut.block_position.z
+				face:   int(ut.block_face)
+			})
+			s.hub.events.player_interact(mut ictx)
+			if ictx.is_cancelled() {
+				s.resend_block(ut.block_position)
 				return
 			}
 			// Neighbor cell in the clicked face direction. Used as the default
@@ -122,7 +135,8 @@ fn (mut s NetworkSession) handle_player_action(p protocol.PlayerActionPacket) ! 
 // place_reach_sq returns the squared placement reach for the player's
 // current gamemode.
 fn (s &NetworkSession) place_reach_sq() f32 {
-	if s.game_mode == protocol.game_type_creative || s.game_mode == protocol.game_type_creative_spectator {
+	if s.game_mode == protocol.game_type_creative
+		|| s.game_mode == protocol.game_type_creative_spectator {
 		return creative_place_reach_sq
 	}
 	return survival_place_reach_sq
@@ -155,12 +169,26 @@ fn (mut s NetworkSession) place_block(pos types.BlockPosition, runtime_id int) !
 		}
 		return false
 	}
+	mut ctx := event.new_context(event.BlockPlaceData{
+		player:   s
+		x:        pos.x
+		y:        pos.y
+		z:        pos.z
+		block_id: runtime_id
+	})
+	s.hub.events.block_place(mut ctx)
+	if ctx.is_cancelled() {
+		s.resend_block(pos)
+		return false
+	}
 	mut wld := s.current_world()
 	if !isnil(wld) {
 		wld.set_block(pos.x, pos.y, pos.z, runtime_id)
 	}
 	s.broadcast_block_update(pos, runtime_id)
 	s.broadcast_swing()
+	// Placing water starts a flow; a neighbour break re-triggers spread below.
+	s.hub.on_block_changed(pos.x, pos.y, pos.z)
 	return true
 }
 
@@ -197,13 +225,16 @@ fn (mut s NetworkSession) obstructed_by_entity(pos types.BlockPosition) (bool, b
 	block_max_z := f32(pos.z) + 1
 	mut obstructed := false
 	for mut target in s.hub.snapshot() {
-		feet_y := target.position.y - player_eye_height
-		min_x := target.position.x - player_half_width
-		max_x := target.position.x + player_half_width
+		// Read cross-session position under the target's pos_mutex - it is
+		// written on that session's own thread.
+		tp := target.current_position()
+		feet_y := tp.y - player_eye_height
+		min_x := tp.x - player_half_width
+		max_x := tp.x + player_half_width
 		min_y := feet_y
 		max_y := feet_y + player_height
-		min_z := target.position.z - player_half_width
-		max_z := target.position.z + player_half_width
+		min_z := tp.z - player_half_width
+		max_z := tp.z + player_half_width
 		overlaps := min_x < block_max_x && max_x > block_min_x && min_y < block_max_y
 			&& max_y > block_min_y && min_z < block_max_z && max_z > block_min_z
 		if !overlaps {
@@ -233,6 +264,18 @@ fn (mut s NetworkSession) break_block(pos types.BlockPosition) ! {
 		})!
 		return
 	}
+	mut ctx := event.new_context(event.BlockBreakData{
+		player:   s
+		x:        pos.x
+		y:        pos.y
+		z:        pos.z
+		block_id: old_id
+	})
+	s.hub.events.block_break(mut ctx)
+	if ctx.is_cancelled() {
+		s.resend_block(pos)
+		return
+	}
 	mut wld := s.current_world()
 	if !isnil(wld) {
 		wld.set_block(pos.x, pos.y, pos.z, air_id)
@@ -240,6 +283,8 @@ fn (mut s NetworkSession) break_block(pos types.BlockPosition) ! {
 	s.broadcast_block_update(pos, air_id)
 	s.broadcast_destroy_particles(pos, old_id)
 	s.broadcast_swing()
+	// A break can free a path for adjacent water to flow into.
+	s.hub.on_block_changed(pos.x, pos.y, pos.z)
 }
 
 fn (mut s NetworkSession) broadcast_destroy_particles(pos types.BlockPosition, runtime_id int) {

--- a/server/session/blocks_api.v
+++ b/server/session/blocks_api.v
@@ -1,0 +1,140 @@
+module session
+
+import protocol
+import protocol.types
+import server.world
+import server.arena
+
+// SetBlockJob is the plugin/command block write as a WorldJob. Like every other
+// cross-session mutation it runs on the actor thread, so it reuses the same
+// world+broadcast path break_block/place_block use without racing them.
+struct SetBlockJob {
+	x  int
+	y  int
+	z  int
+	id int
+}
+
+fn (j SetBlockJob) run(mut h Hub) {
+	h.write_block(j.id, j.x, j.y, j.z)
+}
+
+// write_block sets a block id in the default world and broadcasts the update to
+// every viewer. Actor-thread only - reached via SetBlockJob or restore_area,
+// both of which run on run_jobs().
+fn (mut h Hub) write_block(id int, x int, y int, z int) {
+	if mut wld := h.default_world() {
+		wld.set_block(x, y, z, id)
+	}
+	h.broadcast(&protocol.UpdateBlockPacket{
+		block_position:   types.BlockPosition{x, y, z}
+		block_runtime_id: id
+		flags:            protocol.update_block_flag_network
+		data_layer_id:    0
+	})
+}
+
+// block_id_for resolves a namespaced block name to its network id, or none if
+// the name isn't a known block. Air maps to world.air; every other name is
+// validated against the item palette (real blocks exist there as items).
+fn (h &Hub) block_id_for(name string) ?int {
+	if name == 'minecraft:air' {
+		return world.air.network_id
+	}
+	if h.data.item_id(name) == 0 {
+		return none
+	}
+	return world.new_block(name).network_id
+}
+
+// set_block sets a block by namespaced id in the default world and broadcasts
+// the change. Returns false if name isn't a known block. The name is resolved
+// synchronously; the write itself is routed through the actor thread.
+pub fn (mut h Hub) set_block(name string, x int, y int, z int) bool {
+	id := h.block_id_for(name) or { return false }
+	h.submit(SetBlockJob{
+		x:  x
+		y:  y
+		z:  z
+		id: id
+	})
+	return true
+}
+
+// get_block returns the block network id at a position in the default world,
+// preferring a saved override and otherwise falling back to the generator so
+// untouched terrain reads correctly.
+pub fn (mut h Hub) get_block(x int, y int, z int) int {
+	mut wld := h.default_world() or { return world.air.network_id }
+	if id := wld.block_override(x, y, z) {
+		return id
+	}
+	gen := wld.make_generator(world.new_generator(h.world_generator))
+	return gen.block_at(x, y, z)
+}
+
+// set_block_id writes a raw block network id, used by arena restore. It routes
+// through the same actor-thread write path as set_block.
+pub fn (mut h Hub) set_block_id(id int, x int, y int, z int) {
+	h.submit(SetBlockJob{
+		x:  x
+		y:  y
+		z:  z
+		id: id
+	})
+}
+
+// PlaceWaterJob places a water source and starts its spread on the actor thread.
+struct PlaceWaterJob {
+	x int
+	y int
+	z int
+}
+
+fn (j PlaceWaterJob) run(mut h Hub) {
+	h.liquids.place_source(j.x, j.y, j.z)
+}
+
+// place_water sets a water source at the position and enqueues the spread. The
+// write and every spread step run on the actor thread via the liquid tick.
+pub fn (mut h Hub) place_water(x int, y int, z int) {
+	h.submit(PlaceWaterJob{
+		x: x
+		y: y
+		z: z
+	})
+}
+
+// BlockChangedJob re-evaluates a cell and its neighbours for liquid flow.
+struct BlockChangedJob {
+	x int
+	y int
+	z int
+}
+
+fn (j BlockChangedJob) run(mut h Hub) {
+	h.liquids.on_block_changed(j.x, j.y, j.z)
+}
+
+// on_block_changed notifies the liquid manager that a block edit happened so
+// nearby water re-evaluates its flow. Cheap and non-blocking - dropped under a
+// full actor queue since the periodic liquid tick will catch up anyway.
+pub fn (mut h Hub) on_block_changed(x int, y int, z int) {
+	h.try_submit(BlockChangedJob{
+		x: x
+		y: y
+		z: z
+	})
+}
+
+// capture_area snapshots the block ids over the box between the two corners in
+// the default world. See arena.max_volume for the size cap.
+pub fn (mut h Hub) capture_area(x1 int, y1 int, z1 int, x2 int, y2 int, z2 int) ?&arena.Snapshot {
+	return arena.capture(mut h, arena.new_box(x1, y1, z1, x2, y2, z2)) or { return none }
+}
+
+// restore_area writes a snapshot back through the block write path so viewers
+// see the arena reset.
+pub fn (mut h Hub) restore_area(snapshot &arena.Snapshot) {
+	snapshot.restore(mut h)
+}

--- a/server/session/chat.v
+++ b/server/session/chat.v
@@ -3,6 +3,7 @@ module session
 import protocol
 import protocol.enums
 import server.cmd
+import server.event
 
 fn (mut s NetworkSession) handle_text(p protocol.TextPacket) ! {
 	if p.@type != int(enums.TextType.chat) {
@@ -16,11 +17,20 @@ fn (mut s NetworkSession) handle_text(p protocol.TextPacket) ! {
 		s.run_command(message)!
 		return
 	}
-	s.log.info('<${s.identity.display_name}> ${message}')
+	mut ctx := event.new_context(event.ChatData{
+		player:  s
+		message: message
+	})
+	s.hub.events.player_chat(mut ctx)
+	if ctx.is_cancelled() {
+		return
+	}
+	final := ctx.val.message
+	s.log.info('<${s.identity.display_name}> ${final}')
 	s.hub.broadcast(&protocol.TextPacket{
 		@type:       int(enums.TextType.chat)
 		source_name: s.identity.display_name
-		message:     message
+		message:     final
 	})
 }
 
@@ -29,7 +39,16 @@ fn (mut s NetworkSession) handle_command_request(p protocol.CommandRequestPacket
 }
 
 fn (mut s NetworkSession) run_command(line string) ! {
-	s.log.info('${s.identity.display_name} issued command: ${line}')
+	mut cctx := event.new_context(event.CommandData{
+		player:  s
+		command: line
+	})
+	s.hub.events.player_command(mut cctx)
+	if cctx.is_cancelled() {
+		return
+	}
+	final := cctx.val.command
+	s.log.info('${s.identity.display_name} issued command: ${final}')
 	ctx := cmd.Context{
 		lang:           s.hub.lang
 		sender_name:    s.identity.display_name
@@ -40,7 +59,7 @@ fn (mut s NetworkSession) run_command(line string) ! {
 		tps:            s.hub.tps()
 		load:           s.hub.load()
 	}
-	s.hub.commands.dispatch(line, mut s, ctx)!
+	s.hub.commands.dispatch(final, mut s, ctx)!
 }
 
 fn (mut s NetworkSession) send_message(message string) ! {

--- a/server/session/combat.v
+++ b/server/session/combat.v
@@ -4,6 +4,7 @@ import math
 import protocol
 import protocol.types
 import protocol.enums
+import server.event
 
 const knockback_horizontal = f32(0.4)
 const knockback_vertical = f32(0.4)
@@ -42,22 +43,51 @@ fn (j DamageJob) run(mut h Hub) {
 	}
 }
 
-fn (mut s NetworkSession) handle_attack(target_runtime_id u64, held types.ItemStackWrapper) ! {
+// max_attack_reach_sq caps how far an attack can land, measured from the
+// attacker to the victim. Bedrock melee reach is ~3 blocks; the extra padding
+// absorbs latency while still rejecting kill-aura hits from across the map.
+const max_attack_reach_sq = f32(6.0 * 6.0)
+
+fn (mut s NetworkSession) handle_attack(target_runtime_id u64) ! {
 	if s.dead || target_runtime_id == s.runtime_id {
 		return
 	}
-	mut damage := s.weapon_damage(s.hub.data.item_name(held.item_stack.id))
+	mut victim := s.hub.session_by_runtime(target_runtime_id) or { return }
+	vp := victim.current_position()
+	dx := s.position.x - vp.x
+	dy := s.position.y - vp.y
+	dz := s.position.z - vp.z
+	if dx * dx + dy * dy + dz * dz > max_attack_reach_sq {
+		return
+	}
+	// Damage comes from the server-side inventory at the held slot, never the
+	// client-supplied held item - otherwise a client could claim a weapon it
+	// does not own to inflate damage.
+	server_stack, _ := s.inventory_stack_at(s.held_slot)
+	mut damage := s.weapon_damage(s.hub.data.item_name(server_stack.id))
 	critical := s.is_critical()
 	if critical {
 		damage *= critical_multiplier
 	}
-	s.hub.submit(DamageJob{
+	mut ctx := event.new_context(event.AttackData{
+		player:            s
 		victim_runtime_id: target_runtime_id
-		amount:            damage
+		critical:          critical
+		damage:            damage
+	})
+	s.hub.events.player_attack(mut ctx)
+	if ctx.is_cancelled() {
+		return
+	}
+	if !s.hub.try_submit(DamageJob{
+		victim_runtime_id: target_runtime_id
+		amount:            ctx.val.damage
 		attacker_name:     s.identity.display_name
 		knockback_from:    s.position
 		critical:          critical
-	})
+	}) {
+		s.log.debug('Dropped attack job - actor queue full')
+	}
 }
 
 fn (s &NetworkSession) is_critical() bool {
@@ -72,7 +102,16 @@ fn (mut s NetworkSession) take_damage(amount f32, attacker_name string) {
 		|| s.game_mode == protocol.game_type_spectator {
 		return
 	}
-	s.health -= amount
+	mut ctx := event.new_context(event.HurtData{
+		player:        s
+		amount:        amount
+		attacker_name: attacker_name
+	})
+	s.hub.events.player_hurt(mut ctx)
+	if ctx.is_cancelled() {
+		return
+	}
+	s.health -= ctx.val.amount
 	if s.health < 0 {
 		s.health = 0
 	}
@@ -88,16 +127,25 @@ fn (mut s NetworkSession) take_damage(amount f32, attacker_name string) {
 }
 
 fn (mut s NetworkSession) die(message_key string, parameters []string) {
+	mut ctx := event.new_context(event.DeathData{
+		player:      s
+		message_key: message_key
+		params:      parameters
+	})
+	s.hub.events.player_death(mut ctx)
 	s.dead = true
 	s.hub.broadcast_except(s.runtime_id, &protocol.ActorEventPacket{
 		actor_runtime_id: s.runtime_id
 		event_id:         protocol.actor_event_death
 		event_data:       0
 	})
+	if ctx.is_cancelled() {
+		return
+	}
 	s.hub.broadcast(&protocol.TextPacket{
 		@type:             int(enums.TextType.translation)
 		needs_translation: true
-		message:           message_key
+		message:           ctx.val.message_key
 		parameters:        parameters
 	})
 }
@@ -116,9 +164,11 @@ fn (j RespawnJob) run(mut h Hub) {
 
 fn (mut s NetworkSession) handle_respawn(p protocol.RespawnPacket) ! {
 	if p.respawn_state == protocol.respawn_state_client_ready {
-		s.hub.submit(RespawnJob{
+		if !s.hub.try_submit(RespawnJob{
 			runtime_id: s.runtime_id
-		})
+		}) {
+			s.log.debug('Dropped respawn job - actor queue full')
+		}
 	}
 }
 
@@ -129,8 +179,15 @@ fn (mut s NetworkSession) respawn() {
 	s.dead = false
 	s.health = 20.0
 	spawn_y := s.generator.spawn_y()
+	mut ctx := event.new_context(event.RespawnData{
+		player: s
+		x:      0.0
+		y:      f32(spawn_y) + player_eye_height
+		z:      0.0
+	})
+	s.hub.events.player_respawn(mut ctx)
 	s.pos_mutex.lock()
-	s.position = types.Vector3{0.0, f32(spawn_y) + player_eye_height, 0.0}
+	s.position = types.Vector3{ctx.val.x, ctx.val.y, ctx.val.z}
 	s.prev_y = s.position.y
 	s.vy = 0.0
 	s.pos_mutex.unlock()

--- a/server/session/console.v
+++ b/server/session/console.v
@@ -69,6 +69,10 @@ pub fn (mut c ConsoleSender) position() (f32, f32, f32) {
 
 pub fn (mut c ConsoleSender) teleport(x f32, y f32, z f32) {}
 
+pub fn (mut c ConsoleSender) place_water(x int, y int, z int) {
+	c.hub.place_water(x, y, z)
+}
+
 pub fn (mut c ConsoleSender) clear_inventory() {}
 
 pub fn (mut c ConsoleSender) give_item(id string, count int) bool {
@@ -78,6 +82,12 @@ pub fn (mut c ConsoleSender) give_item(id string, count int) bool {
 pub fn (mut c ConsoleSender) send_form(f form.Form) ! {
 	return error('the console cannot display forms')
 }
+
+pub fn (mut c ConsoleSender) show_scoreboard(title string, lines []string) {
+	// The console has no client to render a scoreboard on.
+}
+
+pub fn (mut c ConsoleSender) clear_scoreboard() {}
 
 // strip_formatting removes Minecraft § formatting codes so command output
 // stays readable in a terminal.

--- a/server/session/entity_view.v
+++ b/server/session/entity_view.v
@@ -1,0 +1,22 @@
+module session
+
+import protocol
+
+// broadcast_near delivers p only to players whose position is within radius of
+// the point (x, y, z). Used by the entity Manager for view-distance culling so
+// spawn and move packets never reach players too far away to render the entity.
+// Distance is compared squared to skip the sqrt.
+pub fn (mut h Hub) broadcast_near(x f32, y f32, z f32, radius f32, p protocol.Packet) {
+	r2 := radius * radius
+	for mut target in h.snapshot() {
+		// Read the position under the target's own pos_mutex - it is written on
+		// that session's thread while we read here on the actor thread.
+		pos := target.current_position()
+		dx := pos.x - x
+		dy := pos.y - y
+		dz := pos.z - z
+		if dx * dx + dy * dy + dz * dz <= r2 {
+			target.deliver(p)
+		}
+	}
+}

--- a/server/session/gamemode.v
+++ b/server/session/gamemode.v
@@ -1,6 +1,7 @@
 module session
 
 import protocol
+import server.event
 
 fn gamemode_id(name string) int {
 	return match name.to_lower() {
@@ -11,7 +12,7 @@ fn gamemode_id(name string) int {
 	}
 }
 
-// SetGamemodeJob is `set_gamemode` run through the actor. 
+// SetGamemodeJob is `set_gamemode` run through the actor.
 struct SetGamemodeJob {
 	runtime_id u64
 	mode       int
@@ -31,9 +32,17 @@ fn (mut s NetworkSession) set_gamemode(mode int) {
 
 // apply_gamemode is the actual mutation, run exclusively from run_jobs().
 fn (mut s NetworkSession) apply_gamemode(mode int) {
-	s.game_mode = mode
+	mut ctx := event.new_context(event.GameModeChangeData{
+		player: s
+		mode:   mode
+	})
+	s.hub.events.gamemode_change(mut ctx)
+	if ctx.is_cancelled() {
+		return
+	}
+	s.game_mode = ctx.val.mode
 	s.transport.send(&protocol.SetPlayerGameTypePacket{
-		gamemode: mode
+		gamemode: s.game_mode
 	}) or {}
 	s.transport.send(&protocol.UpdateAbilitiesPacket{
 		data: s.build_abilities()

--- a/server/session/hub.v
+++ b/server/session/hub.v
@@ -5,6 +5,12 @@ import sync.stdatomic
 import math
 import time
 import protocol
+import protocol.enums
+import protocol.types
+import server.event
+import server.scheduler
+import server.entity
+import server.liquid
 import server.internal.gamedata
 import server.item
 import server.block
@@ -19,30 +25,40 @@ import server.permission
 pub struct Hub {
 mut:
 	sessions        map[u64]&NetworkSession
-	mutex           &sync.Mutex   = sync.new_mutex()
-	next_runtime_id u64           = 1
+	mutex           &sync.Mutex = sync.new_mutex()
+	next_runtime_id u64         = 1
 	// jobs is the only door into gameplay-mutable state that spans sessions
 	// (combat, targeted /gamemode, etc.). run_jobs() is the sole consumer.
-	jobs chan WorldJob = chan WorldJob{cap: 256}
-	tps_bits  &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](math.f64_bits(20.0))
-	load_bits &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](0)
+	jobs         chan WorldJob             = chan WorldJob{cap: 256}
+	tps_bits     &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](math.f64_bits(20.0))
+	load_bits    &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](0)
 	online_count &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](0)
 pub mut:
-	world_time   int
-	data         gamedata.GameData
-	items        item.Registry    = item.new_registry()
-	blocks       block.Registry   = block.new_registry()
-	lang         &language.Lang   = unsafe { nil }
-	commands     cmd.Registry     = cmd.new_registry()
-	started_at   i64
+	world_time         int
+	data               gamedata.GameData
+	items              item.Registry        = item.new_registry()
+	blocks             block.Registry       = block.new_registry()
+	lang               &language.Lang       = unsafe { nil }
+	commands           cmd.Registry         = cmd.new_registry()
+	events             &event.Bus           = unsafe { nil }
+	scheduler          &scheduler.Scheduler = unsafe { nil }
+	entities           &entity.Manager      = unsafe { nil }
+	liquids            &liquid.LiquidManager = unsafe { nil }
+	entity_registry    entity.Registry      = entity.new_registry()
+	current_tick       i64
+	started_at         i64
 	worlds             map[string]&db.World
 	default_world_name string
-	packs        &resource.PackRegistry = unsafe { nil }
-	ops          permission.OpList
-	player_grants permission.PlayerGrants
-	whitelist    permission.Whitelist
+	// worlds_dir is the on-disk root for world folders and world_generator the
+	// fallback generator name for freshly created worlds. Both are set at boot.
+	worlds_dir      string                 = 'worlds'
+	world_generator string                 = 'flat'
+	packs           &resource.PackRegistry = unsafe { nil }
+	ops             permission.OpList
+	player_grants   permission.PlayerGrants
+	whitelist       permission.Whitelist
 	// needs vedrock.yml storage.
-	difficulty   int = protocol.difficulty_easy
+	difficulty int = protocol.difficulty_easy
 }
 
 pub fn (mut h Hub) tps() f64 {
@@ -64,13 +80,20 @@ fn (mut h Hub) set_load(v f64) {
 pub fn new_hub(data gamedata.GameData) &Hub {
 	mut commands := cmd.new_registry()
 	defaultcmd.register_all(mut commands)
+	mut registry := entity.new_registry()
+	entity.register_defaults(mut registry)
 	mut hub := &Hub{
-		sessions:   map[u64]&NetworkSession{}
-		mutex:      sync.new_mutex()
-		data:       data
-		commands:   commands
-		started_at: time.now().unix()
+		sessions:        map[u64]&NetworkSession{}
+		mutex:           sync.new_mutex()
+		data:            data
+		commands:        commands
+		events:          event.new_bus()
+		scheduler:       scheduler.new_scheduler()
+		entity_registry: registry
+		started_at:      time.now().unix()
 	}
+	hub.entities = entity.new_manager(hub)
+	hub.liquids = liquid.new_manager(hub)
 	spawn hub.run_jobs()
 	return hub
 }
@@ -127,6 +150,134 @@ pub fn (mut h Hub) close_worlds() {
 	h.mutex.unlock()
 }
 
+// set_world_config records where worlds live on disk and the default generator
+// used for worlds created at runtime. Called once at boot from load_worlds.
+pub fn (mut h Hub) set_world_config(worlds_dir string, generator string) {
+	h.mutex.lock()
+	h.worlds_dir = worlds_dir
+	h.world_generator = generator
+	h.mutex.unlock()
+}
+
+// list_worlds returns the names of every loaded world.
+pub fn (mut h Hub) list_worlds() []string {
+	h.mutex.lock()
+	defer { h.mutex.unlock() }
+	mut names := []string{cap: h.worlds.len}
+	for name, _ in h.worlds {
+		names << name
+	}
+	return names
+}
+
+// WorldInfo is a read-only snapshot describing a loaded world.
+pub struct WorldInfo {
+pub:
+	name       string
+	generator  string
+	overrides  int
+	is_default bool
+	players    int
+}
+
+// world_info gathers a snapshot for the named world, or none when it isn't
+// loaded.
+pub fn (mut h Hub) world_info(name string) ?WorldInfo {
+	h.mutex.lock()
+	world := h.worlds[name] or {
+		h.mutex.unlock()
+		return none
+	}
+	is_default := name == h.default_world_name
+	h.mutex.unlock()
+	return WorldInfo{
+		name:       world.name
+		generator:  world.generator_name
+		overrides:  world.block_count()
+		is_default: is_default
+		players:    h.players_in_world(name)
+	}
+}
+
+// players_in_world counts the connected players whose active world matches name.
+pub fn (mut h Hub) players_in_world(name string) int {
+	h.mutex.lock()
+	defer { h.mutex.unlock() }
+	mut count := 0
+	for _, target in h.sessions {
+		if target.world_name() == name {
+			count++
+		}
+	}
+	return count
+}
+
+// create_world creates a fresh empty world on disk and registers it as loaded.
+// Refuses to clobber an already-loaded or already-on-disk world. Safe to call
+// off the actor thread - it only adds to the worlds map, never mutates a
+// player's active world.
+pub fn (mut h Hub) create_world(name string) !string {
+	if _ := h.world(name) {
+		return error('world "${name}" is already loaded')
+	}
+	h.mutex.lock()
+	dir := h.worlds_dir
+	generator := h.world_generator
+	h.mutex.unlock()
+	store := db.create_world_store(dir, name) or {
+		return error('failed to create world "${name}": ${err}')
+	}
+	world := db.new_world(name, store, generator)
+	h.add_world(world)
+	return name
+}
+
+// unload_world flushes and releases a loaded world without deleting its files.
+// Refuses the default world and any world that still has players in it.
+pub fn (mut h Hub) unload_world(name string) ! {
+	h.mutex.lock()
+	if name == h.default_world_name {
+		h.mutex.unlock()
+		return error('cannot unload the default world')
+	}
+	mut world := h.worlds[name] or {
+		h.mutex.unlock()
+		return error('world "${name}" is not loaded')
+	}
+	h.mutex.unlock()
+	if h.players_in_world(name) > 0 {
+		return error('world "${name}" still has players in it')
+	}
+	world.close()
+	h.mutex.lock()
+	h.worlds.delete(name)
+	h.mutex.unlock()
+}
+
+// delete_world unloads the named world and removes its on-disk folder. Refuses
+// the default world and any world that still has players in it. The LevelDB
+// handle is always closed before the files are touched.
+pub fn (mut h Hub) delete_world(name string) ! {
+	h.mutex.lock()
+	if name == h.default_world_name {
+		h.mutex.unlock()
+		return error('cannot delete the default world')
+	}
+	dir := h.worlds_dir
+	loaded := name in h.worlds
+	h.mutex.unlock()
+	if h.players_in_world(name) > 0 {
+		return error('world "${name}" still has players in it')
+	}
+	if loaded {
+		// unload_world closes the handle so the files are no longer held open.
+		h.unload_world(name)!
+	} else if !db.world_exists(dir, name) {
+		return error('world "${name}" does not exist')
+	}
+	db.delete_world_files(dir, name) or { return error('failed to delete world "${name}": ${err}') }
+}
+
 pub fn (mut h Hub) allocate_runtime_id() u64 {
 	h.mutex.lock()
 	id := h.next_runtime_id
@@ -176,6 +327,45 @@ pub fn (mut h Hub) count() int {
 	return int(h.online_count.load())
 }
 
+// broadcast_message sends a raw chat line to every connected player. Part of the
+// plugin.ServerView surface.
+pub fn (mut h Hub) broadcast_message(text string) {
+	h.broadcast(&protocol.TextPacket{
+		@type:   int(enums.TextType.raw)
+		message: text
+	})
+}
+
+// online_count is the plugin.ServerView alias for count().
+pub fn (mut h Hub) online_count() int {
+	return h.count()
+}
+
+// spawn_entity spawns a registered entity type by name at the given position.
+// Returns false if the type is unknown. Part of the plugin.ServerView surface.
+pub fn (mut h Hub) spawn_entity(name string, x f32, y f32, z f32) bool {
+	behaviour := h.entity_registry.create(name) or { return false }
+	h.entities.spawn(behaviour, types.Vector3{x, y, z})
+	return true
+}
+
+// entity_type_names lists every summonable entity type.
+pub fn (mut h Hub) entity_type_names() []string {
+	return h.entity_registry.names()
+}
+
+// player_names lists the display names of every connected player. Part of the
+// plugin.ServerView surface.
+pub fn (mut h Hub) player_names() []string {
+	h.mutex.lock()
+	defer { h.mutex.unlock() }
+	mut names := []string{cap: h.sessions.len}
+	for _, target in h.sessions {
+		names << target.identity.display_name
+	}
+	return names
+}
+
 fn (mut h Hub) snapshot() []&NetworkSession {
 	h.mutex.lock()
 	mut list := []&NetworkSession{cap: h.sessions.len}
@@ -209,6 +399,22 @@ pub fn (mut h Hub) disconnect_all(message string) {
 // submit queues a WorldJob for run_jobs() to execute. Blocks if the queue is full.
 pub fn (mut h Hub) submit(job WorldJob) {
 	h.jobs <- job
+}
+
+// try_submit queues a job without blocking, returning false if the actor queue
+// is full. Used for high-frequency, client- or plugin-driven jobs (attacks,
+// respawns, block edits) so a flood of them can never back up connection
+// threads or stall the tick loop - the excess job is simply dropped.
+pub fn (mut h Hub) try_submit(job WorldJob) bool {
+	select {
+		h.jobs <- job {
+			return true
+		}
+		else {
+			return false
+		}
+	}
+	return false
 }
 
 // run_jobs is the single owner thread for gameplay-mutable state that spans

--- a/server/session/inventory.v
+++ b/server/session/inventory.v
@@ -60,6 +60,11 @@ fn (mut s NetworkSession) send_slot_update(slot int, wrapped types.ItemStackWrap
 }
 
 fn (mut s NetworkSession) handle_mob_equipment(p protocol.MobEquipmentPacket) ! {
+	// Reject an out-of-range hotbar slot before it feeds held_slot (used to
+	// index the server inventory for combat damage).
+	if p.hotbar_slot < 0 || p.hotbar_slot > 8 {
+		return
+	}
 	s.held_item = p.item
 	s.held_slot = p.hotbar_slot
 	s.hub.broadcast_except(s.runtime_id, &protocol.MobEquipmentPacket{

--- a/server/session/login.v
+++ b/server/session/login.v
@@ -2,6 +2,7 @@ module session
 
 import server.internal.network
 import server.internal.auth
+import server.internal.encryption
 import server.resource
 import protocol
 import protocol.enums
@@ -33,10 +34,26 @@ fn (mut s NetworkSession) handle_request_network_settings(p protocol.RequestNetw
 	s.state = .login
 }
 
+// Identity field bounds. display_name is the vanilla gamertag limit; xuid/uuid
+// are bounded to reject absurd values from a hostile or offline client.
+const max_display_name = 32
+const max_xuid_len = 32
+const max_uuid_len = 64
+
 fn (mut s NetworkSession) handle_login(p protocol.LoginPacket) ! {
 	identity := auth.parse_login_chain(p.auth_info_json, s.cfg.xbox_auth) or {
 		s.log.warn('Authentication failed: ${err}')
 		s.disconnect('Login failed: ${err}')
+		return
+	}
+	// parse_login_chain verifies the JWT chain signatures, but with xbox_auth
+	// off the display_name/xuid/uuid come from a self-signed offline chain and
+	// are NOT proof of identity - only trustworthy when identity.xbox_authenticated.
+	// Validate the fields regardless so downstream code (whitelist, ops, grants,
+	// data files keyed by these strings) never sees empty or oversized input.
+	s.validate_identity(identity) or {
+		s.log.warn('Rejected login from ${s.transport.remote_addr()}: ${err}')
+		s.disconnect('Login failed: invalid identity')
 		return
 	}
 	if !s.hub.whitelist.is_allowed(identity.display_name) {
@@ -44,15 +61,89 @@ fn (mut s NetworkSession) handle_login(p protocol.LoginPacket) ! {
 		s.disconnect('You are not white-listed on this server!')
 		return
 	}
+	// Reject a second connection for a player already online - guards against
+	// duplicate-identity sessions clobbering each other's state.
+	if _ := s.hub.session_by_name(identity.display_name) {
+		s.log.info('${identity.display_name} is already connected, rejecting duplicate login')
+		s.disconnect('You are already connected to this server!')
+		return
+	}
 	s.identity = identity
+	s.transport.mark_logged_in()
 	s.perm.set_op(s.hub.ops.is_op(identity.display_name))
 	s.hub.player_grants.apply(mut s.perm, identity.display_name, identity.xuid, identity.uuid)
 	mode := if identity.xbox_authenticated { 'Xbox Live' } else { 'offline' }
 	s.log.info('${identity.display_name} authenticated [${mode}] xuid=${identity.xuid} uuid=${identity.uuid}')
+	// Negotiate protocol encryption before login_success so the rest of the
+	// session runs ciphered. Gated behind the encryption config flag (off by
+	// default until interop is verified). If the client sent no public key, or
+	// the handshake fails, we fall back to cleartext rather than dropping the
+	// player.
+	if s.cfg.encryption {
+		s.start_encryption(identity.client_public_key) or {
+			s.log.warn('Encryption handshake skipped for ${identity.display_name}: ${err}')
+		}
+	}
 	s.transport.send(&protocol.PlayStatusPacket{
 		status: int(enums.PlayStatus.login_success)
 	})!
 	s.start_resource_packs()!
+}
+
+// start_encryption runs the server side of the Bedrock encryption handshake:
+// derive the key from the client public key, send the signed
+// ServerToClientHandshake in cleartext, then switch the transport to encrypted.
+// The client replies with an (encrypted) ClientToServerHandshake, handled as a
+// confirmation. Does nothing if the client provided no public key.
+fn (mut s NetworkSession) start_encryption(client_public_key string) ! {
+	if client_public_key == '' {
+		return error('client provided no public key')
+	}
+	result := encryption.prepare_handshake(client_public_key)!
+	mut ctx := encryption.new_context(result.key)!
+	// Must be flushed in cleartext before the cipher is installed.
+	s.transport.send(&protocol.ServerToClientHandshakePacket{
+		jwt: result.handshake_jwt
+	})!
+	s.transport.enable_encryption(mut ctx)
+	s.encryption_enabled = true
+	s.log.debug('Encryption enabled for ${s.identity.display_name}')
+}
+
+fn (mut s NetworkSession) handle_client_to_server_handshake(p protocol.ClientToServerHandshakePacket) ! {
+	if !s.encryption_enabled {
+		s.log.debug('Unexpected ClientToServerHandshake without an active cipher')
+		return
+	}
+	s.log.debug('Client confirmed encryption handshake')
+}
+
+// validate_identity rejects empty, oversized, or malformed identity fields
+// before they reach the whitelist, permission grants, or on-disk player data.
+fn (s &NetworkSession) validate_identity(identity auth.Identity) ! {
+	name := identity.display_name
+	if name.len == 0 || name.len > max_display_name {
+		return error('display_name length ${name.len} out of range')
+	}
+	// Bedrock gamertags are alphanumerics and spaces. Reject control chars and
+	// path/format-hostile characters that could poison logs or data-file paths.
+	for c in name {
+		if !(c.is_alnum() || c == ` ` || c == `_`) {
+			return error('display_name contains invalid character')
+		}
+	}
+	if identity.xuid.len > max_xuid_len {
+		return error('xuid too long')
+	}
+	// An empty uuid is allowed - player_key falls back to the (charset-checked)
+	// display_name and playerdb sanitises the final key. Only cap the max length
+	// so an oversized value can't bloat identifiers.
+	if identity.uuid.len > max_uuid_len {
+		return error('uuid too long')
+	}
+	// TODO(security): with xbox_auth disabled we accept any self-signed offline
+	// chain - display_name/xuid are unverified and a client can impersonate any
+	// non-online player. Operators relying on identity must set xbox_auth=true.
 }
 
 fn (mut s NetworkSession) start_resource_packs() ! {

--- a/server/session/moderation.v
+++ b/server/session/moderation.v
@@ -63,6 +63,12 @@ pub fn (mut s NetworkSession) position() (f32, f32, f32) {
 	return p.x, p.y, p.z
 }
 
+// place_water sets a water source at the block position and starts its spread.
+// Routes through the actor thread via Hub.place_water.
+pub fn (mut s NetworkSession) place_water(x int, y int, z int) {
+	s.hub.place_water(x, y, z)
+}
+
 struct TeleportJob {
 	runtime_id u64
 	x          f32

--- a/server/session/scoreboard.v
+++ b/server/session/scoreboard.v
@@ -1,0 +1,60 @@
+module session
+
+import protocol
+import protocol.types
+
+// sidebar_objective is the stable objective name used for the per-player
+// sidebar scoreboard. Reusing one name means re-showing cleanly replaces the
+// previous board instead of stacking objectives.
+const sidebar_objective = 'vedrock.sidebar'
+const sidebar_slot = 'sidebar'
+
+// build_sidebar_packets returns the packet sequence that renders a sidebar
+// scoreboard with the given title and lines. Factored out as a pure function so
+// the protocol wiring can be unit-tested without a live connection.
+//
+// Bedrock renders sidebar lines as fake-player entries ordered by their score.
+// We use ascending sort (sort_order 0) and assign score = line index, so
+// lines[0] has the lowest score and sits at the top - matching the slice order.
+// Each entry needs a distinct scoreboard_id or the client collapses them.
+fn build_sidebar_packets(title string, lines []string) []protocol.Packet {
+	mut packets := []protocol.Packet{cap: lines.len + 2}
+	// Drop any previous board first so re-showing replaces cleanly.
+	packets << &protocol.RemoveObjectivePacket{
+		objective_name: sidebar_objective
+	}
+	packets << &protocol.SetDisplayObjectivePacket{
+		display_slot:   sidebar_slot
+		objective_name: sidebar_objective
+		display_name:   title
+		criteria_name:  'dummy'
+		sort_order:     0
+	}
+	mut entries := []types.ScorePacketEntry{cap: lines.len}
+	for i, line in lines {
+		entries << types.ScorePacketEntry{
+			scoreboard_id:  i64(i + 1)
+			objective_name: sidebar_objective
+			score:          i
+			type:           types.score_entry_type_fake_player
+			custom_name:    line
+		}
+	}
+	packets << &protocol.SetScorePacket{
+		type:    protocol.set_score_type_change
+		entries: entries
+	}
+	return packets
+}
+
+pub fn (mut s NetworkSession) show_scoreboard(title string, lines []string) {
+	for p in build_sidebar_packets(title, lines) {
+		s.transport.send(p) or {}
+	}
+}
+
+pub fn (mut s NetworkSession) clear_scoreboard() {
+	s.transport.send(&protocol.RemoveObjectivePacket{
+		objective_name: sidebar_objective
+	}) or {}
+}

--- a/server/session/scoreboard_test.v
+++ b/server/session/scoreboard_test.v
@@ -1,0 +1,70 @@
+module session
+
+import protocol
+import protocol.types
+
+fn test_build_sidebar_packets_sequence() {
+	packets := build_sidebar_packets('Title', ['a', 'b', 'c'])
+	// RemoveObjective, SetDisplayObjective, SetScore
+	assert packets.len == 3
+
+	remove := packets[0]
+	if remove is protocol.RemoveObjectivePacket {
+		assert remove.objective_name == sidebar_objective
+	} else {
+		assert false, 'packet 0 is not RemoveObjectivePacket'
+	}
+
+	display := packets[1]
+	if display is protocol.SetDisplayObjectivePacket {
+		assert display.display_slot == sidebar_slot
+		assert display.objective_name == sidebar_objective
+		assert display.display_name == 'Title'
+		assert display.sort_order == 0
+	} else {
+		assert false, 'packet 1 is not SetDisplayObjectivePacket'
+	}
+
+	score := packets[2]
+	if score is protocol.SetScorePacket {
+		assert score.type == protocol.set_score_type_change
+		assert score.entries.len == 3
+	} else {
+		assert false, 'packet 2 is not SetScorePacket'
+	}
+}
+
+fn test_build_sidebar_packets_line_order_top_to_bottom() {
+	packets := build_sidebar_packets('T', ['top', 'mid', 'bottom'])
+	score := packets[2]
+	if score is protocol.SetScorePacket {
+		// Ascending sort with score = index means lines[0] gets the lowest score
+		// and renders at the top, matching the slice order.
+		assert score.entries[0].custom_name == 'top'
+		assert score.entries[0].score == 0
+		assert score.entries[1].custom_name == 'mid'
+		assert score.entries[1].score == 1
+		assert score.entries[2].custom_name == 'bottom'
+		assert score.entries[2].score == 2
+		for entry in score.entries {
+			assert entry.type == types.score_entry_type_fake_player
+			assert entry.objective_name == sidebar_objective
+		}
+		// Distinct scoreboard ids so the client keeps entries separate.
+		assert score.entries[0].scoreboard_id != score.entries[1].scoreboard_id
+		assert score.entries[1].scoreboard_id != score.entries[2].scoreboard_id
+	} else {
+		assert false, 'packet 2 is not SetScorePacket'
+	}
+}
+
+fn test_build_sidebar_packets_empty_lines() {
+	packets := build_sidebar_packets('Empty', [])
+	assert packets.len == 3
+	score := packets[2]
+	if score is protocol.SetScorePacket {
+		assert score.entries.len == 0
+	} else {
+		assert false, 'packet 2 is not SetScorePacket'
+	}
+}

--- a/server/session/session.v
+++ b/server/session/session.v
@@ -3,7 +3,6 @@ module session
 import server.internal.network
 import server.internal.auth
 import protocol
-import protocol.enums
 import protocol.types
 import server.internal.logger
 import server.conf
@@ -12,6 +11,7 @@ import server.world.db
 import server.player.playerdb
 import server.permission
 import server.cmd
+import server.event
 import server.form
 import server.effect
 import sync
@@ -32,43 +32,45 @@ pub enum State {
 @[heap]
 pub struct NetworkSession {
 mut:
-	transport        &network.Session = unsafe { nil }
-	hub              &Hub             = unsafe { nil }
-	state            State            = .handshake
-	cfg              conf.Config
-	world            &db.World       = unsafe { nil }
-	generator        world.Generator = world.VoidGenerator{}
+	transport &network.Session = unsafe { nil }
+	hub       &Hub             = unsafe { nil }
+	state     State            = .handshake
+	cfg       conf.Config
+	world     &db.World       = unsafe { nil }
+	generator world.Generator = world.VoidGenerator{}
 	// world_mutex guards world and generator - both are swapped from the Hub
 	// job thread on a world change while the session thread reads them.
-	world_mutex      &sync.Mutex = sync.new_mutex()
-	identity         auth.Identity
-	runtime_id       u64
-	pos_mutex        &sync.Mutex = sync.new_mutex()
-	position         types.Vector3
-	pitch            f32
-	yaw              f32
-	head_yaw         f32
-	spawned          bool
-	inv_opened       bool
-	game_mode        int
-	health           f32 = 20.0
-	prev_y           f32
-	vy               f32
-	dead             bool
-	held_item        types.ItemStackWrapper
-	held_slot        int
-	inv_stacks       map[int]types.ItemStack
-	inv_slots        map[int]int
-	inv_next_id      int = 1
-	pending_creative ?types.ItemStack
-	loaded_items     []playerdb.InvItem
-	pending_radius   int
-	perm             permission.Permissible
-	give_next_slot   int
-	next_form_id     int
-	pending_forms    map[int]form.Form
-	last_place_ms    i64
-	effects          effect.Manager
+	world_mutex        &sync.Mutex = sync.new_mutex()
+	identity           auth.Identity
+	encryption_enabled bool
+	runtime_id         u64
+	pos_mutex          &sync.Mutex = sync.new_mutex()
+	position           types.Vector3
+	pitch              f32
+	yaw                f32
+	head_yaw           f32
+	spawned            bool
+	inv_opened         bool
+	game_mode          int
+	health             f32 = 20.0
+	prev_y             f32
+	vy                 f32
+	dead               bool
+	held_item          types.ItemStackWrapper
+	held_slot          int
+	inv_stacks         map[int]types.ItemStack
+	inv_slots          map[int]int
+	inv_next_id        int = 1
+	pending_creative   ?types.ItemStack
+	loaded_items       []playerdb.InvItem
+	pending_radius     int
+	perm               permission.Permissible
+	give_next_slot     int
+	next_form_id       int
+	pending_forms      map[int]form.Form
+	last_place_ms      i64
+	effects            effect.Manager
+
 pub mut:
 	log &logger.Logger = unsafe { nil }
 }
@@ -165,16 +167,47 @@ fn (mut s NetworkSession) leave() {
 	s.hub.remove(s.runtime_id)
 	s.hub.broadcast(s.player_list_remove_packet())
 	s.hub.broadcast(s.remove_actor_packet())
-	s.hub.broadcast(&protocol.TextPacket{
-		@type:             int(enums.TextType.translation)
-		needs_translation: true
-		message:           '§e%multiplayer.player.left'
-		parameters:        [s.identity.display_name]
+	mut ctx := event.new_context(event.QuitData{
+		player:  s
+		message: '§e${s.identity.display_name} left the game'
 	})
+	s.hub.events.player_quit(mut ctx)
+	if !ctx.is_cancelled() && ctx.val.message != '' {
+		s.hub.broadcast_message(ctx.val.message)
+	}
 	s.log.info('${s.identity.display_name} left the game (${s.hub.count()} online)')
 }
 
 fn (mut s NetworkSession) update_movement(position types.Vector3, pitch f32, yaw f32, head_yaw f32) {
+	// Diagnostic: log the client-reported position roughly every 2s (debug only)
+	// so an idle drift can be traced to server vs client. If y climbs here while
+	// the player stands still, the drift is coming from the client's authoritative
+	// movement prediction, not from the server.
+	if s.spawned && s.hub.current_tick % 40 == 0 {
+		s.log.debug('move ${s.identity.display_name} pos=(${position.x:.2f}, ${position.y:.2f}, ${position.z:.2f})')
+	}
+	// Movement is high-frequency; only pay for the event when a listener exists.
+	if s.spawned && s.hub.events.len() > 0 {
+		mut ctx := event.new_context(event.MoveData{
+			player: s
+			x:      position.x
+			y:      position.y
+			z:      position.z
+		})
+		s.hub.events.player_move(mut ctx)
+		if ctx.is_cancelled() {
+			s.transport.send(&protocol.MovePlayerPacket{
+				actor_runtime_id: s.runtime_id
+				position:         s.position
+				pitch:            s.pitch
+				yaw:              s.yaw
+				head_yaw:         s.head_yaw
+				mode:             1
+				on_ground:        false
+			}) or {}
+			return
+		}
+	}
 	s.pos_mutex.lock()
 	s.vy = position.y - s.prev_y
 	s.prev_y = position.y
@@ -200,6 +233,8 @@ fn (mut s NetworkSession) handle(p protocol.Packet) ! {
 		.login {
 			if p is protocol.LoginPacket {
 				s.handle_login(p)!
+			} else if p is protocol.ClientToServerHandshakePacket {
+				s.handle_client_to_server_handshake(p)!
 			} else if p is protocol.RequestChunkRadiusPacket {
 				s.pending_radius = p.radius
 			} else {
@@ -211,6 +246,8 @@ fn (mut s NetworkSession) handle(p protocol.Packet) ! {
 				s.handle_resource_pack_response(p)!
 			} else if p is protocol.ResourcePackChunkRequestPacket {
 				s.handle_resource_pack_chunk_request(p)!
+			} else if p is protocol.ClientToServerHandshakePacket {
+				s.handle_client_to_server_handshake(p)!
 			} else if p is protocol.RequestChunkRadiusPacket {
 				s.pending_radius = p.radius
 			} else {

--- a/server/session/spawn.v
+++ b/server/session/spawn.v
@@ -5,6 +5,7 @@ import protocol
 import protocol.enums
 import protocol.types
 import nbt
+import server.event
 import server.player.playerdb
 import server.world
 
@@ -148,16 +149,21 @@ fn (mut s NetworkSession) handle_player_initialized(p protocol.SetLocalPlayerAsI
 		s.deliver(other.player_list_add_packet())
 		s.deliver(other.add_player_packet())
 	}
+	for e in s.hub.entities.snapshot() {
+		s.deliver(e.spawn_packet())
+	}
 	s.hub.add(s)
 	s.hub.broadcast(s.player_list_add_packet())
 	s.hub.broadcast_except(s.runtime_id, s.add_player_packet())
 	s.send_active_effects()
-	s.hub.broadcast(&protocol.TextPacket{
-		@type:             int(enums.TextType.translation)
-		needs_translation: true
-		message:           '§e%multiplayer.player.joined'
-		parameters:        [s.identity.display_name]
+	mut ctx := event.new_context(event.JoinData{
+		player:  s
+		message: '§e${s.identity.display_name} joined the game'
 	})
+	s.hub.events.player_join(mut ctx)
+	if !ctx.is_cancelled() && ctx.val.message != '' {
+		s.hub.broadcast_message(ctx.val.message)
+	}
 	s.transport.send(s.restore_inventory())!
 	s.refresh_available_commands()
 	s.log.info('${s.identity.display_name} spawned in the world (${s.hub.count()} online)')

--- a/server/session/tick.v
+++ b/server/session/tick.v
@@ -6,14 +6,19 @@ module session
 // and submits one of these per tick rather than writing Hub's fields directly.
 pub struct TickJob {
 pub:
+	tick       i64
 	world_time int
 	tps        f64
 	load       f64
 }
 
 fn (j TickJob) run(mut h Hub) {
+	h.current_tick = j.tick
 	h.world_time = j.world_time
 	h.set_tps(j.tps)
 	h.set_load(j.load)
 	h.tick_effects()
+	h.scheduler.heartbeat(j.tick)
+	h.entities.tick()
+	h.liquids.tick()
 }

--- a/server/session/world_admin.v
+++ b/server/session/world_admin.v
@@ -1,0 +1,65 @@
+module session
+
+import server.cmd
+
+// world_admin wires the /world command's needs onto the Hub. Create/delete
+// only touch the worlds map (never a player's active world), so they run
+// directly on the Hub which already guards that map. Teleport goes through the
+// existing TeleportJob so the world swap happens on the actor thread.
+
+pub fn (mut s NetworkSession) world_names() []string {
+	return s.hub.list_worlds()
+}
+
+pub fn (mut s NetworkSession) world_info(name string) ?cmd.WorldSummary {
+	info := s.hub.world_info(name)?
+	return to_world_summary(info)
+}
+
+pub fn (mut s NetworkSession) world_create(name string) ! {
+	s.hub.create_world(name)!
+}
+
+pub fn (mut s NetworkSession) world_delete(name string) ! {
+	s.hub.delete_world(name)!
+}
+
+pub fn (mut s NetworkSession) world_teleport(name string) ! {
+	if _ := s.hub.world(name) {
+		x, y, z := s.position()
+		s.teleport_to_world(name, x, y, z)
+		return
+	}
+	return error('world "${name}" is not loaded')
+}
+
+pub fn (mut c ConsoleSender) world_names() []string {
+	return c.hub.list_worlds()
+}
+
+pub fn (mut c ConsoleSender) world_info(name string) ?cmd.WorldSummary {
+	info := c.hub.world_info(name)?
+	return to_world_summary(info)
+}
+
+pub fn (mut c ConsoleSender) world_create(name string) ! {
+	c.hub.create_world(name)!
+}
+
+pub fn (mut c ConsoleSender) world_delete(name string) ! {
+	c.hub.delete_world(name)!
+}
+
+pub fn (mut c ConsoleSender) world_teleport(name string) ! {
+	return error('the console cannot teleport into a world')
+}
+
+fn to_world_summary(info WorldInfo) cmd.WorldSummary {
+	return cmd.WorldSummary{
+		name:       info.name
+		generator:  info.generator
+		overrides:  info.overrides
+		is_default: info.is_default
+		players:    info.players
+	}
+}

--- a/server/world/db/leveldb.v
+++ b/server/world/db/leveldb.v
@@ -9,9 +9,7 @@ mut:
 }
 
 pub fn open_leveldb(path string) !&LevelDB {
-	ldb := leveldb.open(path, leveldb.Options{}) or {
-		return error('leveldb open failed: ${err}')
-	}
+	ldb := leveldb.open(path, leveldb.Options{}) or { return error('leveldb open failed: ${err}') }
 	return &LevelDB{
 		db: ldb
 	}
@@ -38,6 +36,14 @@ pub fn (l &LevelDB) each(cb fn (key []u8, value []u8)) {
 	for ok := it.first(); ok; ok = it.next() {
 		cb(it.key(), it.value())
 	}
+}
+
+// flush forces pending writes down to disk without releasing the handle, so a
+// crash after a flush cannot lose the flushed data. close() already syncs, so
+// this is only needed for periodic mid-run durability.
+pub fn (l &LevelDB) flush() {
+	mut ldb := unsafe { l.db }
+	ldb.compact() or {}
 }
 
 pub fn (l &LevelDB) close() {

--- a/server/world/db/manage.v
+++ b/server/world/db/manage.v
@@ -1,0 +1,60 @@
+module db
+
+import os
+
+// world-lifecycle filesystem helpers. Anything that touches the on-disk world
+// folder lives here so the safety checks (path traversal, staying inside
+// worlds_dir) sit in one place.
+
+// safe_world_dir resolves worlds_dir/name and refuses any name that would
+// escape worlds_dir. Returns the absolute world folder path.
+fn safe_world_dir(worlds_dir string, name string) !string {
+	if name.trim_space() == '' {
+		return error('world name is empty')
+	}
+	// Reject anything that could climb out of worlds_dir. A world is always a
+	// single direct subdirectory, never a nested path.
+	if name.contains('/') || name.contains('\\') || name.contains('..') || name == '.'
+		|| os.is_abs_path(name) {
+		return error('illegal world name "${name}"')
+	}
+	base := os.abs_path(worlds_dir)
+	full := os.abs_path(os.join_path(worlds_dir, name))
+	// Belt and suspenders - after normalisation the folder must still sit
+	// directly under worlds_dir.
+	if !full.starts_with(base + os.path_separator) {
+		return error('world path escapes worlds directory')
+	}
+	return full
+}
+
+// world_exists reports whether a world folder with a db subdirectory is present
+// under worlds_dir.
+pub fn world_exists(worlds_dir string, name string) bool {
+	full := safe_world_dir(worlds_dir, name) or { return false }
+	return os.is_dir(os.join_path(full, 'db'))
+}
+
+// delete_world_files removes the on-disk folder for the named world. The caller
+// is responsible for closing the LevelDB handle first - this only touches the
+// filesystem. Refuses to delete anything outside worlds_dir or a world that
+// isn't actually there.
+pub fn delete_world_files(worlds_dir string, name string) ! {
+	full := safe_world_dir(worlds_dir, name)!
+	if !os.is_dir(full) {
+		return error('world "${name}" does not exist on disk')
+	}
+	os.rmdir_all(full)!
+}
+
+// create_world_store creates a fresh, empty world on disk under worlds_dir and
+// returns its opened store. Errors if a world by that name already exists.
+pub fn create_world_store(worlds_dir string, name string) !&WorldStore {
+	full := safe_world_dir(worlds_dir, name)!
+	if os.is_dir(full) {
+		return error('world "${name}" already exists')
+	}
+	os.mkdir_all(full)!
+	path := os.join_path(full, 'db')
+	return open_world(path)!
+}

--- a/server/world/db/manage_test.v
+++ b/server/world/db/manage_test.v
@@ -1,0 +1,73 @@
+module db
+
+import os
+
+fn temp_worlds_dir() string {
+	dir := os.join_path(os.temp_dir(), 'vedrock_worlds_test_${os.getpid()}_${rand_suffix()}')
+	os.mkdir_all(dir) or { panic(err) }
+	return dir
+}
+
+fn rand_suffix() string {
+	return os.getpid().str() + os.args.len.str()
+}
+
+fn make_world_on_disk(worlds_dir string, name string) {
+	os.mkdir_all(os.join_path(worlds_dir, name, 'db')) or { panic(err) }
+}
+
+fn test_delete_refuses_path_traversal() {
+	worlds_dir := temp_worlds_dir()
+	defer {
+		os.rmdir_all(worlds_dir) or {}
+	}
+	// A sibling dir we must never be able to reach out and delete.
+	victim := os.join_path(os.dir(worlds_dir), 'vedrock_victim_${os.getpid()}')
+	os.mkdir_all(victim) or { panic(err) }
+	defer {
+		os.rmdir_all(victim) or {}
+	}
+
+	for bad in ['../vedrock_victim_${os.getpid()}', '..', 'a/b', '/etc', 'foo/../bar'] {
+		if _ := delete_world_files(worlds_dir, bad) {
+			assert false, 'delete_world_files accepted illegal name "${bad}"'
+		}
+	}
+	// The traversal attempt must not have touched the sibling.
+	assert os.is_dir(victim)
+}
+
+fn test_delete_nonexistent_world_errors() {
+	worlds_dir := temp_worlds_dir()
+	defer {
+		os.rmdir_all(worlds_dir) or {}
+	}
+	if _ := delete_world_files(worlds_dir, 'ghost') {
+		assert false, 'deleting a missing world should error'
+	}
+}
+
+fn test_delete_removes_only_the_named_world() {
+	worlds_dir := temp_worlds_dir()
+	defer {
+		os.rmdir_all(worlds_dir) or {}
+	}
+	make_world_on_disk(worlds_dir, 'alpha')
+	make_world_on_disk(worlds_dir, 'beta')
+	assert world_exists(worlds_dir, 'alpha')
+	assert world_exists(worlds_dir, 'beta')
+
+	delete_world_files(worlds_dir, 'alpha')!
+	assert !world_exists(worlds_dir, 'alpha')
+	assert world_exists(worlds_dir, 'beta')
+}
+
+fn test_world_exists_rejects_illegal_names() {
+	worlds_dir := temp_worlds_dir()
+	defer {
+		os.rmdir_all(worlds_dir) or {}
+	}
+	assert !world_exists(worlds_dir, '../etc')
+	assert !world_exists(worlds_dir, '')
+	assert !world_exists(worlds_dir, 'missing')
+}

--- a/server/world/db/vanilla.v
+++ b/server/world/db/vanilla.v
@@ -2,6 +2,9 @@ module db
 
 import sync
 import server.world
+import server.world.upgrader
+
+const block_upgrader = upgrader.default_upgrader()
 
 const subchunk_tag = u8(0x2f)
 const min_subchunk_y = -4
@@ -145,6 +148,7 @@ fn read_palette_entry(mut r SubchunkReader) !int {
 	r.str_le()!
 	mut name := ''
 	mut states := []world.BlockState{}
+	mut version := 0
 	for {
 		field_tag := r.u8()!
 		if field_tag == 0x00 {
@@ -153,7 +157,10 @@ fn read_palette_entry(mut r SubchunkReader) !int {
 		key := r.str_le()!
 		match field_tag {
 			0x03 {
-				r.i32_le()!
+				value := r.i32_le()!
+				if key == 'version' {
+					version = value
+				}
 			}
 			0x08 {
 				value := r.str_le()!
@@ -176,7 +183,8 @@ fn read_palette_entry(mut r SubchunkReader) !int {
 	if name == '' {
 		return error('subchunk: palette entry missing block name')
 	}
-	return world.new_block_with_states(name, states).network_id
+	upgraded := block_upgrader.upgrade(upgrader.from_world(name, states, version))
+	return world.new_block_with_states(upgraded.name, upgraded.to_world()).network_id
 }
 
 fn read_states(mut r SubchunkReader) ![]world.BlockState {

--- a/server/world/db/world.v
+++ b/server/world/db/world.v
@@ -50,6 +50,12 @@ pub fn (w &WorldStore) each_block(cb fn (x int, y int, z int, runtime_id int)) {
 	})
 }
 
+// flush persists both backing databases without closing them.
+pub fn (w &WorldStore) flush() {
+	w.db.flush()
+	w.overrides.flush()
+}
+
 pub fn (w &WorldStore) close() {
 	w.db.close()
 	w.overrides.close()

--- a/server/world/db/world_instance.v
+++ b/server/world/db/world_instance.v
@@ -108,6 +108,14 @@ pub fn (w &World) make_generator(fallback world.Generator) world.Generator {
 	return new_stored_generator(w.store, fallback)
 }
 
+// flush persists this world's store to disk without unloading it. Safe to call
+// while the world is live - it does not touch the in-memory override cache.
+pub fn (mut w World) flush() {
+	if !isnil(w.store) {
+		w.store.flush()
+	}
+}
+
 pub fn (mut w World) close() {
 	if !isnil(w.store) {
 		w.store.close()


### PR DESCRIPTION
## Summary

Adds server/liquid/ - server-side water flow modeled on dragonfly/PocketMine:
- Source spreads horizontally with decay and pours straight down; flowing cells dry up without a feeding source; two adjacent sources can form a new source
- Reads/writes blocks through a `BlockSource`/`BlockSink` abstraction (Hub satisfies it), so it stays unit-testable
- Per-tick cell cap so a flood can slow but never stall the tick

Wired into the Hub tick and block hooks in the integration PR. Unit tested.