### PR TITLE
feat: configurable difficulty via vedrock.yml

### DIFF
--- a/server/conf/conf.v
+++ b/server/conf/conf.v
@@ -31,7 +31,7 @@ pub mut:
 	debug                 bool
 }
 
-const default_file = 'vedrock.yml'
+pub const default_file = 'vedrock.yml'
 
 pub fn load() !Config {
 	return load_from(default_file)
@@ -147,4 +147,32 @@ pub fn difficulty_from_string(s string) int {
 		'hard', 'h', '3' { protocol.difficulty_hard }
 		else { protocol.difficulty_normal }
 	}
+}
+
+// difficulty_name returns the canonical name for a protocol difficulty constant.
+pub fn difficulty_name(value int) string {
+	return match value {
+		protocol.difficulty_peaceful { 'peaceful' }
+		protocol.difficulty_easy { 'easy' }
+		protocol.difficulty_normal { 'normal' }
+		protocol.difficulty_hard { 'hard' }
+		else { 'normal' }
+	}
+}
+
+// update_difficulty_in_file rewrites the difficulty line in a vedrock.yml file.
+pub fn update_difficulty_in_file(path string, new_name string) ! {
+	mut lines := os.read_lines(path)!
+	mut found := false
+	for mut line in lines {
+		if line.starts_with('difficulty:') {
+			line = 'difficulty: "${new_name}"'
+			found = true
+			break
+		}
+	}
+	if !found {
+		return error("difficulty key not found in ${path}")
+	}
+	os.write_file(path, lines.join_lines())!
 }

--- a/server/conf/conf.v
+++ b/server/conf/conf.v
@@ -1,6 +1,7 @@
 module conf
 
 import os
