### PR TITLE
feat: item & block hooks

### DIFF
--- a/server/block/decorative_components.v
+++ b/server/block/decorative_components.v
@@ -98,6 +98,10 @@ fn sign_block_name(wood_type string, shape string) string {
 	return 'minecraft:${prefix}${shape}'
 }
 
+pub struct SignBlock {
+	SimpleBlock
+}
+
 fn standing_sign_block(wood_type string, direction int) Block {
 	id := sign_block_name(wood_type, 'standing_sign')
 	runtime := world.new_block_with_states(id, [
@@ -107,10 +111,12 @@ fn standing_sign_block(wood_type string, direction int) Block {
 			int_value: direction
 		},
 	])
-	return SimpleBlock{
-		id:             id
-		block_runtime:  runtime.network_id
-		break_hardness: sign_hardness
+	return SignBlock{
+		SimpleBlock: SimpleBlock{
+			id:             id
+			block_runtime:  runtime.network_id
+			break_hardness: sign_hardness
+		}
 	}
 }
 
@@ -123,10 +129,12 @@ fn wall_sign_block(wood_type string, facing int) Block {
 			int_value: facing
 		},
 	])
-	return SimpleBlock{
-		id:             id
-		block_runtime:  runtime.network_id
-		break_hardness: sign_hardness
+	return SignBlock{
+		SimpleBlock: SimpleBlock{
+			id:             id
+			block_runtime:  runtime.network_id
+			break_hardness: sign_hardness
+		}
 	}
 }
 

--- a/server/block/farming_components.v
+++ b/server/block/farming_components.v
@@ -3,7 +3,9 @@ module block
 import server.world
 
 // Farming family: wheat/carrots/potatoes/beetroot crops, farmland, composter.
-// None of these carry growth-timer, moisture-tick or compost-fill behaviour yet.
+// Wheat ticks its growth stage forward (see WheatBlock); carrots/potatoes/
+// beetroot/farmland/composter don't carry growth timer, moisture-tick or
+// compost-fill behaviour yet.
 
 const crop_hardness = f32(0.0)
 const farmland_hardness = f32(0.6)
@@ -23,6 +25,66 @@ fn crop_block(name string, growth int) Block {
 		block_runtime:  runtime.network_id
 		break_hardness: crop_hardness
 	}
