### PR TITLE
feat: per type projectile config, stuck-in block state, proactive mob targeting

### DIFF
--- a/server/entity/behaviour.v
+++ b/server/entity/behaviour.v
@@ -2,6 +2,7 @@ module entity
 
 import math
 import rand
+import protocol.types
 
 // Behaviour drives an Entity's per-tick logic, mirroring dragonfly's Behaviour
 // interface. identifier() returns the network type id used when the entity is
@@ -34,6 +35,13 @@ mut:
 const wander_interval_ticks = i64(100)
 const wander_speed = f32(0.08)
 const hostile_speed = f32(0.14)
+// detection_scan_interval_ticks bounds how often an untargeted HostileBehaviour
+// queries the Host for the nearest player, instead of every tick.
+const detection_scan_interval_ticks = i64(10)
+// give_up_range_multiplier is how much farther than detection_radius a target
+// must drift before a HostileBehaviour drops it, wider than the detect range
+// so a target sitting right at the boundary doesn't flip flop every scan.
+const give_up_range_multiplier = f32(1.5)
 
 // set_wander_velocity picks a new random horizontal direction and walk speed.
 fn set_wander_velocity(mut e Entity, speed f32) {
@@ -50,6 +58,7 @@ fn set_wander_velocity(mut e Entity, speed f32) {
 // rests there between wanders.
 @[heap]
 pub struct PassiveBehaviour {
+pub mut:
 	network_id string
 mut:
 	wander_cooldown i64 = wander_interval_ticks
@@ -71,13 +80,19 @@ pub fn (mut b PassiveBehaviour) tick(mut e Entity, mut host Host) {
 	set_wander_velocity(mut e, wander_speed)
 }
 
-// HostileBehaviour wanders the same way PassiveBehaviour does until
-// on_hurt gives it a target, then chases that runtime id directly.
+// HostileBehaviour wanders the same way PassiveBehaviour does until it either
+// gets hurt (reactive) or spots a player within detection_radius on its own
+// (proactive), then chases that runtime id directly until the target dies,
+// despawns or wanders far enough past detection_radius to give up. However there is no line of sight or sound based
+// detection, just a periodic radius scan.
 @[heap]
 pub struct HostileBehaviour {
-	network_id string
+pub mut:
+	network_id       string
+	detection_radius f32 = 16.0
 mut:
 	wander_cooldown   i64 = wander_interval_ticks
+	scan_cooldown     i64
 	target_runtime_id u64
 	has_target        bool
 }
@@ -92,16 +107,30 @@ pub fn (mut b HostileBehaviour) tick(mut e Entity, mut host Host) {
 			dx := target_pos.x - e.pos.x
 			dz := target_pos.z - e.pos.z
 			dist := math.sqrtf(dx * dx + dz * dz)
-			if dist > 0.2 {
-				e.velocity.x = (dx / dist) * hostile_speed
-				e.velocity.z = (dz / dist) * hostile_speed
-				e.yaw = f32(math.atan2(f64(dz), f64(dx)) * (180.0 / math.pi))
-				e.head_yaw = e.yaw
+			if dist > b.detection_radius * give_up_range_multiplier {
+				b.has_target = false
+			} else {
+				if dist > 0.2 {
+					e.velocity.x = (dx / dist) * hostile_speed
+					e.velocity.z = (dz / dist) * hostile_speed
+					e.yaw = f32(math.atan2(f64(dz), f64(dx)) * (180.0 / math.pi))
+					e.head_yaw = e.yaw
+				}
+				return
 			}
+		} else {
+			// target no longer exists (died, despawned); go back to wandering.
+			b.has_target = false
+		}
+	}
+	b.scan_cooldown--
+	if b.scan_cooldown <= 0 {
+		b.scan_cooldown = detection_scan_interval_ticks
+		if target_runtime_id := host.nearest_player(e.pos, b.detection_radius) {
+			b.has_target = true
+			b.target_runtime_id = target_runtime_id
 			return
 		}
-		// target no longer exists (died, despawned); go back to wandering.
-		b.has_target = false
 	}
 	if !e.on_ground {
 		return
@@ -125,14 +154,21 @@ pub fn (mut b HostileBehaviour) on_hurt(mut e Entity, amount f32, source_runtime
 	b.target_runtime_id = source_runtime_id
 }
 
-// ProjectileBehaviour flies with its initial velocity, despawns when it hits
-// the ground or outlives max_age ticks and deals damage to the first entity or player its path
-// touches.
+// ProjectileBehaviour flies with its initial velocity, deals damage to the
+// first entity or player its path touches and either despawns on its first
+// block collision (survive_block_collision: false, e.g. a snowball) or freezes
+// in place there until max_age (survive_block_collision: true, e.g. an arrow).
 @[heap]
 pub struct ProjectileBehaviour {
-	network_id string
-	max_age    i64 = 100
-	damage     f32
+pub mut:
+	network_id              string
+	max_age                 i64 = 100
+	damage                  f32
+	gravity_accel           f32 = gravity
+	drag_factor             f32 = drag
+	survive_block_collision bool
+mut:
+	stuck bool
 }
 
 pub fn (b &ProjectileBehaviour) identifier() string {
@@ -140,7 +176,15 @@ pub fn (b &ProjectileBehaviour) identifier() string {
 }
 
 pub fn (mut b ProjectileBehaviour) tick(mut e Entity, mut host Host) {
-	if e.age >= b.max_age || (e.on_ground && e.age > 1) {
+	if b.stuck {
+		if e.age >= b.max_age {
+			e.kill()
+		}
+		return
+	}
+	e.gravity_accel = b.gravity_accel
+	e.drag_factor = b.drag_factor
+	if e.age >= b.max_age {
 		e.kill()
 		return
 	}
@@ -149,6 +193,23 @@ pub fn (mut b ProjectileBehaviour) tick(mut e Entity, mut host Host) {
 	}
 	if hit_runtime_id := host.entity_hit_test(e.pos, e.runtime_id) {
 		host.damage_entity(hit_runtime_id, b.damage, e.identifier, e.runtime_id, e.pos)
+		e.kill()
+		return
+	}
+	if e.hit_block {
+		if b.survive_block_collision {
+			// Freeze in place rather than despawn. no_gravity plus a zeroed
+			// velocity makes apply_physics a noop from here on, same effect
+			// as skipping physics for this entity without special casing it
+			// in Manager.tick.
+			b.stuck = true
+			e.no_gravity = true
+			e.velocity = types.Vector3{}
+			return
+		}
+		// hit_block is a superset of on_ground (it also covers hitting a wall
+		// or ceiling), so a nonsurviving projectile now despawns on any axis
+		// collision, not just landing on top.
 		e.kill()
 	}
 }

--- a/server/entity/entity.v
+++ b/server/entity/entity.v
@@ -37,6 +37,9 @@ pub mut:
 	floor_y    f32
 	on_ground  bool
 	no_gravity bool
+	gravity_accel f32 = gravity
+	drag_factor   f32 = drag
+	hit_block  bool
 	health     f32 = 20.0
 	dead       bool
 	age        i64
@@ -121,22 +124,26 @@ pub fn (mut e Entity) teleport(pos types.Vector3) {
 // over ungenerated terrain.
 fn (mut e Entity) apply_physics(mut host Host) {
 	if !e.no_gravity {
-		e.velocity.y -= gravity
+		e.velocity.y -= e.gravity_accel
 	}
-	e.velocity.x *= (1.0 - drag)
-	e.velocity.y *= (1.0 - drag)
-	e.velocity.z *= (1.0 - drag)
+	e.velocity.x *= (1.0 - e.drag_factor)
+	e.velocity.y *= (1.0 - e.drag_factor)
+	e.velocity.z *= (1.0 - e.drag_factor)
+
+	e.hit_block = false
 
 	e.pos.x += e.velocity.x
 	if e.collides(mut host) {
 		e.pos.x -= e.velocity.x
 		e.velocity.x = 0.0
+		e.hit_block = true
 	}
 
 	e.pos.z += e.velocity.z
 	if e.collides(mut host) {
 		e.pos.z -= e.velocity.z
 		e.velocity.z = 0.0
+		e.hit_block = true
 	}
 
 	e.on_ground = false
@@ -151,6 +158,7 @@ fn (mut e Entity) apply_physics(mut host Host) {
 			e.pos.y -= e.velocity.y
 		}
 		e.velocity.y = 0.0
+		e.hit_block = true
 	}
 
 	if e.pos.y <= e.floor_y {

--- a/server/entity/manager.v
+++ b/server/entity/manager.v
@@ -36,6 +36,11 @@ mut:
 	// entity), attributed to source_name/source_runtime_id, with
 	// knockback_from as the origin used to compute knockback direction.
 	damage_entity(runtime_id u64, amount f32, source_name string, source_runtime_id u64, knockback_from types.Vector3)
+	// nearest_player returns the runtime id of the closest connected player
+	// within radius of pos or none if nobody is that close. Used for
+	// proactive mob targeting (HostileBehaviour scanning for a target it
+	// hasn't been hit by yet).
+	nearest_player(pos types.Vector3, radius f32) ?u64
 }
 
 // Manager owns every live non-player Entity. spawn/despawn are safe from any

--- a/server/entity/manager_test.v
+++ b/server/entity/manager_test.v
@@ -21,6 +21,9 @@ mut:
 	damage_calls           int
 	last_damage_runtime_id u64
 	last_damage_amount     f32
+	// players is the settable pool nearest_player searches: keyed by runtime
+	// id, distinct from the generic entity positions map above.
+	players map[u64]types.Vector3
 }
 
 fn block_key(x int, y int, z int) string {
@@ -73,6 +76,28 @@ fn (mut h FakeHost) damage_entity(runtime_id u64, amount f32, source_name string
 	h.damage_calls++
 	h.last_damage_runtime_id = runtime_id
 	h.last_damage_amount = amount
+}
+
+fn (mut h FakeHost) nearest_player(pos types.Vector3, radius f32) ?u64 {
+	radius_sq := radius * radius
+	mut best_rid := u64(0)
+	mut best_dist_sq := radius_sq
+	mut found := false
+	for rid, p in h.players {
+		dx := p.x - pos.x
+		dy := p.y - pos.y
+		dz := p.z - pos.z
+		dist_sq := dx * dx + dy * dy + dz * dz
+		if dist_sq <= best_dist_sq {
+			best_rid = rid
+			best_dist_sq = dist_sq
+			found = true
+		}
+	}
+	if !found {
+		return none
+	}
+	return best_rid
 }
 
 fn test_spawn_registers_and_broadcasts() {
@@ -249,4 +274,111 @@ fn test_entity_heals_from_instant_health_effect() {
 	e.health = 10
 	e.add_effect(mut host, effect.new_instant(effect.instant_health, 1))
 	assert e.health > 10
+}
+
+fn test_projectile_survives_block_collision_and_freezes() {
+	mut host := &FakeHost{}
+	host.set_solid(1, 5, 0) // wall east of the spawn point
+	mut m := new_manager(host)
+	mut e := m.spawn(&ProjectileBehaviour{
+		network_id:              'minecraft:arrow'
+		survive_block_collision: true
+	}, types.Vector3{0.5, 5, 0.5})
+	e.floor_y = 5
+	e.no_gravity = true
+	e.age = 2 // past the spawn tick guard
+	e.set_velocity(types.Vector3{0.5, 0, 0})
+	m.tick() // hits the wall this tick, cancels velocity, flags hit_block
+	m.tick() // behaviour sees hit_block and freezes
+	assert m.count() == 1 // stuck, not despawned
+	stuck_pos := e.pos
+	m.tick()
+	m.tick()
+	assert e.pos.x == stuck_pos.x // frozen in place
+	assert e.velocity.x == 0
+	assert m.count() == 1
+}
+
+fn test_projectile_without_survive_despawns_on_wall_hit() {
+	mut host := &FakeHost{}
+	host.set_solid(1, 5, 0) // wall east of the spawn point
+	mut m := new_manager(host)
+	mut e := m.spawn(&ProjectileBehaviour{
+		network_id:              'minecraft:snowball'
+		survive_block_collision: false
+	}, types.Vector3{0.5, 5, 0.5})
+	e.floor_y = 5
+	e.no_gravity = true
+	e.age = 2
+	e.set_velocity(types.Vector3{0.5, 0, 0})
+	m.tick() // hits the wall this tick, cancels velocity, flags hit_block
+	m.tick() // behaviour sees hit_block and despawns
+	// previously only landing on top (on_ground) despawned a projectile.
+	assert m.count() == 0
+}
+
+fn test_projectile_gravity_is_configurable_per_instance() {
+	mut light_host := &FakeHost{}
+	mut light_m := new_manager(light_host)
+	mut light := light_m.spawn(&ProjectileBehaviour{
+		network_id:    'minecraft:snowball'
+		gravity_accel: 0.03
+	}, types.Vector3{0, 100, 0})
+	light.floor_y = -1000
+	light.age = 2
+
+	mut heavy_host := &FakeHost{}
+	mut heavy_m := new_manager(heavy_host)
+	mut heavy := heavy_m.spawn(&ProjectileBehaviour{
+		network_id:    'minecraft:arrow'
+		gravity_accel: 0.05
+	}, types.Vector3{0, 100, 0})
+	heavy.floor_y = -1000
+	heavy.age = 2
+
+	for _ in 0 .. 20 {
+		light_m.tick()
+		heavy_m.tick()
+	}
+	assert heavy.pos.y < light.pos.y // heavier gravity falls faster
+}
+
+fn test_hostile_behaviour_proactively_targets_nearby_player_without_being_hurt() {
+	mut host := &FakeHost{}
+	// players drives the nearest_player scan; positions drives the
+	// existing entity_position lookup the chase step already uses.
+	// A real Hub resolves both from the same live session, FakeHost keeps
+	// them as two settable maps.
+	host.players[99] = types.Vector3{10, 5, 0}
+	host.positions[99] = types.Vector3{10, 5, 0}
+	mut m := new_manager(host)
+	mut e := m.spawn(&HostileBehaviour{
+		network_id:       'minecraft:zombie'
+		detection_radius: 16.0
+	}, types.Vector3{0, 5, 0})
+	e.floor_y = 5
+	e.no_gravity = true
+	m.tick()
+	m.tick() // target acquired last tick; this tick moves toward it
+	assert e.velocity.x > 0
+}
+
+fn test_hostile_behaviour_gives_up_target_out_of_range() {
+	mut host := &FakeHost{}
+	mut m := new_manager(host)
+	mut e := m.spawn(&HostileBehaviour{
+		network_id:       'minecraft:zombie'
+		detection_radius: 10.0
+	}, types.Vector3{0, 5, 0})
+	e.floor_y = 5
+	e.no_gravity = true
+	e.hurt(mut host, 1, true, 99)
+	host.positions[99] = types.Vector3{9, 5, 0} // within detection_radius * 1.5
+	m.tick()
+	assert e.velocity.x > 0 // still chasing
+
+	host.positions[99] = types.Vector3{100, 5, 0} // far past the giveup range
+	e.set_velocity(types.Vector3{})
+	m.tick()
+	assert e.velocity.x == 0 // gave up, back to wandering
 }

--- a/server/entity/registry.v
+++ b/server/entity/registry.v
@@ -59,7 +59,20 @@ pub fn register_defaults(mut r Registry) {
 	})
 	r.register('snowball', fn () Behaviour {
 		return &ProjectileBehaviour{
-			network_id: 'minecraft:snowball'
+			network_id:              'minecraft:snowball'
+			gravity_accel:           0.03
+			drag_factor:             0.01
+			survive_block_collision: false
+		}
+	})
+	r.register('arrow', fn () Behaviour {
+		return &ProjectileBehaviour{
+			network_id:              'minecraft:arrow'
+			max_age:                 1200
+			damage:                  2.0
+			gravity_accel:           0.05
+			drag_factor:             0.01
+			survive_block_collision: true
 		}
 	})
 }

--- a/server/plugin/api.v
+++ b/server/plugin/api.v
@@ -57,6 +57,9 @@ mut:
 	custom_item_names() []string
 	custom_block_names() []string
 	custom_entity_names() []string
+	// nearest_player_name returns the display name of the closest connected
+	// player within radius of (x, y, z) or none if nobody is that close.
+	nearest_player_name(x f32, y f32, z f32, radius f32) ?string
 }
 
 // Api is the single handle handed to a plugin on enable. Everything a plugin can
@@ -123,4 +126,10 @@ pub fn (mut a Api) register_enchantment(e enchant.Enchantment) bool {
 // next_enchantment_id returns the next free custom enchantment id.
 pub fn (mut a Api) next_enchantment_id() int {
 	return a.server.next_enchantment_id()
+}
+
+// nearest_player_name returns the display name of the closest connected
+// player within radius of (x, y, z) or none if nobody is that close.
+pub fn (mut a Api) nearest_player_name(x f32, y f32, z f32, radius f32) ?string {
+	return a.server.nearest_player_name(x, y, z, radius)
 }

--- a/server/plugin/manager_test.v
+++ b/server/plugin/manager_test.v
@@ -85,6 +85,10 @@ fn (mut v FakeView) custom_entity_names() []string {
 	return []
 }
 
+fn (mut v FakeView) nearest_player_name(x f32, y f32, z f32, radius f32) ?string {
+	return none
+}
+
 struct LoggingPlugin {
 	Base
 mut:

--- a/server/session/entity_view.v
+++ b/server/session/entity_view.v
@@ -57,3 +57,48 @@ pub fn (mut h Hub) damage_entity(runtime_id u64, amount f32, source_name string,
 	}
 	h.entities.damage(runtime_id, amount, true, mut h, source_runtime_id)
 }
+
+pub fn (mut h Hub) nearest_player(pos types.Vector3, radius f32) ?u64 {
+	rid, _, found := h.find_nearest_player(pos, radius)
+	if !found {
+		return none
+	}
+	return rid
+}
+
+// nearest_player_name is the plugin.ServerView facing form of nearest_player.
+// It resolves the runtime id back to a display name rather than leaking the
+// internal runtime id concept into the plugin surface.
+pub fn (mut h Hub) nearest_player_name(x f32, y f32, z f32, radius f32) ?string {
+	rid, _, found := h.find_nearest_player(types.Vector3{x, y, z}, radius)
+	if !found {
+		return none
+	}
+	target := h.session_by_runtime(rid) or { return none }
+	return target.name()
+}
+
+// find_nearest_player scans live sessions for the closest one to pos within
+// radius, returning its runtime id, position and whether anyone was found.
+// Shared by entity.Host's nearest_player (proactive mob targeting) and
+// plugin.ServerView's nearest_player_name.
+fn (mut h Hub) find_nearest_player(pos types.Vector3, radius f32) (u64, types.Vector3, bool) {
+	mut best_rid := u64(0)
+	mut best_pos := types.Vector3{}
+	mut best_dist_sq := radius * radius
+	mut found := false
+	for mut target in h.snapshot() {
+		tp := target.current_position()
+		dx := tp.x - pos.x
+		dy := tp.y - pos.y
+		dz := tp.z - pos.z
+		dist_sq := dx * dx + dy * dy + dz * dz
+		if dist_sq <= best_dist_sq {
+			best_rid = target.runtime_id
+			best_pos = tp
+			best_dist_sq = dist_sq
+			found = true
+		}
+	}
+	return best_rid, best_pos, found
+}


### PR DESCRIPTION
<!-- Describe what this PR does and why. Keep it focused. -->

## Description
The entity system had some concrete gaps: projectiles were all identical regardless of type (no way to differ snowball vs. arrow), hitting a block always despawned a projectile immediately (no stuck-in the wall/block state) and hostile mobs only ever reacted to being hit, but they never noticed a nearby player on their own. So this pr addresses them. 

## Checklist
- [x] `v -check .` is clean
- [x] `v test server` is fully green