+import protocol
 
 pub struct Config {
 pub mut:
@@ -11,6 +12,7 @@ pub mut:
 	max_players   int    = 20
 	view_distance int    = 8
 	gamemode      string = 'survival'
+	difficulty    string = 'normal'
 	xbox_auth     bool   = true
 	// encryption negotiates Bedrock protocol encryption. Off by default - the
 	// implementation is spec-complete but not yet verified against a real client,
@@ -51,6 +53,7 @@ pub fn load_from(path string) !Config {
 	cfg.max_players = (values['max-players'] or { cfg.max_players.str() }).int()
 	cfg.view_distance = (values['view-distance'] or { cfg.view_distance.str() }).int()
 	cfg.gamemode = values['gamemode'] or { cfg.gamemode }
+	cfg.difficulty = values['difficulty'] or { cfg.difficulty }
 	cfg.xbox_auth = to_bool(values['xbox-auth'] or { cfg.xbox_auth.str() })
 	cfg.encryption = to_bool(values['encryption'] or { cfg.encryption.str() })
 	cfg.compression_threshold = (values['compression-threshold'] or {
@@ -111,6 +114,7 @@ port: ${cfg.port}
 max-players: ${cfg.max_players}
 view-distance: ${cfg.view_distance}
 gamemode: "${cfg.gamemode}"
+difficulty: "${cfg.difficulty}"
 xbox-auth: ${cfg.xbox_auth}
 encryption: ${cfg.encryption}
 compression-threshold: ${cfg.compression_threshold}
@@ -131,4 +135,16 @@ debug: ${cfg.debug}
 
 pub fn (c &Config) bind_address() string {
 	return '${c.address}:${c.port}'
+}
+
+// difficulty_from_string maps a human-readable difficulty name to its protocol
+// constant. Unknown values fall back to normal.
+pub fn difficulty_from_string(s string) int {
+	return match s.to_lower() {
+		'peaceful', 'p', '0' { protocol.difficulty_peaceful }
+		'easy', 'e', '1' { protocol.difficulty_easy }
+		'normal', 'n', '2' { protocol.difficulty_normal }
+		'hard', 'h', '3' { protocol.difficulty_hard }
+		else { protocol.difficulty_normal }
+	}
 }

--- a/server/server.v
+++ b/server/server.v
@@ -127,6 +127,7 @@ pub fn new(cfg conf.Config) &Server {
 	log.info('Loaded ${data.item_entries.len} items and ${data.creative_items.len} creative entries')
 	mut hub := session.new_hub(data)
 	hub.lang = lang
+	hub.difficulty = conf.difficulty_from_string(cfg.difficulty)
 	hub.ops = permission.load_ops(permission.default_ops_file) or {
 		log.warn('Failed to load ops file: ${err}')
 		permission.OpList{}

--- a/server/server.v
+++ b/server/server.v
@@ -128,6 +128,7 @@ pub fn new(cfg conf.Config) &Server {
 	mut hub := session.new_hub(data)
 	hub.lang = lang
 	hub.difficulty = conf.difficulty_from_string(cfg.difficulty)
+	hub.conf_file = conf.default_file
 	hub.ops = permission.load_ops(permission.default_ops_file) or {
 		log.warn('Failed to load ops file: ${err}')
 		permission.OpList{}

--- a/server/session/difficulty.v
+++ b/server/session/difficulty.v
@@ -1,6 +1,7 @@
 module session
 
 import protocol
+import server.conf
 
 struct SetDifficultyJob {
 	value int
@@ -11,6 +12,9 @@ fn (j SetDifficultyJob) run(mut h Hub) {
 	h.broadcast(&protocol.SetDifficultyPacket{
 		difficulty: j.value
 	})
+	conf.update_difficulty_in_file(h.conf_file, conf.difficulty_name(j.value)) or {
+		eprintln('Failed to persist difficulty to ${h.conf_file}: ${err}')
+	}
 }
 
 pub fn (mut s NetworkSession) set_difficulty(value int) {

--- a/server/session/hub.v
+++ b/server/session/hub.v
@@ -66,6 +66,9 @@ pub mut:
 	player_grants   permission.PlayerGrants
 	whitelist       permission.Whitelist
 	difficulty int = protocol.difficulty_easy
+	// conf_file is the path to vedrock.yml so runtime difficulty changes can
+	// persist across restarts.
+	conf_file string
 }
 
 pub fn (mut h Hub) tps() f64 {

--- a/server/session/hub.v
+++ b/server/session/hub.v
@@ -65,7 +65,6 @@ pub mut:
 	ops             permission.OpList
 	player_grants   permission.PlayerGrants
 	whitelist       permission.Whitelist
-	// needs vedrock.yml storage.
 	difficulty int = protocol.difficulty_easy
 }
 

--- a/server/session/spawn.v
+++ b/server/session/spawn.v
@@ -120,6 +120,9 @@ fn (mut s NetworkSession) start_game() ! {
 		biome_definitions: []protocol.BiomeDefinition{}
 		string_list:       []string{}
 	})!
+	s.transport.send(&protocol.SetDifficultyPacket{
+		difficulty: s.hub.difficulty
+	})!
 	s.transport.send(&protocol.UpdateAbilitiesPacket{
 		data: s.build_abilities()
 	})!


### PR DESCRIPTION
## Description
Allow server operators to set the world difficulty in `vedrock.yml` instead of the hardcoded `easy` default.

## Changes

- Add `difficulty` field to `conf.Config` (default `"normal"`)
- Add `conf.difficulty_from_string()` — maps peaceful/easy/normal/hard (plus shortcuts p/e/n/h and digits 0–3) to protocol difficulty constants; unknown values fall back to normal
- Add `conf.difficulty_name()` — reverse mapping from protocol constant back to canonical name
- Add `conf.update_difficulty_in_file()` — rewrites the difficulty line in vedrock.yml
- Wire `hub.difficulty` from parsed config in `server.new()`
- Store config file path on Hub (`hub.conf_file`)
- Send `SetDifficultyPacket` in `start_game()` so reconnecting clients get the current difficulty instead of falling back to normal
- Persist runtime difficulty changes (`/difficulty` command) back to vedrock.yml so they survive server restarts
- Remove stale "needs vedrock.yml storage" todo comment on `hub.difficulty`

## Checklist
- [x] `v -check .` is clean
- [x] `v test server` is fully green (62/62)
- [x] Follows the conventions in AGENTS.md (OOP, `pub`/capitalized exports, no import cycles, minimal 
comments)
- [x] Cross-session gameplay state is only mutated on the actor thread (via `hub.submit(...)`)
- [x] No unrelated changes bundled in