+}
+
+// WheatBlock is the class for 'minecraft:wheat'. Its growth stages (0-7)
+// tick forward via random_tick.
+//
+// This is a deliberate simplification, not vanilla parity: it only checks
+// for farmland underneath, not light level, haste, or bonemeal adjacent
+// growth rate boosts.
+pub struct WheatBlock {
+	SimpleBlock
+	next_growth_id int // 0 once fully grown (growth=7) - no further tick
+	farmland_ids   []int
+}
+
+pub fn (b WheatBlock) random_tick(x int, y int, z int, mut w TickWorld) {
+	if b.next_growth_id == 0 {
+		return
+	}
+	below := w.block_id(x, y - 1, z)
+	if below !in b.farmland_ids {
+		return
+	}
+	w.set_block(x, y, z, b.next_growth_id)
+}
+
+fn wheat_blocks() []Block {
+	mut growth_ids := []int{cap: 8}
+	for growth in 0 .. 8 {
+		growth_ids << world.new_block_with_states('minecraft:wheat', [
+			world.BlockState{
+				key:       'growth'
+				kind:      world.state_kind_int
+				int_value: growth
+			},
+		]).network_id
+	}
+	mut farmland_ids := []int{cap: 8}
+	for moisture in 0 .. 8 {
+		farmland_ids << world.new_block_with_states('minecraft:farmland', [
+			world.BlockState{
+				key:       'moisturized_amount'
+				kind:      world.state_kind_int
+				int_value: moisture
+			},
+		]).network_id
+	}
+	mut result := []Block{cap: 8}
+	for growth in 0 .. 8 {
+		next := if growth < 7 { growth_ids[growth + 1] } else { 0 }
+		result << Block(WheatBlock{
+			SimpleBlock:    SimpleBlock{
+				id:             'minecraft:wheat'
+				block_runtime:  growth_ids[growth]
+				break_hardness: crop_hardness
+			}
+			next_growth_id: next
+			farmland_ids:   farmland_ids
+		})
+	}
+	return result
 }
 
 fn farmland_block(moisture int) Block {
@@ -59,7 +121,8 @@ fn composter_block(fill_level int) Block {
 
 pub fn farming_blocks() []Block {
 	mut result := []Block{}
-	for name in ['wheat', 'carrots', 'potatoes', 'beetroot'] {
+	result << wheat_blocks()
+	for name in ['carrots', 'potatoes', 'beetroot'] {
 		for growth in 0 .. 8 {
 			result << crop_block(name, growth)
 		}

--- a/server/block/farming_components_test.v
+++ b/server/block/farming_components_test.v
@@ -66,3 +66,74 @@ fn test_composter_fill_levels_registered() {
 	b := r.get(full.network_id) or { panic('missing composter composter_fill_level=8') }
 	assert b.hardness() == 0.6
 }
+
+// FakeTickWorld is a minimal in memory TickWorld fixture for testing
+// RandomTicker blocks without a real db.World.
+struct FakeTickWorld {
+mut:
+	blocks map[string]int
+}
+
+fn (w &FakeTickWorld) block_id(x int, y int, z int) int {
+	return w.blocks['${x}:${y}:${z}'] or { 0 }
+}
+
+fn (mut w FakeTickWorld) set_block(x int, y int, z int, id int) {
+	w.blocks['${x}:${y}:${z}'] = id
+}
+
+fn (mut w FakeTickWorld) schedule_tick(x int, y int, z int, delay int) {}
+
+fn test_wheat_growth_chains_stages_on_farmland() {
+	blocks := wheat_blocks()
+	assert blocks.len == 8
+
+	stage0 := blocks[0]
+	stage1 := blocks[1]
+	assert stage0 is WheatBlock
+	assert stage0 is RandomTicker
+
+	if stage0 is WheatBlock {
+		mut w := FakeTickWorld{}
+		w.set_block(0, -1, 0, stage0.farmland_ids[0])
+		stage0.random_tick(0, 0, 0, mut w)
+		assert w.block_id(0, 0, 0) == stage1.runtime_id()
+	} else {
+		assert false
+	}
+}
+
+fn test_wheat_growth_noop_without_farmland() {
+	blocks := wheat_blocks()
+	stage0 := blocks[0]
+	if stage0 is WheatBlock {
+		mut w := FakeTickWorld{}
+		w.set_block(0, -1, 0, 0) // not a farmland id
+		stage0.random_tick(0, 0, 0, mut w)
+		assert w.block_id(0, 0, 0) == 0
+	} else {
+		assert false
+	}
+}
+
+fn test_wheat_fully_grown_stage_never_advances() {
+	blocks := wheat_blocks()
+	stage7 := blocks[7]
+	if stage7 is WheatBlock {
+		assert stage7.next_growth_id == 0
+		mut w := FakeTickWorld{}
+		w.set_block(0, -1, 0, stage7.farmland_ids[0])
+		stage7.random_tick(0, 0, 0, mut w)
+		assert w.block_id(0, 0, 0) == 0
+	} else {
+		assert false
+	}
+}
+
+fn test_wheat_registered_via_farming_blocks_in_real_registry() {
+	r := new_registry()
+	stage0_id := wheat_blocks()[0].runtime_id()
+	got := r.get(stage0_id) or { panic('missing wheat stage 0') }
+	assert got is WheatBlock
+	assert got.hardness() == crop_hardness
+}

--- a/server/item/bucket_item.v
+++ b/server/item/bucket_item.v
@@ -1,0 +1,27 @@
+module item
+
+// BucketItem is the class for 'minecraft:bucket' (the empty bucket).
+// Filled buckets (milk_bucket, water_bucket, lava_bucket) stay on the
+// fallback path, only the empty bucket has a UsableOnEntityItem behaviour.
+pub struct BucketItem {
+	SimpleItem
+}
+
+pub fn (i BucketItem) use_on_entity_result(entity_name string, meta int) ?UseOnEntityResult {
+	if entity_name != 'minecraft:cow' {
+		return none
+	}
+	return UseOnEntityResult{
+		sound:         'mob.cow.milk'
+		replaces_with: 'minecraft:milk_bucket'
+	}
+}
+
+pub fn new_bucket_item() BucketItem {
+	return BucketItem{
+		SimpleItem: SimpleItem{
+			id:        'minecraft:bucket'
+			stack_max: 16
+		}
+	}
+}

--- a/server/item/item.v
+++ b/server/item/item.v
@@ -62,17 +62,20 @@ pub interface UsableOnBlockItem {
 	use_on_block_result(block_name string, meta int) ?UseOnBlockResult
 }
 
-// UseOnEntityResult describes what a UsableOnEntityItem does when used on an
-// entity.
+// UseOnEntityResult describes what a UsableOnEntityItem does when used on a
+// qualifying entity: an optional sound plus an optional item id the held
+// stack is replaced with (empty means no swap, just the sound).
 pub struct UseOnEntityResult {
 pub:
-	sound string
+	sound         string
+	replaces_with string
 }
 
-// UsableOnEntityItem is implemented by items with a behaviour when used on
-// an entity.
+// UsableOnEntityItem is implemented by items with a behaviour when used on a
+// specific kind of entity (e.g. milk bucket on a cow). Returns none if this
+// item does nothing to an entity named entity_name.
 pub interface UsableOnEntityItem {
-	use_on_entity_result(meta int) UseOnEntityResult
+	use_on_entity_result(entity_name string, meta int) ?UseOnEntityResult
 }
 
 // CooldownItem is implemented by items that can't be used again for a period

--- a/server/item/item_test.v
+++ b/server/item/item_test.v
@@ -2,7 +2,7 @@ module item
 
 fn test_default_registry_has_builtins() {
 	r := new_registry()
-	assert r.len() == 486
+	assert r.len() == 487
 }
 
 fn test_registered_blocks_carry_runtime_id() {

--- a/server/item/registry.v
+++ b/server/item/registry.v
@@ -86,10 +86,10 @@ pub fn (r &Registry) use_on_block_result(id string, block_name string, meta int)
 	return none
 }
 
-pub fn (r &Registry) use_on_entity_result(id string, meta int) ?UseOnEntityResult {
+pub fn (r &Registry) use_on_entity_result(id string, entity_name string, meta int) ?UseOnEntityResult {
 	it := r.get(id) or { return none }
 	if it is UsableOnEntityItem {
-		return it.use_on_entity_result(meta)
+		return it.use_on_entity_result(entity_name, meta)
 	}
 	return none
 }
@@ -124,6 +124,7 @@ fn default_items() []Item {
 	items << new_bedrock_item()
 	items << new_stick()
 	items << new_goat_horn_item()
+	items << new_bucket_item()
 	items << new_compass_item()
 	items << new_recovery_compass_item()
 	items << new_lodestone_compass_item()

--- a/server/session/blocks.v
+++ b/server/session/blocks.v
@@ -1,5 +1,6 @@
 module session
 
+import math
 import time
 import protocol
 import protocol.types
@@ -15,6 +16,28 @@ const place_cooldown_ms = i64(100)
 
 const survival_place_reach_sq = f32(8.0 * 8.0)
 const creative_place_reach_sq = f32(14.0 * 14.0)
+
+// break_grace_ticks absorbs latency jitter around the expected break time
+// boundary so a legitimate client isn't rejected for arriving a tick or two
+// early.
+const break_grace_ticks = i64(2)
+
+// required_break_ticks approximates vanilla's break time formula
+// (hardness * 30 / mining_speed). This is deliberately not vanilla exact.
+fn required_break_ticks(hardness f32, mining_speed f32) i64 {
+	if hardness <= 0 {
+		return 0
+	}
+	return i64(math.ceil(hardness * 30.0 / mining_speed))
+}
+
+fn (s &NetworkSession) held_mining_speed() f32 {
+	_, name := s.held_stack_and_name()
+	if it := s.hub.items.get(name) {
+		return it.mining_speed()
+	}
+	return 1.0
+}
 
 // dimension returns the player's current world's dimension.
 fn (s &NetworkSession) dimension() world.Dimension {
@@ -68,6 +91,8 @@ fn (mut s NetworkSession) handle_inventory_transaction(p protocol.InventoryTrans
 		ue := p.use_item_on_entity
 		if ue.action_type == protocol.item_use_on_entity_action_attack {
 			s.handle_attack(ue.target_entity_runtime_id)!
+		} else if ue.action_type == protocol.item_use_on_entity_action_interact {
+			s.handle_entity_interact(ue.target_entity_runtime_id)
 		}
 		return
 	}
@@ -107,7 +132,23 @@ fn (mut s NetworkSession) handle_inventory_transaction(p protocol.InventoryTrans
 			if s.use_item_on_block(ut.block_position, clicked_id) {
 				return
 			}
-			runtime_id := ut.held_item.item_stack.block_runtime_id
+			// The item stack's own block_runtime_id is 0 for at least some
+			// items (confirmed via packet capture: signs and doors). The
+			// transaction's own top-level block_runtime_id field is NOT a
+			// usable fallback for this - packet capture against a real
+			// client shows it's actually an echo of the clicked/support
+			// block (e.g. the grass block placed against, not the item
+			// placing it), not the held item's block form. The reliable
+			// source is the server's own item registry, resolving the held
+			// item's name from its wire id the same way held_stack_and_name
+			// does elsewhere.
+			mut runtime_id := ut.held_item.item_stack.block_runtime_id
+			if runtime_id == 0 && ut.held_item.item_stack.id != 0 {
+				held_name := s.hub.data.item_name(ut.held_item.item_stack.id)
+				if held_item := s.hub.items.get(held_name) {
+					runtime_id = held_item.block_runtime_id()
+				}
+			}
 			if runtime_id == 0 {
 				return
 			}
@@ -340,6 +381,7 @@ fn (mut s NetworkSession) handle_start_break(pos types.BlockPosition, click_face
 		s.resend_block(pos)
 		return
 	}
+	s.breaking = BreakProgress{pos.x, pos.y, pos.z, old_id, s.hub.current_tick}
 	if punchable := s.hub.blocks.get(old_id) {
 		if punchable is block.Punchable {
 			mut wld := s.current_world()
@@ -448,6 +490,8 @@ fn (mut s NetworkSession) place_block(pos types.BlockPosition, runtime_id int) !
 	s.broadcast_block_update(pos, runtime_id)
 	s.broadcast_swing()
 	s.after_block_changed(pos)
+	s.create_sign_tile(pos, runtime_id)
+	s.maybe_open_sign_editor(pos, runtime_id)
 	return true
 }
 
@@ -467,6 +511,8 @@ fn (mut s NetworkSession) replace_block(pos types.BlockPosition, runtime_id int)
 	s.set_block_runtime(pos, runtime_id)
 	s.broadcast_swing()
 	s.after_block_changed(pos)
+	s.create_sign_tile(pos, runtime_id)
+	s.maybe_open_sign_editor(pos, runtime_id)
 	return true
 }
 
@@ -578,6 +624,20 @@ fn (mut s NetworkSession) break_block(pos types.BlockPosition) ! {
 		})!
 		return
 	}
+	if s.game_mode != protocol.game_type_creative {
+		required := required_break_ticks(s.hub.blocks.hardness(old_id), s.held_mining_speed())
+		matches := if bp := s.breaking {
+			bp.x == pos.x && bp.y == pos.y && bp.z == pos.z && bp.block_id == old_id
+		} else {
+			false
+		}
+		elapsed := if bp := s.breaking { s.hub.current_tick - bp.started_tick } else { 0 }
+		if !matches || elapsed < required - break_grace_ticks {
+			s.resend_block(pos)
+			return
+		}
+	}
+	s.breaking = none
 	mut ctx := event.new_context(event.BlockBreakData{
 		player:   s
 		x:        pos.x
@@ -607,6 +667,19 @@ fn (mut s NetworkSession) break_block(pos types.BlockPosition) ! {
 }
 
 fn (mut s NetworkSession) interact_block(pos types.BlockPosition, old_id int, click_face int) !bool {
+	if b := s.hub.blocks.get(old_id) {
+		if b is block.SignBlock {
+			if !isnil(s.log) {
+				s.log.debug('[sign-debug] interact_block: recognized sign at (${pos.x}, ${pos.y}, ${pos.z}), old_id=${old_id}, click_face=${click_face} - reopening editor')
+			}
+			s.maybe_open_sign_editor(pos, old_id)
+			return true
+		}
+	} else {
+		if !isnil(s.log) {
+			s.log.debug('[sign-debug] interact_block: block_at(${pos.x},${pos.y},${pos.z})=${old_id} not found in registry at all')
+		}
+	}
 	if isnil(s.hub.palette) {
 		return false
 	}
@@ -690,30 +763,48 @@ fn (mut s NetworkSession) set_block_runtime(pos types.BlockPosition, runtime_id 
 // the plugin/command path, so a player placing/breaking a block is
 // serialized against scheduled ticks/liquid spread/arena restores touching
 // the same cell instead of writing directly on the connection thread.
+//
+// done signals once the write has actually landed in World.overrides.
+// write_block_runtime blocks on it - submit() only guarantees the job is
+// queued, not applied, and every write is immediately followed by
+// synchronous reads of the same position (occupancy checks, interact
+// dispatch, resend-on-reject) on the connection thread. Without waiting,
+// a fast enough follow-up action (most visibly: placing a block and
+// immediately clicking it again, as signs invite) can read the position
+// before the actor thread applies the write, see stale (pre-write) state,
+// and resend it to the client - which looks like the just-placed block
+// vanishing, since nothing else ever corrects that resend afterward.
 struct PlayerBlockWriteJob {
 	session_runtime_id u64
 	x                  int
 	y                  int
 	z                  int
 	block_id           int
+	done               chan bool = chan bool{cap: 1}
 }
 
 fn (j PlayerBlockWriteJob) run(mut h Hub) {
-	mut owner := h.session_by_runtime(j.session_runtime_id) or { return }
+	mut owner := h.session_by_runtime(j.session_runtime_id) or {
+		j.done <- true
+		return
+	}
 	mut wld := owner.current_world()
 	if !isnil(wld) {
 		wld.set_block(j.x, j.y, j.z, j.block_id)
 	}
+	j.done <- true
 }
 
 fn (mut s NetworkSession) write_block_runtime(pos types.BlockPosition, runtime_id int) {
-	s.hub.submit(PlayerBlockWriteJob{
+	job := PlayerBlockWriteJob{
 		session_runtime_id: s.runtime_id
 		x:                  pos.x
 		y:                  pos.y
 		z:                  pos.z
 		block_id:           runtime_id
-	})
+	}
+	s.hub.submit(job)
+	_ := <-job.done
 }
 
 fn (mut s NetworkSession) after_block_changed(pos types.BlockPosition) {

--- a/server/session/blocks_test.v
+++ b/server/session/blocks_test.v
@@ -1,0 +1,486 @@
+module session
+
+import protocol
+import protocol.types
+import server.event
+import server.internal.gamedata
+import server.internal.auth
+import server.world
+import server.world.db
+import server.block
+import server.item
+
+fn test_within_place_reach_survival_vs_creative() {
+	mut s := &NetworkSession{
+		position:  types.Vector3{0.0, player_eye_height, 0.0}
+		game_mode: protocol.game_type_survival
+	}
+	near := types.BlockPosition{0, 5, 0}
+	// Beyond survival's reach but within creative's reach.
+	far := types.BlockPosition{10, 0, 0}
+	assert s.within_place_reach(near)
+	assert !s.within_place_reach(far)
+
+	s.game_mode = protocol.game_type_creative
+	assert s.within_place_reach(far)
+}
+
+fn test_place_block_rejects_when_occupied() {
+	mut hub := new_hub(gamedata.GameData{})
+	mut transport := &FakeTransport{}
+	mut s := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		transport:  transport
+		hub:        hub
+		position:   types.Vector3{0.0, player_eye_height, 0.0}
+		generator:  world.FlatGenerator{}
+	}
+	hub.add(s)
+
+	// FlatGenerator's bottom layer (bedrock) sits at the dimension's min_y.
+	pos := types.BlockPosition{0, world.overworld.min_y, 0}
+	placed := s.place_block(pos, world.bedrock.network_id)!
+	assert !placed
+	assert transport.sent.len == 1
+	sent := transport.sent[0]
+	if sent is protocol.UpdateBlockPacket {
+		assert sent.block_position == pos
+	} else {
+		assert false
+	}
+}
+
+fn test_place_block_writes_and_broadcasts_when_clear() {
+	mut hub := new_hub(gamedata.GameData{})
+	target := db.new_world('world', unsafe { nil }, 'flat', world.overworld)
+	hub.add_world(target)
+	mut transport := &FakeTransport{}
+	mut s := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		transport:  transport
+		hub:        hub
+		world:      target
+		position:   types.Vector3{0.0, player_eye_height, 0.0}
+		generator:  world.VoidGenerator{}
+	}
+	hub.add(s)
+
+	pos := types.BlockPosition{5, 5, 5}
+	placed := s.place_block(pos, world.bedrock.network_id)!
+	assert placed
+
+	// write_block_runtime blocks until the WorldJob actually lands (see its
+	// comment). No need to run the job manually or poll for it here.
+	assert target.block_override(pos.x, pos.y, pos.z) or { -1 } == world.bedrock.network_id
+
+	mut saw_update := false
+	for p in transport.sent {
+		if p is protocol.UpdateBlockPacket {
+			if p.block_position == pos && p.block_runtime_id == world.bedrock.network_id {
+				saw_update = true
+			}
+		}
+	}
+	assert saw_update
+}
+
+fn test_place_block_cancelled_resends_skips_write() {
+	mut hub := new_hub(gamedata.GameData{})
+	hub.events.register(&CancelBlockPlaceHandler{}, .normal)
+	target := db.new_world('world', unsafe { nil }, 'flat', world.overworld)
+	hub.add_world(target)
+	mut transport := &FakeTransport{}
+	mut s := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		transport:  transport
+		hub:        hub
+		world:      target
+		position:   types.Vector3{0.0, player_eye_height, 0.0}
+		generator:  world.VoidGenerator{}
+	}
+	hub.add(s)
+
+	pos := types.BlockPosition{5, 5, 5}
+	placed := s.place_block(pos, world.bedrock.network_id)!
+	assert !placed
+	if _ := target.block_override(pos.x, pos.y, pos.z) {
+		assert false
+	}
+	assert transport.sent.len == 1
+}
+
+struct CancelBlockPlaceHandler {
+	event.NopHandler
+}
+
+fn (mut h CancelBlockPlaceHandler) on_block_place(mut ctx event.Context[event.BlockPlaceData]) {
+	ctx.cancel()
+}
+
+fn test_break_block_unbreakable_resends_without_event() {
+	mut hub := new_hub(gamedata.GameData{})
+	mut transport := &FakeTransport{}
+	mut s := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		transport:  transport
+		hub:        hub
+		game_mode:  protocol.game_type_survival
+		generator:  world.FlatGenerator{}
+	}
+	hub.add(s)
+
+	pos := types.BlockPosition{0, world.overworld.min_y, 0}
+	old_id := s.block_at(pos.x, pos.y, pos.z)
+	assert old_id != world.air.network_id
+	s.break_block(pos)!
+	assert transport.sent.len == 1
+	sent := transport.sent[0]
+	if sent is protocol.UpdateBlockPacket {
+		assert sent.block_runtime_id == old_id
+	} else {
+		assert false
+	}
+}
+
+fn test_break_block_air_is_noop() {
+	mut hub := new_hub(gamedata.GameData{})
+	mut transport := &FakeTransport{}
+	mut s := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		transport:  transport
+		hub:        hub
+		generator:  world.VoidGenerator{}
+	}
+	hub.add(s)
+
+	s.break_block(types.BlockPosition{0, 0, 0})!
+	assert transport.sent.len == 0
+}
+
+fn test_break_block_cancelled_resends_keeps_block() {
+	mut hub := new_hub(gamedata.GameData{})
+	hub.events.register(&CancelBlockBreakHandler{}, .normal)
+	target := db.new_world('world', unsafe { nil }, 'flat', world.overworld)
+	hub.add_world(target)
+	mut transport := &FakeTransport{}
+	mut s := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		transport:  transport
+		hub:        hub
+		world:      target
+		game_mode:  protocol.game_type_survival
+		generator:  world.FlatGenerator{}
+	}
+	hub.add(s)
+
+	pos := types.BlockPosition{0, world.overworld.min_y, 0}
+	old_id := s.block_at(pos.x, pos.y, pos.z)
+	s.break_block(pos)!
+	if _ := target.block_override(pos.x, pos.y, pos.z) {
+		assert false
+	}
+	assert transport.sent.len == 1
+	sent := transport.sent[0]
+	if sent is protocol.UpdateBlockPacket {
+		assert sent.block_runtime_id == old_id
+	} else {
+		assert false
+	}
+}
+
+struct CancelBlockBreakHandler {
+	event.NopHandler
+}
+
+fn (mut h CancelBlockBreakHandler) on_block_break(mut ctx event.Context[event.BlockBreakData]) {
+	ctx.cancel()
+}
+
+fn test_obstructed_by_entity_ignores_only_own_body() {
+	mut hub := new_hub(gamedata.GameData{})
+	mut alex := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		hub:        hub
+		position:   types.Vector3{0.5, player_eye_height, 0.5}
+	}
+	hub.add(alex)
+
+	// Alex's own body occupies (0,0,0), obstructed but self_only.
+	obstructed, self_only := alex.obstructed_by_entity(types.BlockPosition{0, 0, 0})
+	assert obstructed
+	assert self_only
+
+	// Nobody else occupies a faraway cell.
+	clear_obstructed, clear_self_only := alex.obstructed_by_entity(types.BlockPosition{50, 0, 50})
+	assert !clear_obstructed
+	assert clear_self_only
+}
+
+fn test_obstructed_by_entity_blocks_other_player() {
+	mut hub := new_hub(gamedata.GameData{})
+	mut alex := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		hub:        hub
+		position:   types.Vector3{10.5, player_eye_height, 10.5}
+	}
+	mut steve := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Steve'
+		}
+		runtime_id: 2
+		hub:        hub
+		position:   types.Vector3{0.5, player_eye_height, 0.5}
+	}
+	hub.add(alex)
+	hub.add(steve)
+
+	obstructed, self_only := alex.obstructed_by_entity(types.BlockPosition{0, 0, 0})
+	assert obstructed
+	assert !self_only
+}
+
+fn test_face_offset_covers_all_six_faces() {
+	pos := types.BlockPosition{5, 5, 5}
+	assert face_offset(pos, 0) == types.BlockPosition{5, 4, 5}
+	assert face_offset(pos, 1) == types.BlockPosition{5, 6, 5}
+	assert face_offset(pos, 2) == types.BlockPosition{5, 5, 4}
+	assert face_offset(pos, 3) == types.BlockPosition{5, 5, 6}
+	assert face_offset(pos, 4) == types.BlockPosition{4, 5, 5}
+	assert face_offset(pos, 5) == types.BlockPosition{6, 5, 5}
+}
+
+fn test_required_break_ticks_formula() {
+	assert required_break_ticks(0.0, 1.0) == 0
+	assert required_break_ticks(0.5, 1.0) == 15
+	assert required_break_ticks(1.5, 2.0) == 23
+}
+
+fn dirt_break_test_session(mut hub Hub, mut transport FakeTransport) &NetworkSession {
+	mut s := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		transport:  transport
+		hub:        hub
+		game_mode:  protocol.game_type_survival
+		generator:  world.FlatGenerator{}
+	}
+	hub.add(s)
+	return s
+}
+
+fn test_break_block_rejects_before_ticks_elapsed() {
+	mut hub := new_hub(gamedata.GameData{})
+	mut transport := &FakeTransport{}
+	mut s := dirt_break_test_session(mut hub, mut transport)
+
+	pos := types.BlockPosition{0, world.overworld.min_y + 1, 0} // dirt layer
+	dirt_id := s.block_at(pos.x, pos.y, pos.z)
+	s.breaking = BreakProgress{pos.x, pos.y, pos.z, dirt_id, 0}
+	hub.current_tick = 0
+
+	s.break_block(pos)!
+	assert transport.sent.len == 1
+	sent := transport.sent[0]
+	if sent is protocol.UpdateBlockPacket {
+		assert sent.block_runtime_id == dirt_id
+	} else {
+		assert false
+	}
+}
+
+fn test_break_block_succeeds_after_ticks_elapsed() {
+	mut hub := new_hub(gamedata.GameData{})
+	target := db.new_world('world', unsafe { nil }, 'flat', world.overworld)
+	hub.add_world(target)
+	mut transport := &FakeTransport{}
+	mut s := dirt_break_test_session(mut hub, mut transport)
+	s.world = target
+
+	pos := types.BlockPosition{0, world.overworld.min_y + 1, 0}
+	dirt_id := s.block_at(pos.x, pos.y, pos.z)
+	s.breaking = BreakProgress{pos.x, pos.y, pos.z, dirt_id, 0}
+	hub.current_tick = 20
+
+	s.break_block(pos)!
+
+	assert target.block_override(pos.x, pos.y, pos.z) or { -1 } == world.air.network_id
+}
+
+fn test_break_block_rejects_mismatched_position() {
+	mut hub := new_hub(gamedata.GameData{})
+	mut transport := &FakeTransport{}
+	mut s := dirt_break_test_session(mut hub, mut transport)
+
+	pos := types.BlockPosition{0, world.overworld.min_y + 1, 0}
+	other_pos := types.BlockPosition{5, world.overworld.min_y + 1, 5}
+	dirt_id := s.block_at(pos.x, pos.y, pos.z)
+	s.breaking = BreakProgress{other_pos.x, other_pos.y, other_pos.z, dirt_id, 0}
+	hub.current_tick = 100
+
+	s.break_block(pos)!
+	assert transport.sent.len == 1
+	sent := transport.sent[0]
+	if sent is protocol.UpdateBlockPacket {
+		assert sent.block_runtime_id == dirt_id
+	} else {
+		assert false
+	}
+}
+
+fn test_break_block_creative_bypasses_gating() {
+	mut hub := new_hub(gamedata.GameData{})
+	target := db.new_world('world', unsafe { nil }, 'flat', world.overworld)
+	hub.add_world(target)
+	mut transport := &FakeTransport{}
+	mut s := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		transport:  transport
+		hub:        hub
+		world:      target
+		game_mode:  protocol.game_type_creative
+		generator:  world.FlatGenerator{}
+	}
+	hub.add(s)
+
+	pos := types.BlockPosition{0, world.overworld.min_y + 1, 0}
+	hub.current_tick = 0
+
+	s.break_block(pos)!
+
+	assert target.block_override(pos.x, pos.y, pos.z) or { -1 } == world.air.network_id
+}
+
+fn test_place_resolves_block_from_item_registry() {
+	data := gamedata.GameData{
+		item_id_by_name: {
+			'minecraft:oak_sign': 390
+		}
+	}
+	mut hub := new_hub(data)
+	target := db.new_world('world', unsafe { nil }, 'flat', world.overworld)
+	hub.add_world(target)
+	sign_id :=
+		hub.blocks.get_by_name('minecraft:standing_sign') or { panic('missing sign') }.runtime_id()
+	hub.items.register(item.BlockItem{
+		id:            'minecraft:oak_sign'
+		block_runtime: sign_id
+	})
+	mut transport := &FakeTransport{}
+	mut s := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		transport:  transport
+		hub:        hub
+		world:      target
+		game_mode:  protocol.game_type_creative
+		position:   types.Vector3{2.1901546, -58.37999, 10.302694}
+		generator:  world.FlatGenerator{}
+	}
+	hub.add(s)
+
+	place_packet := protocol.InventoryTransactionPacket{
+		transaction_type: protocol.inventory_transaction_type_use_item
+		use_item:         protocol.UseItemTransactionData{
+			action_type:       protocol.item_use_action_click_block
+			trigger_type:      1
+			block_position:    types.BlockPosition{2, -61, 12}
+			block_face:        1
+			hotbar_slot:       0
+			held_item:         types.ItemStackWrapper{
+				item_stack: types.ItemStack{
+					id:               390
+					count:            16
+					block_runtime_id: 0
+				}
+			}
+			position:          types.Vector3{2.1901546, -58.37999, 10.302694}
+			clicked_position:  types.Vector3{0.35214186, 1.0, 0.20941257}
+			block_runtime_id:  u32(3727763636) // grass_block echo: must NOT BE USED
+			client_prediction: 1
+		}
+	}
+
+	s.handle_inventory_transaction(place_packet)!
+
+	target_id := s.block_at(2, -60, 12)
+	got := hub.blocks.get(target_id) or { panic('placed block not in registry') }
+	assert got is block.SignBlock
+	assert got.identifier() == 'minecraft:standing_sign'
+}
+
+fn test_empty_hand_interact_places_nothing() {
+	mut hub := new_hub(gamedata.GameData{})
+	target := db.new_world('world', unsafe { nil }, 'flat', world.overworld)
+	hub.add_world(target)
+	mut transport := &FakeTransport{}
+	mut s := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		transport:  transport
+		hub:        hub
+		world:      target
+		game_mode:  protocol.game_type_creative
+		position:   types.Vector3{2.1901546, -58.37999, 10.302694}
+		generator:  world.FlatGenerator{}
+	}
+	hub.add(s)
+
+	interact_packet := protocol.InventoryTransactionPacket{
+		transaction_type: protocol.inventory_transaction_type_use_item
+		use_item:         protocol.UseItemTransactionData{
+			action_type:       protocol.item_use_action_click_block
+			trigger_type:      1
+			block_position:    types.BlockPosition{2, -60, 12}
+			block_face:        2
+			hotbar_slot:       3
+			held_item:         types.ItemStackWrapper{
+				item_stack: types.ItemStack{
+					id:               0
+					count:            0
+					block_runtime_id: 0
+				}
+			}
+			position:          types.Vector3{2.1901546, -58.37999, 10.302694}
+			clicked_position:  types.Vector3{0.42559528, 0.7279053, 0.25}
+			block_runtime_id:  u32(2761757297) // nonzero even with empty hand
+			client_prediction: 1
+		}
+	}
+	s.handle_inventory_transaction(interact_packet)!
+
+	assert s.block_at(2, -60, 12) == world.air.network_id
+	assert s.block_at(2, -60, 11) == world.air.network_id
+}

