### PR TITLE
fix: eliminate freeze on dimension change

### DIFF
--- a/server/session/moderation.v
+++ b/server/session/moderation.v
@@ -1,6 +1,7 @@
 module session
 
 import protocol
+import protocol.enums
 import protocol.types
 
 // op / deop
@@ -156,10 +157,10 @@ fn (mut s NetworkSession) change_world(name string, x f32, y f32, z f32) bool {
 			stop_all:   true
 		}) or {}
 		s.transport.send(&protocol.PlayStatusPacket{
-			status: 3
+			status: int(enums.PlayStatus.player_spawn)
 		}) or {}
 		s.transport.send(&protocol.PlayerActionPacket{
-			action:           14
+			action:           int(enums.PlayerAction.dimension_change_ack)
 			actor_runtime_id: s.runtime_id
 		}) or {}
 	}

--- a/server/session/moderation.v
+++ b/server/session/moderation.v
@@ -151,6 +151,17 @@ fn (mut s NetworkSession) change_world(name string, x f32, y f32, z f32) bool {
 			position:  types.Vector3{x, y, z}
 			respawn:   false
 		}) or {}
+		s.transport.send(&protocol.StopSoundPacket{
+			sound_name: ''
+			stop_all:   true
+		}) or {}
+		s.transport.send(&protocol.PlayStatusPacket{
+			status: 3
+		}) or {}
+		s.transport.send(&protocol.PlayerActionPacket{
+			action:           14
+			actor_runtime_id: s.runtime_id
+		}) or {}
 	}
 	return true
 }


### PR DESCRIPTION
The client was freezing for ~10s on dimension change because the server only sent `ChangeDimensionPacket` without the follow-up packets the client expects.

Since v1.19.50, the dimension ack is sent by the server, not the client. Added `StopSoundPacket`, `PlayStatusPacket` and `PlayerActionPacket` (action 14) after `ChangeDimensionPacket` in `change_world`, which eliminates the freeze entirely.

Credit to @nepinhum for pointing out the correct packet sequence.
