### PR TITLE
fix: send chunk publisher and play status on dimension change

### DIFF
--- a/server/session/moderation.v
+++ b/server/session/moderation.v
@@ -101,10 +101,22 @@ fn (mut s NetworkSession) reload_chunks(radius int) {
 	defer {
 		s.chunk_stream_mutex.unlock()
 	}
+	s.transport.send(&protocol.ChunkRadiusUpdatedPacket{
+		radius: radius
+	}) or {}
+	s.transport.send(&protocol.NetworkChunkPublisherUpdatePacket{
+		block_position: types.BlockPosition{int(s.position.x), int(s.position.y), int(s.position.z)}
+		radius:         radius * 16
+		saved_chunks:   []types.ChunkPosition{}
+	}) or {}
 	s.send_spawn_chunks(radius) or {
 		s.log.warn('Failed to send chunks after world change: ${err}')
+		return
 	}
 	s.remember_chunk_window(radius)
+	s.transport.send(&protocol.PlayStatusPacket{
+		status: 3
+	}) or {}
 }
 
 pub fn (s &NetworkSession) world_name() string {


### PR DESCRIPTION
Chunks weren't loading after `/world tp` into a different dimension — the player was stuck in a void with no terrain and couldn't move.

`reload_chunks` was missing `ChunkRadiusUpdatedPacket`, `NetworkChunkPublisherUpdatePacket` and `PlayStatusPacket` that the client needs before it starts rendering. Added them to match the flow in `handle_request_chunk_radius`.

There's still a ~10s freeze on dimension switch because we don't wait for the client's ack after `ChangeDimensionPacket` yet, but terrain loads and the player can move after that.