--- a/server/session/combat.v
+++ b/server/session/combat.v
@@ -91,6 +91,60 @@ fn (mut s NetworkSession) handle_attack(target_runtime_id u64) ! {
 	}
 }
 
+// handle_entity_interact runs a UsableOnEntityItem's behaviour when a player
+// uses the held item on an entity (the "interact", as opposed to "attack",
+// use item onentity action) - e.g. milking a cow with an empty bucket.
+fn (mut s NetworkSession) handle_entity_interact(target_runtime_id u64) {
+	if s.dead || !s.can_interact() {
+		return
+	}
+	target := s.hub.entities.by_runtime_id(target_runtime_id) or { return }
+	dx := s.position.x - target.pos.x
+	dy := s.position.y - target.pos.y
+	dz := s.position.z - target.pos.z
+	if dx * dx + dy * dy + dz * dz > max_attack_reach_sq {
+		return
+	}
+	stack, name := s.held_stack_and_name()
+	result := s.hub.items.use_on_entity_result(name, target.identifier, stack.meta) or { return }
+	mut ctx := event.new_context(event.ItemUseData{
+		player:    s
+		item_name: name
+		meta:      stack.meta
+	})
+	s.hub.events.item_use(mut ctx)
+	if ctx.is_cancelled() {
+		return
+	}
+	if result.replaces_with != '' {
+		s.replace_held_item(result.replaces_with)
+	}
+	if result.sound != '' {
+		s.hub.broadcast(&protocol.LevelSoundEventPacket{
+			sound:           result.sound
+			position:        target.pos
+			extra_data:      -1
+			entity_type:     target.identifier
+			actor_unique_id: i64(target.runtime_id)
+		})
+	}
+}
+
+// replace_held_item swaps the held stack for a single new item id, reusing
+// the same slot-bookkeeping primitives consume_held_item uses to decrement.
+fn (mut s NetworkSession) replace_held_item(item_name string) {
+	new_id := s.hub.data.item_id_by_name[item_name] or { return }
+	new_stack := types.ItemStack{
+		id:    new_id
+		count: 1
+	}
+	net_id := s.track_stack(new_stack)
+	s.inv_slots[s.held_slot] = net_id
+	wrapped := wrap_stack_id(new_stack, net_id)
+	s.held_item = wrapped
+	s.send_slot_update(s.held_slot, wrapped)
+}
+
 fn (s &NetworkSession) is_critical() bool {
 	if s.game_mode == protocol.game_type_creative || s.game_mode == protocol.game_type_spectator {
 		return false

--- a/server/session/combat_test.v
+++ b/server/session/combat_test.v
@@ -1,0 +1,392 @@
+module session
+
+import protocol
+import protocol.types
+import server.event
+import server.internal.gamedata
+import server.internal.auth
+import server.world
+
+fn test_is_critical_requires_falling_and_survival() {
+	mut s := &NetworkSession{
+		game_mode: protocol.game_type_survival
+	}
+	s.vy = -0.2
+	assert s.is_critical()
+
+	s.vy = 0.0
+	assert !s.is_critical()
+
+	s.vy = -0.2
+	s.game_mode = protocol.game_type_creative
+	assert !s.is_critical()
+}
+
+fn test_handle_attack_rejects_out_of_reach() {
+	mut hub := new_hub(gamedata.GameData{})
+	mut attacker := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		hub:        hub
+		health:     20
+		position:   types.Vector3{0.0, 0.0, 0.0}
+	}
+	mut victim := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Steve'
+		}
+		runtime_id: 2
+		hub:        hub
+		health:     20
+		spawned:    true
+		position:   types.Vector3{100.0, 0.0, 0.0}
+	}
+	hub.add(attacker)
+	hub.add(victim)
+
+	// Out of reach returns before a DamageJob is ever submitted, so this is
+	// deterministic without needing to poll the actor thread.
+	attacker.handle_attack(2)!
+	assert victim.health == 20
+}
+
+fn test_handle_attack_cancelled_event_does_no_damage() {
+	mut hub := new_hub(gamedata.GameData{})
+	hub.events.register(&CancelAttackHandler{}, .normal)
+	mut attacker := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		hub:        hub
+		health:     20
+		position:   types.Vector3{0.0, 0.0, 0.0}
+	}
+	mut victim := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Steve'
+		}
+		runtime_id: 2
+		hub:        hub
+		health:     20
+		spawned:    true
+		position:   types.Vector3{1.0, 0.0, 0.0}
+	}
+	hub.add(attacker)
+	hub.add(victim)
+
+	attacker.handle_attack(2)!
+	assert victim.health == 20
+}
+
+struct CancelAttackHandler {
+	event.NopHandler
+}
+
+fn (mut h CancelAttackHandler) on_player_attack(mut ctx event.Context[event.AttackData]) {
+	ctx.cancel()
+}
+
+fn test_take_damage_clamps_health_at_zero_and_kills() {
+	mut hub := new_hub(gamedata.GameData{})
+	mut transport := &FakeTransport{}
+	mut victim := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Steve'
+		}
+		runtime_id: 2
+		hub:        hub
+		transport:  transport
+		health:     5
+		game_mode:  protocol.game_type_survival
+	}
+	hub.add(victim)
+
+	victim.take_damage(10.0, 'Alex')
+	assert victim.health == 0
+	assert victim.dead
+}
+
+fn test_take_damage_creative_is_immune() {
+	mut hub := new_hub(gamedata.GameData{})
+	mut victim := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Steve'
+		}
+		runtime_id: 2
+		hub:        hub
+		health:     20
+		game_mode:  protocol.game_type_creative
+	}
+	hub.add(victim)
+
+	victim.take_damage(10.0, 'Alex')
+	assert victim.health == 20
+	assert !victim.dead
+}
+
+fn test_take_damage_cancelled_event_prevents_damage() {
+	mut hub := new_hub(gamedata.GameData{})
+	hub.events.register(&CancelHurtHandler{}, .normal)
+	mut victim := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Steve'
+		}
+		runtime_id: 2
+		hub:        hub
+		health:     20
+		game_mode:  protocol.game_type_survival
+	}
+	hub.add(victim)
+
+	victim.take_damage(10.0, 'Alex')
+	assert victim.health == 20
+	assert !victim.dead
+}
+
+struct CancelHurtHandler {
+	event.NopHandler
+}
+
+fn (mut h CancelHurtHandler) on_player_hurt(mut ctx event.Context[event.HurtData]) {
+	ctx.cancel()
+}
+
+fn test_die_sets_dead_even_when_event_cancelled() {
+	mut hub := new_hub(gamedata.GameData{})
+	hub.events.register(&CancelDeathHandler{}, .normal)
+	mut victim := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Steve'
+		}
+		runtime_id: 2
+		hub:        hub
+		health:     0
+	}
+	hub.add(victim)
+
+	victim.die('%death.attack.player', ['Steve', 'Alex'])
+	// Cancelling the DeathData event only suppresses the death-position/message
+	// broadcast. It never un kills the player (see die() in combat.v).
+	assert victim.dead
+	assert !victim.has_last_death
+}
+
+struct CancelDeathHandler {
+	event.NopHandler
+}
+
+fn (mut h CancelDeathHandler) on_player_death(mut ctx event.Context[event.DeathData]) {
+	ctx.cancel()
+}
+
+fn test_die_records_last_death_position_when_not_cancelled() {
+	mut hub := new_hub(gamedata.GameData{})
+	mut victim := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Steve'
+		}
+		runtime_id: 2
+		hub:        hub
+		health:     0
+		position:   types.Vector3{3.0, 4.0, 5.0}
+	}
+	hub.add(victim)
+
+	victim.die('%death.attack.player', ['Steve', 'Alex'])
+	assert victim.dead
+	assert victim.has_last_death
+	assert victim.last_death_pos == types.Vector3{3.0, 4.0, 5.0}
+}
+
+fn test_respawn_resets_health_and_position() {
+	mut hub := new_hub(gamedata.GameData{})
+	mut transport := &FakeTransport{}
+	mut victim := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Steve'
+		}
+		runtime_id: 2
+		hub:        hub
+		transport:  transport
+		health:     0
+		dead:       true
+		generator:  world.VoidGenerator{}
+		vy:         -1.0
+	}
+	hub.add(victim)
+
+	victim.respawn()
+	assert !victim.dead
+	assert victim.health == 20.0
+	assert victim.vy == 0.0
+	assert victim.position.y == f32(world.VoidGenerator{}.spawn_y()) + player_eye_height
+}
+
+fn test_respawn_is_noop_when_not_dead() {
+	mut hub := new_hub(gamedata.GameData{})
+	mut victim := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Steve'
+		}
+		runtime_id: 2
+		hub:        hub
+		health:     20
+		dead:       false
+		generator:  world.VoidGenerator{}
+	}
+	hub.add(victim)
+
+	victim.respawn()
+	assert victim.health == 20
+}
+
+fn test_apply_knockback_degenerate_case_has_no_horizontal_component() {
+	mut transport := &FakeTransport{}
+	mut s := &NetworkSession{
+		transport: transport
+		position:  types.Vector3{0.0, 0.0, 0.0}
+	}
+	s.apply_knockback(types.Vector3{0.0, 0.0, 0.0})
+	assert transport.sent.len == 1
+	sent := transport.sent[0]
+	if sent is protocol.SetActorMotionPacket {
+		assert sent.motion.x == 0.0
+		assert sent.motion.z == 0.0
+		assert sent.motion.y == knockback_vertical
+	} else {
+		assert false
+	}
+}
+
+fn test_apply_knockback_pushes_away_from_attacker() {
+	mut transport := &FakeTransport{}
+	mut s := &NetworkSession{
+		transport: transport
+		position:  types.Vector3{10.0, 0.0, 0.0}
+	}
+	s.apply_knockback(types.Vector3{0.0, 0.0, 0.0})
+	sent := transport.sent[0]
+	if sent is protocol.SetActorMotionPacket {
+		assert sent.motion.x == knockback_horizontal
+		assert sent.motion.z == 0.0
+	} else {
+		assert false
+	}
+}
+
+fn test_weapon_damage_heuristic_by_tier() {
+	assert weapon_damage_heuristic('minecraft:wooden_sword') == 5.0
+	assert weapon_damage_heuristic('minecraft:stone_sword') == 6.0
+	assert weapon_damage_heuristic('minecraft:iron_sword') == 7.0
+	assert weapon_damage_heuristic('minecraft:diamond_sword') == 8.0
+	assert weapon_damage_heuristic('minecraft:netherite_sword') == 9.0
+}
+
+fn test_weapon_damage_heuristic_axes() {
+	assert weapon_damage_heuristic('minecraft:wooden_axe') == 4.0
+	assert weapon_damage_heuristic('minecraft:iron_axe') == 6.0
+	assert weapon_damage_heuristic('minecraft:netherite_axe') == 8.0
+}
+
+fn test_weapon_damage_heuristic_defaults_to_bare_hand() {
+	assert weapon_damage_heuristic('minecraft:stick') == 1.0
+	assert weapon_damage_heuristic('minecraft:air') == 1.0
+}
+
+fn test_material_tier_by_name_substring() {
+	assert material_tier('minecraft:wooden_sword') == 0
+	assert material_tier('minecraft:stone_pickaxe') == 1
+	assert material_tier('minecraft:iron_axe') == 2
+	assert material_tier('minecraft:diamond_sword') == 3
+	assert material_tier('minecraft:netherite_sword') == 4
+}
+
+fn bucket_test_data() gamedata.GameData {
+	return gamedata.GameData{
+		item_id_by_name: {
+			'minecraft:bucket':      200
+			'minecraft:milk_bucket': 201
+		}
+	}
+}
+
+fn test_handle_entity_interact_milks_cow_with_bucket() {
+	mut hub := new_hub(bucket_test_data())
+	cow_behaviour := hub.entity_registry.create('cow') or { panic('missing cow behaviour') }
+	cow := hub.entities.spawn(cow_behaviour, types.Vector3{1.0, 0.0, 0.0})
+	mut player := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		hub:        hub
+		position:   types.Vector3{0.0, 0.0, 0.0}
+	}
+	hub.add(player)
+	bucket := types.ItemStack{
+		id:    200
+		count: 1
+	}
+	net_id := player.track_stack(bucket)
+	player.inv_slots[0] = net_id
+
+	player.handle_entity_interact(cow.runtime_id)
+
+	held, _ := player.inventory_stack_at(player.held_slot)
+	assert held.id == 201
+}
+
+fn test_handle_entity_interact_non_cow_is_noop() {
+	mut hub := new_hub(bucket_test_data())
+	pig_behaviour := hub.entity_registry.create('pig') or { panic('missing pig behaviour') }
+	pig := hub.entities.spawn(pig_behaviour, types.Vector3{1.0, 0.0, 0.0})
+	mut player := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		hub:        hub
+		position:   types.Vector3{0.0, 0.0, 0.0}
+	}
+	hub.add(player)
+	bucket := types.ItemStack{
+		id:    200
+		count: 1
+	}
+	net_id := player.track_stack(bucket)
+	player.inv_slots[0] = net_id
+
+	player.handle_entity_interact(pig.runtime_id)
+
+	held, _ := player.inventory_stack_at(player.held_slot)
+	assert held.id == 200
+}
+
+fn test_handle_entity_interact_out_of_reach_is_noop() {
+	mut hub := new_hub(bucket_test_data())
+	cow_behaviour := hub.entity_registry.create('cow') or { panic('missing cow behaviour') }
+	cow := hub.entities.spawn(cow_behaviour, types.Vector3{100.0, 0.0, 0.0})
+	mut player := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		hub:        hub
+		position:   types.Vector3{0.0, 0.0, 0.0}
+	}
+	hub.add(player)
+	bucket := types.ItemStack{
+		id:    200
+		count: 1
+	}
+	net_id := player.track_stack(bucket)
+	player.inv_slots[0] = net_id
+
+	player.handle_entity_interact(cow.runtime_id)
+
+	held, _ := player.inventory_stack_at(player.held_slot)
+	assert held.id == 200
+}

--- a/server/session/session.v
+++ b/server/session/session.v
@@ -29,12 +29,24 @@ pub enum State {
 	closed
 }
 
+// BreakProgress tracks the one block a player is currently breaking, armed by
+// handle_start_break and checked in break_block to reject a destroy action
+// that arrives before enough ticks have elapsed for the block's hardness.
+struct BreakProgress {
+	x            int
+	y            int
+	z            int
+	block_id     int
+	started_tick i64
+}
+
 @[heap]
 pub struct NetworkSession {
 mut:
 	transport network.Transport = FakeTransport{}
-	hub       &Hub              = unsafe { nil }
-	state     State             = .handshake
+	breaking  ?BreakProgress
+	hub       &Hub  = unsafe { nil }
+	state     State = .handshake
 	cfg       conf.Config
 	world     &db.World       = unsafe { nil }
 	generator world.Generator = world.VoidGenerator{}
@@ -311,6 +323,8 @@ fn (mut s NetworkSession) handle(p protocol.Packet) ! {
 				s.handle_modal_form_response(p)!
 			} else if p is protocol.BookEditPacket {
 				s.handle_book_edit(p)!
+			} else if p is protocol.BlockActorDataPacket {
+				s.handle_block_actor_data(p)!
 			}
 		}
 		else {}

--- a/server/session/signs.v
+++ b/server/session/signs.v
@@ -1,0 +1,102 @@
+module session
+
+import nbt
+import protocol
+import protocol.types
+import server.block
+
+fn (mut s NetworkSession) handle_block_actor_data(p protocol.BlockActorDataPacket) ! {
+	pos := p.block_position
+	if s.dead || !s.can_interact() {
+		return
+	}
+	if !s.within_place_reach(pos) {
+		return
+	}
+	old_id := s.block_at(pos.x, pos.y, pos.z)
+	b := s.hub.blocks.get(old_id) or { return }
+	if b !is block.SignBlock {
+		return
+	}
+	if p.nbt.tag !is nbt.Compound {
+		return
+	}
+	compound := p.nbt.tag as nbt.Compound
+	text := extract_sign_text(compound) or { return }
+	mut wld := s.current_world()
+	if isnil(wld) {
+		return
+	}
+	wld.set_tile_text(pos.x, pos.y, pos.z, text)
+	s.hub.broadcast(&protocol.BlockActorDataPacket{
+		block_position: pos
+		nbt:            build_sign_nbt(pos.x, pos.y, pos.z, text)
+	})
+}
+
+// extract_sign_text pulls FrontText.Text out of a sign's block-entity NBT
+// compound. Uses `is` checks rather than blind `as` casts since this parses
+// untrusted client input, malformed NBT must be rejected.
+fn extract_sign_text(compound nbt.Compound) ?string {
+	front_tag := compound.get('FrontText') or { return none }
+	if front_tag is nbt.Compound {
+		text_tag := front_tag.get('Text') or { return none }
+		if text_tag is string {
+			return text_tag
+		}
+	}
+	return none
+}
+
+// sign_text_side builds one FrontText/BackText compound.
+fn sign_text_side(text string) nbt.Compound {
+	mut side := nbt.new_compound()
+	side.set('Text', nbt.Tag(text))
+	side.set('TextOwner', nbt.Tag(''))
+	side.set('SignTextColor', nbt.Tag(i32(-16777216))) // opaque black, 0xff000000
+	side.set('IgnoreLighting', nbt.Tag(i8(0)))
+	side.set('PersistFormatting', nbt.Tag(i8(1)))
+	return side
+}
+
+fn build_sign_nbt(x int, y int, z int, text string) nbt.RootTag {
+	mut root := nbt.new_compound()
+	root.set('id', nbt.Tag('Sign'))
+	root.set('x', nbt.Tag(i32(x)))
+	root.set('y', nbt.Tag(i32(y)))
+	root.set('z', nbt.Tag(i32(z)))
+	root.set('IsWaxed', nbt.Tag(i8(0)))
+	root.set('FrontText', nbt.Tag(sign_text_side(text)))
+	root.set('BackText', nbt.Tag(sign_text_side('')))
+	return nbt.RootTag{
+		name: ''
+		tag:  nbt.Tag(root)
+	}
+}
+
+fn (mut s NetworkSession) create_sign_tile(pos types.BlockPosition, runtime_id int) {
+	b := s.hub.blocks.get(runtime_id) or { return }
+	if b !is block.SignBlock {
+		return
+	}
+	mut wld := s.current_world()
+	if isnil(wld) {
+		return
+	}
+	wld.set_tile_text(pos.x, pos.y, pos.z, '')
+	s.hub.broadcast(&protocol.BlockActorDataPacket{
+		block_position: pos
+		nbt:            build_sign_nbt(pos.x, pos.y, pos.z, '')
+	})
+}
+
+fn (mut s NetworkSession) maybe_open_sign_editor(pos types.BlockPosition, runtime_id int) {
+	b := s.hub.blocks.get(runtime_id) or { return }
+	if b !is block.SignBlock {
+		return
+	}
+	s.transport.send(&protocol.OpenSignPacket{
+		block_position: pos
+		front:          true
+	}) or {}
+}

--- a/server/session/signs_test.v
+++ b/server/session/signs_test.v
@@ -1,0 +1,201 @@
+module session
+
+import nbt
+import protocol
+import protocol.types
+import server.internal.gamedata
+import server.internal.auth
+import server.world
+import server.world.db
+
+fn test_build_and_extract_sign_text_roundtrip() {
+	root := build_sign_nbt(1, 2, 3, 'Hello world')
+	compound := root.tag as nbt.Compound
+	text := extract_sign_text(compound) or { panic('expected front text') }
+	assert text == 'Hello world'
+
+	x := compound.get('x') or { panic('missing x') }
+	y := compound.get('y') or { panic('missing y') }
+	z := compound.get('z') or { panic('missing z') }
+	assert x as i32 == i32(1)
+	assert y as i32 == i32(2)
+	assert z as i32 == i32(3)
+}
+
+fn test_extract_sign_text_missing_front_text_is_none() {
+	mut compound := nbt.new_compound()
+	compound.set('id', nbt.Tag('Sign'))
+	if _ := extract_sign_text(compound) {
+		assert false
+	}
+}
+
+fn test_extract_sign_text_wrong_shape_is_none() {
+	mut compound := nbt.new_compound()
+	compound.set('FrontText', nbt.Tag('not a compound'))
+	if _ := extract_sign_text(compound) {
+		assert false
+	}
+}
+
+fn test_maybe_open_sign_editor_sends_for_sign_only() {
+	mut hub := new_hub(gamedata.GameData{})
+	mut transport := &FakeTransport{}
+	mut s := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		transport:  transport
+		hub:        hub
+	}
+	hub.add(s)
+
+	r := s.hub.blocks
+	sign_id := r.get_by_name('minecraft:standing_sign') or { panic('missing sign') }.runtime_id()
+	dirt_id := r.get_by_name('minecraft:dirt') or { panic('missing dirt') }.runtime_id()
+
+	s.maybe_open_sign_editor(types.BlockPosition{0, 0, 0}, sign_id)
+	assert transport.sent.len == 1
+	sent := transport.sent[0]
+	if sent is protocol.OpenSignPacket {
+		assert sent.front
+	} else {
+		assert false
+	}
+
+	s.maybe_open_sign_editor(types.BlockPosition{1, 0, 0}, dirt_id)
+	assert transport.sent.len == 1 // unchanged - dirt isn't a sign
+}
+
+fn test_handle_block_actor_data_persists_and_broadcasts_text() {
+	mut hub := new_hub(gamedata.GameData{})
+	target := db.new_world('world', unsafe { nil }, 'flat', world.overworld)
+	hub.add_world(target)
+	mut transport := &FakeTransport{}
+	mut s := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		transport:  transport
+		hub:        hub
+		world:      target
+		position:   types.Vector3{0.5, player_eye_height, 0.5}
+		generator:  world.VoidGenerator{}
+	}
+	hub.add(s)
+
+	sign_id :=
+		s.hub.blocks.get_by_name('minecraft:standing_sign') or { panic('missing sign') }.runtime_id()
+	pos := types.BlockPosition{0, 0, 0}
+	target.set_block(pos.x, pos.y, pos.z, sign_id)
+
+	s.handle_block_actor_data(protocol.BlockActorDataPacket{
+		block_position: pos
+		nbt:            build_sign_nbt(pos.x, pos.y, pos.z, 'Welcome!')
+	})!
+
+	assert target.tile_text(pos.x, pos.y, pos.z) or { '' } == 'Welcome!'
+	assert transport.sent.len == 1
+	sent := transport.sent[0]
+	if sent is protocol.BlockActorDataPacket {
+		compound := sent.nbt.tag as nbt.Compound
+		text := extract_sign_text(compound) or { panic('expected text') }
+		assert text == 'Welcome!'
+	} else {
+		assert false
+	}
+}
+
+fn test_handle_block_actor_data_ignores_non_sign_block() {
+	mut hub := new_hub(gamedata.GameData{})
+	target := db.new_world('world', unsafe { nil }, 'flat', world.overworld)
+	hub.add_world(target)
+	mut transport := &FakeTransport{}
+	mut s := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		transport:  transport
+		hub:        hub
+		world:      target
+		position:   types.Vector3{0.5, player_eye_height, 0.5}
+		generator:  world.VoidGenerator{}
+	}
+	hub.add(s)
+
+	dirt_id := s.hub.blocks.get_by_name('minecraft:dirt') or { panic('missing dirt') }.runtime_id()
+	pos := types.BlockPosition{0, 0, 0}
+	target.set_block(pos.x, pos.y, pos.z, dirt_id)
+
+	s.handle_block_actor_data(protocol.BlockActorDataPacket{
+		block_position: pos
+		nbt:            build_sign_nbt(pos.x, pos.y, pos.z, 'Should not be saved')
+	})!
+
+	if _ := target.tile_text(pos.x, pos.y, pos.z) {
+		assert false
+	}
+	assert transport.sent.len == 0
+}
+
+fn test_create_sign_tile_initializes_empty_text_and_broadcasts() {
+	mut hub := new_hub(gamedata.GameData{})
+	target := db.new_world('world', unsafe { nil }, 'flat', world.overworld)
+	hub.add_world(target)
+	mut transport := &FakeTransport{}
+	mut s := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		transport:  transport
+		hub:        hub
+		world:      target
+	}
+	hub.add(s)
+
+	sign_id :=
+		s.hub.blocks.get_by_name('minecraft:standing_sign') or { panic('missing sign') }.runtime_id()
+	pos := types.BlockPosition{5, 5, 5}
+
+	s.create_sign_tile(pos, sign_id)
+
+	assert target.tile_text(pos.x, pos.y, pos.z) or { 'missing' } == ''
+	assert transport.sent.len == 1
+	sent := transport.sent[0]
+	if sent is protocol.BlockActorDataPacket {
+		assert sent.block_position == pos
+	} else {
+		assert false
+	}
+}
+
+fn test_create_sign_tile_ignores_non_sign_block() {
+	mut hub := new_hub(gamedata.GameData{})
+	target := db.new_world('world', unsafe { nil }, 'flat', world.overworld)
+	hub.add_world(target)
+	mut transport := &FakeTransport{}
+	mut s := &NetworkSession{
+		identity:   auth.Identity{
+			display_name: 'Alex'
+		}
+		runtime_id: 1
+		transport:  transport
+		hub:        hub
+		world:      target
+	}
+	hub.add(s)
+
+	dirt_id := s.hub.blocks.get_by_name('minecraft:dirt') or { panic('missing dirt') }.runtime_id()
+	pos := types.BlockPosition{5, 5, 5}
+
+	s.create_sign_tile(pos, dirt_id)
+
+	if _ := target.tile_text(pos.x, pos.y, pos.z) {
+		assert false
+	}
+	assert transport.sent.len == 0
+}

--- a/server/session/spawn.v
+++ b/server/session/spawn.v
@@ -308,6 +308,7 @@ fn (mut s NetworkSession) send_needed_chunks(cx int, cz int, radius int) ! {
 		mut chunk := s.generated_chunk(gen, target.x, target.z)
 		apply_overrides(mut chunk, wld, target.x, target.z)
 		batch << level_chunk_packet(dim, target.x, target.z, chunk)
+		batch << tile_data_packets(wld, target.x, target.z)
 		batch_keys << chunk_cache_key(target.x, target.z)
 		if batch.len >= chunk_send_batch_size {
 			s.transport.send_batch(batch)!
@@ -386,6 +387,23 @@ fn apply_overrides(mut chunk world.Chunk, wld &db.World, cx int, cz int) {
 	}
 }
 
+// tile_data_packets builds one BlockActorDataPacket per tile data entry
+// (currently only sign text) in the given chunk column, so a freshly-loaded
+// chunk shows existing sign text without waiting for a re-edit.
+fn tile_data_packets(wld &db.World, cx int, cz int) []protocol.Packet {
+	mut packets := []protocol.Packet{}
+	if isnil(wld) {
+		return packets
+	}
+	for entry in wld.tile_entries_in_chunk(cx, cz) {
+		packets << &protocol.BlockActorDataPacket{
+			block_position: types.BlockPosition{entry.x, entry.y, entry.z}
+			nbt:            build_sign_nbt(entry.x, entry.y, entry.z, entry.text)
+		}
+	}
+	return packets
+}
+
 const subchunk_result_success = u8(1)
 const subchunk_result_invalid_dimension = u8(3)
 const subchunk_result_index_out_of_bounds = u8(5)
@@ -442,6 +460,7 @@ fn (mut s NetworkSession) handle_sub_chunk_request(p protocol.SubChunkRequestPac
 
 	mut entries := []protocol.SubChunkEntry{cap: p.entries.len}
 	mut height_cache := map[u64][]int{}
+	mut tile_sent_columns := map[u64]bool{}
 	for off in p.entries {
 		target_cx := int(p.base_x) + int(off.x_offset)
 		target_cz := int(p.base_z) + int(off.z_offset)
@@ -449,6 +468,12 @@ fn (mut s NetworkSession) handle_sub_chunk_request(p protocol.SubChunkRequestPac
 		mut chunk := s.generated_chunk(gen, target_cx, target_cz)
 		apply_overrides(mut chunk, wld, target_cx, target_cz)
 		cache_key := chunk_cache_key(target_cx, target_cz)
+		if cache_key !in tile_sent_columns {
+			tile_sent_columns[cache_key] = true
+			for pkt in tile_data_packets(wld, target_cx, target_cz) {
+				s.transport.send(pkt) or {}
+			}
+		}
 		height_map := height_cache[cache_key] or {
 			heights := chunk.height_map()
 			height_cache[cache_key] = heights

--- a/server/world/db/tile_data_test.v
+++ b/server/world/db/tile_data_test.v
@@ -1,0 +1,83 @@
+module db
+
+import os
+import server.world
+
+struct TileCollector {
+mut:
+	texts map[string]string
+}
+
+struct RuntimeIdCollector {
+mut:
+	ids map[string]int
+}
+
+fn test_world_store_tile_text_roundtrip() {
+	dir := os.join_path(os.temp_dir(), 'vedrock_tile_db_test')
+	os.rmdir_all(dir) or {}
+	os.rmdir_all(dir + '_overrides') or {}
+	mut store := open_world(dir, world.overworld) or { panic(err) }
+	store.set_block(1, 64, -3, 42)
+	store.set_tile_text(1, 64, -3, 'Hello')
+	store.set_tile_text(5, 5, 5, 'World')
+	mut c := &TileCollector{}
+	store.each_tile(fn [mut c] (x int, y int, z int, text string) {
+		c.texts['${x},${y},${z}'] = text
+	})
+	assert c.texts.len == 2
+	assert c.texts['1,64,-3'] == 'Hello'
+	assert c.texts['5,5,5'] == 'World'
+
+	// each_block must ignore tile prefixed keys and vice versa.
+	mut rc := &RuntimeIdCollector{}
+	store.each_block(fn [mut rc] (x int, y int, z int, runtime_id int) {
+		rc.ids['${x},${y},${z}'] = runtime_id
+	})
+	assert rc.ids.len == 1
+	assert rc.ids['1,64,-3'] == 42
+
+	store.close()
+	os.rmdir_all(dir) or {}
+	os.rmdir_all(dir + '_overrides') or {}
+}
+
+fn test_world_tile_text_and_entries_in_chunk() {
+	mut w := new_world('test', unsafe { nil }, 'flat', world.overworld)
+	w.set_tile_text(1, 5, 2, 'Front line 1')
+	w.set_tile_text(20, 5, 2, 'Other chunk')
+
+	assert w.tile_text(1, 5, 2) or { '' } == 'Front line 1'
+	if _ := w.tile_text(99, 99, 99) {
+		assert false
+	}
+
+	entries := w.tile_entries_in_chunk(0, 0)
+	assert entries.len == 1
+	assert entries[0].x == 1
+	assert entries[0].y == 5
+	assert entries[0].z == 2
+	assert entries[0].text == 'Front line 1'
+
+	other_chunk := w.tile_entries_in_chunk(1, 0)
+	assert other_chunk.len == 1
+	assert other_chunk[0].x == 20
+}
+
+fn test_world_load_restores_tile_data() {
+	dir := os.join_path(os.temp_dir(), 'vedrock_tile_load_test')
+	os.rmdir_all(dir) or {}
+	os.rmdir_all(dir + '_overrides') or {}
+	mut store := open_world(dir, world.overworld) or { panic(err) }
+	store.set_tile_text(3, 4, 5, 'Persisted')
+	store.close()
+
+	mut store2 := open_world(dir, world.overworld) or { panic(err) }
+	mut w := new_world('test', store2, 'flat', world.overworld)
+	w.load()
+	assert w.tile_text(3, 4, 5) or { '' } == 'Persisted'
+	store2.close()
+
+	os.rmdir_all(dir) or {}
+	os.rmdir_all(dir + '_overrides') or {}
+}

--- a/server/world/db/world.v
+++ b/server/world/db/world.v
@@ -39,6 +39,18 @@ fn block_key(x int, y int, z int) []u8 {
 	return b
 }
 
+// tile_key uses the same 13-byte x/y/z layout as block_key with a distinct
+// prefix byte ('t' instead of 'b'), so tile data safely coexists with block
+// overrides in the same LevelDB handle.
+fn tile_key(x int, y int, z int) []u8 {
+	mut b := []u8{}
+	b << u8(`t`)
+	put_i32(mut b, x)
+	put_i32(mut b, y)
+	put_i32(mut b, z)
+	return b
+}
+
 pub fn (w &WorldStore) set_block(x int, y int, z int, runtime_id int) {
 	mut v := []u8{}
 	put_i32(mut v, runtime_id)
@@ -51,6 +63,21 @@ pub fn (w &WorldStore) each_block(cb fn (x int, y int, z int, runtime_id int)) {
 			return
 		}
 		cb(read_i32(key, 1), read_i32(key, 5), read_i32(key, 9), read_i32(value, 0))
+	})
+}
+
+// set_tile_text persists a block-entity's tex at a position, sharing the overrides handle with a distinct key
+// prefix rather than opening a third LevelDB handle for no isolation benefit.
+pub fn (w &WorldStore) set_tile_text(x int, y int, z int, text string) {
+	w.overrides.put(tile_key(x, y, z), text.bytes())
+}
+
+pub fn (w &WorldStore) each_tile(cb fn (x int, y int, z int, text string)) {
+	w.overrides.each(fn [cb] (key []u8, value []u8) {
+		if key.len != 13 || key[0] != u8(`t`) {
+			return
+		}
+		cb(read_i32(key, 1), read_i32(key, 5), read_i32(key, 9), value.bytestr())
 	})
 }
 

--- a/server/world/db/world_instance.v
+++ b/server/world/db/world_instance.v
@@ -126,8 +126,7 @@ pub fn (w &World) overrides_in_chunk(cx int, cz int) []BlockOverride {
 	return out
 }
 
-// set_tile_text stores a position's tile text (currently only signs use
-// this), writing through to the store the same way set_block does.
+// set_tile_text stores a position's tile text, writing through to the store the same way set_block does.
 pub fn (mut w World) set_tile_text(x int, y int, z int, text string) {
 	w.mutex.lock()
 	w.tile_data[override_key(x, y, z)] = TileData{

--- a/server/world/db/world_instance.v
+++ b/server/world/db/world_instance.v
@@ -13,6 +13,7 @@ pub:
 mut:
 	store        &WorldStore = unsafe { nil }
 	overrides    map[string]int
+	tile_data    map[string]TileData
 	mutex        &sync.Mutex = sync.new_mutex()
 	current_tick i64
 	scheduled    []ScheduledEntry
@@ -26,6 +27,22 @@ pub:
 	y  int
 	z  int
 	id int
+}
+
+// TileData is a block-entity's persistent data at a position.
+pub struct TileData {
+pub mut:
+	text string
+}
+
+// TileEntry is a TileData paired with its position, returned by
+// tile_entries_in_chunk for chunk-send enrichment.
+pub struct TileEntry {
+pub:
+	x    int
+	y    int
+	z    int
+	text string
 }
 
 fn override_key(x int, y int, z int) string {
@@ -42,13 +59,19 @@ pub fn new_world(name string, store &WorldStore, generator_name string, dim worl
 	}
 }
 
-// load pulls every persisted block override into the in-memory cache.
+// load pulls every persisted block override and tile data entry into the
+// in-memory cache.
 pub fn (mut w World) load() {
 	if isnil(w.store) {
 		return
 	}
 	w.store.each_block(fn [mut w] (x int, y int, z int, runtime_id int) {
 		w.overrides[override_key(x, y, z)] = runtime_id
+	})
+	w.store.each_tile(fn [mut w] (x int, y int, z int, text string) {
+		w.tile_data[override_key(x, y, z)] = TileData{
+			text: text
+		}
 	})
 }
 
@@ -96,6 +119,53 @@ pub fn (w &World) overrides_in_chunk(cx int, cz int) []BlockOverride {
 				y:  parts[1].int()
 				z:  z
 				id: id
+			}
+		}
+	}
+	m.unlock()
+	return out
+}
+
+// set_tile_text stores a position's tile text (currently only signs use
+// this), writing through to the store the same way set_block does.
+pub fn (mut w World) set_tile_text(x int, y int, z int, text string) {
+	w.mutex.lock()
+	w.tile_data[override_key(x, y, z)] = TileData{
+		text: text
+	}
+	w.mutex.unlock()
+	if !isnil(w.store) {
+		w.store.set_tile_text(x, y, z, text)
+	}
+}
+
+pub fn (w &World) tile_text(x int, y int, z int) ?string {
+	mut m := w.mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	td := w.tile_data[override_key(x, y, z)] or { return none }
+	return td.text
+}
+
+pub fn (w &World) tile_entries_in_chunk(cx int, cz int) []TileEntry {
+	mut out := []TileEntry{}
+	mut m := w.mutex
+	m.lock()
+	for key, td in w.tile_data {
+		parts := key.split(':')
+		if parts.len != 3 {
+			continue
+		}
+		x := parts[0].int()
+		z := parts[2].int()
+		if (x >> 4) == cx && (z >> 4) == cz {
+			out << TileEntry{
+				x:    x
+				y:    parts[1].int()
+				z:    z
+				text: td.text
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Describe what this PR does and why. Keep it focused. -->

## Description

- Added wheat growth via RandomTicker.
- Added sign-tile data.
- Added server side break time gating for block breaking.

### Problems (fixed)

- Block wrote returned before the actor thread applied them, letting a
  fast follow up read see stale state.
- Block placement silently dropped when ItemStack.block_runtime_id is 0
  (confirmed via packet capture, I noted that it affects signs/doors); resolves the block
  form from the item registry instead of trusting client wire fields.

## Checklist
- [x] `v -check .` is clean
- [x] `v test server` is fully green
