### PR TITLE
feat: potions (splash, lingering, drinkable), area effect clouds, and effect particle colours

### DIFF
--- a/server/effect/absorption.v
+++ b/server/effect/absorption.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const absorption = Type{
-	id:      22
-	name:    'absorption'
-	lasting: true
+	id:       22
+	name:     'absorption'
+	lasting:  true
+	rgb:      [u8(0x25), u8(0x52), u8(0xa5)]!
+	category: .beneficial
 }

--- a/server/effect/blindness.v
+++ b/server/effect/blindness.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const blindness = Type{
-	id:      15
-	name:    'blindness'
-	lasting: true
+	id:       15
+	name:     'blindness'
+	lasting:  true
+	rgb:      [u8(0x1f), u8(0x1f), u8(0x23)]!
+	category: .harmful
 }

--- a/server/effect/conduit_power.v
+++ b/server/effect/conduit_power.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const conduit_power = Type{
-	id:      26
-	name:    'conduit_power'
-	lasting: true
+	id:       26
+	name:     'conduit_power'
+	lasting:  true
+	rgb:      [u8(0x1d), u8(0xc2), u8(0xd1)]!
+	category: .beneficial
 }

--- a/server/effect/darkness.v
+++ b/server/effect/darkness.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const darkness = Type{
-	id:      30
-	name:    'darkness'
-	lasting: true
+	id:       30
+	name:     'darkness'
+	lasting:  true
+	rgb:      [u8(0x29), u8(0x27), u8(0x21)]!
+	category: .harmful
 }

--- a/server/effect/effect.v
+++ b/server/effect/effect.v
@@ -25,7 +25,7 @@ pub:
 // colour returns the RGB value packed into an ARGB int (A=0xFF), suitable for
 // entity metadata.
 pub fn (t Type) colour() int {
-	return int(u32(0xff) << 24 | u32(t.rgb[0]) << 16 | u32(t.rgb[1]) << 8 | u32(t.rgb[2]))
+	return int(u32(t.rgb[0]) << 16 | u32(t.rgb[1]) << 8 | u32(t.rgb[2]))
 }
 
 // blend_colour averages the RGB colours of all lasting effects and returns a single
@@ -55,7 +55,8 @@ pub fn blend_colour(effects []Effect) int {
 	r := u8(r_sum / count)
 	g := u8(g_sum / count)
 	b := u8(b_sum / count)
-	return int(u32(0xff) << 24 | u32(r) << 16 | u32(g) << 8 | u32(b))
+	// Bedrock EFFECT_COLOR metadata uses 24-bit RGB (no alpha).
+	return int(u32(r) << 16 | u32(g) << 8 | u32(b))
 }
 
 // any_ambient reports whether any of the active effects has its ambient flag set.
@@ -67,6 +68,17 @@ pub fn any_ambient(effects []Effect) bool {
 		}
 	}
 	return false
+}
+
+// rgb_from_colour unpacks a packed ARGB/RGB int into separate u8 components.
+pub fn rgb_from_colour(c int) (u8, u8, u8) {
+	return u8((c >> 16) & 0xff), u8((c >> 8) & 0xff), u8(c & 0xff)
+}
+
+// mobspell_molang_json builds the Molang variable JSON for the mobspell_emitter
+// particle colour. Format: array of {name, value} with float RGB in [0,1].
+pub fn mobspell_molang_json(r u8, g u8, b u8) string {
+	return '[{"name":"variable.color","value":{"0":${f64(r) / 255.0},"1":${f64(g) / 255.0},"2":${f64(b) / 255.0},"3":1.0}}]'
 }
 
 pub struct Effect {

--- a/server/effect/effect.v
+++ b/server/effect/effect.v
@@ -70,17 +70,6 @@ pub fn any_ambient(effects []Effect) bool {
 	return false
 }
 
-// rgb_from_colour unpacks a packed ARGB/RGB int into separate u8 components.
-pub fn rgb_from_colour(c int) (u8, u8, u8) {
-	return u8((c >> 16) & 0xff), u8((c >> 8) & 0xff), u8(c & 0xff)
-}
-
-// mobspell_molang_json builds the Molang variable JSON for the mobspell_emitter
-// particle colour. Format: array of {name, value} with float RGB in [0,1].
-pub fn mobspell_molang_json(r u8, g u8, b u8) string {
-	return '[{"name":"variable.color","value":{"0":${f64(r) / 255.0},"1":${f64(g) / 255.0},"2":${f64(b) / 255.0},"3":1.0}}]'
-}
-
 pub struct Effect {
 mut:
 	typ              Type

--- a/server/effect/effect.v
+++ b/server/effect/effect.v
@@ -5,11 +5,68 @@ import time
 pub const ticks_per_second = 20
 const tick_duration = time.second / ticks_per_second
 
+// Category labels whether an effect is helpful, harmful, or neither.
+// Used for UI tinting and for colour-blend weighting.
+pub enum Category {
+	beneficial
+	harmful
+	neutral
+}
+
 pub struct Type {
 pub:
-	id      int
-	name    string
-	lasting bool
+	id       int
+	name     string
+	lasting  bool
+	rgb      [3]u8
+	category Category = .neutral
+}
+
+// colour returns the RGB value packed into an ARGB int (A=0xFF), suitable for
+// entity metadata.
+pub fn (t Type) colour() int {
+	return int(u32(0xff) << 24 | u32(t.rgb[0]) << 16 | u32(t.rgb[1]) << 8 | u32(t.rgb[2]))
+}
+
+// blend_colour averages the RGB colours of all lasting effects and returns a single
+// packed ARGB int. Returns 0 when effects is empty or none of the effects have
+// visible potion particles — the client hides particles when the colour is 0.
+// https://minecraft.fandom.com/fr/wiki/Effet#Particules
+pub fn blend_colour(effects []Effect) int {
+	if effects.len == 0 {
+		return 0
+	}
+	mut r_sum := 0
+	mut g_sum := 0
+	mut b_sum := 0
+	mut count := 0
+	for e in effects {
+		if !e.effect_type().lasting || e.particles_hidden {
+			continue
+		}
+		r_sum += int(e.typ.rgb[0])
+		g_sum += int(e.typ.rgb[1])
+		b_sum += int(e.typ.rgb[2])
+		count++
+	}
+	if count == 0 {
+		return 0
+	}
+	r := u8(r_sum / count)
+	g := u8(g_sum / count)
+	b := u8(b_sum / count)
+	return int(u32(0xff) << 24 | u32(r) << 16 | u32(g) << 8 | u32(b))
+}
+
+// any_ambient reports whether any of the active effects has its ambient flag set.
+// Drives the entity metadata flag that dims potion particles (beacon style).
+pub fn any_ambient(effects []Effect) bool {
+	for e in effects {
+		if e.ambient {
+			return true
+		}
+	}
+	return false
 }
 
 pub struct Effect {

--- a/server/effect/effect.v
+++ b/server/effect/effect.v
@@ -30,7 +30,7 @@ pub fn (t Type) colour() int {
 
 // blend_colour averages the RGB colours of all lasting effects and returns a single
 // packed ARGB int. Returns 0 when effects is empty or none of the effects have
-// visible potion particles — the client hides particles when the colour is 0.
+// visible potion particles  -  the client hides particles when the colour is 0.
 // https://minecraft.fandom.com/fr/wiki/Effet#Particules
 pub fn blend_colour(effects []Effect) int {
 	if effects.len == 0 {

--- a/server/effect/effect.v
+++ b/server/effect/effect.v
@@ -117,6 +117,16 @@ pub fn new_instant_with_potency(typ Type, level int, potency f64) Effect {
 	}
 }
 
+// new_with_ticks creates a lasting effect with a duration expressed in ticks
+// instead of a time.Duration. Used when scaling durations, e.g. splash potions.
+pub fn new_with_ticks(typ Type, level int, ticks int) Effect {
+	return Effect{
+		typ:            typ
+		level:          level
+		duration_ticks: ticks
+	}
+}
+
 pub fn (e Effect) without_particles() Effect {
 	mut out := e
 	out.particles_hidden = true

--- a/server/effect/effect_test.v
+++ b/server/effect/effect_test.v
@@ -53,3 +53,58 @@ fn test_instant_effect_is_not_stored() {
 	assert e.instant()
 	assert m.effects().len == 0
 }
+
+fn test_type_colour_packs_argb() {
+	assert speed.colour() == 0xff33ebff
+	assert instant_health.colour() == 0xfff82423
+	assert darkness.colour() == 0xff292721
+}
+
+fn test_blend_colour_averages_rgb() {
+	// RGBs: speed (0x33,0xeb,0xff), slowness (0x5a,0x6c,0x81)
+	// avg: ((51+90)/2, (235+108)/2, (255+129)/2) = (70, 171, 192) = 0x46ABC0
+	e1 := new(speed, 1, 1 * time.second)
+	e2 := new(slowness, 1, 1 * time.second)
+	c := blend_colour([e1, e2])
+	assert c == 0xff46abc0
+}
+
+fn test_blend_colour_empty_returns_zero() {
+	assert blend_colour([]Effect{}) == 0
+}
+
+fn test_blend_colour_skips_non_lasting() {
+	// Only instant effects - should return 0 since particles don't persist.
+	e := new_instant(instant_health, 1)
+	assert blend_colour([e]) == 0
+}
+
+fn test_blend_colour_skips_hidden_particles() {
+	mut e := new(speed, 1, 1 * time.second)
+	ep := e.without_particles()
+	// Only hidden-particles effects: colour should be 0.
+	assert blend_colour([ep]) == 0
+	// Mix of visible and hidden: visible wins.
+	c := blend_colour([e, ep])
+	assert c == speed.colour()
+}
+
+fn test_any_ambient_detects_ambient_flag() {
+	assert !any_ambient([]Effect{})
+	e := new(speed, 1, 1 * time.second)
+	assert !any_ambient([e])
+	ea := new_ambient(speed, 1, 1 * time.second)
+	assert any_ambient([ea])
+}
+
+fn test_type_has_rgb_and_category() {
+	assert speed.rgb[0] == u8(0x33)
+	assert speed.rgb[1] == u8(0xeb)
+	assert speed.rgb[2] == u8(0xff)
+	assert speed.category == .beneficial
+	assert slowness.category == .harmful
+	assert instant_health.category == .beneficial
+	assert instant_damage.category == .harmful
+	assert wither.category == .harmful
+	assert regeneration.category == .beneficial
+}

--- a/server/effect/effect_test.v
+++ b/server/effect/effect_test.v
@@ -61,12 +61,12 @@ fn test_type_colour_packs_argb() {
 }
 
 fn test_blend_colour_averages_rgb() {
-	// RGBs: speed (0x33,0xeb,0xff), slowness (0x5a,0x6c,0x81)
-	// avg: ((51+90)/2, (235+108)/2, (255+129)/2) = (70, 171, 192) = 0x46ABC0
+	// RGBs: speed (0x33,0xeb,0xff), slowness (0x8b,0xaf,0xe0)
+	// avg: ((51+139)/2, (235+175)/2, (255+224)/2) = (95, 205, 239) = 0x5FCDEF
 	e1 := new(speed, 1, 1 * time.second)
 	e2 := new(slowness, 1, 1 * time.second)
 	c := blend_colour([e1, e2])
-	assert c == 0xff46abc0
+	assert c == 0xff5fcdef
 }
 
 fn test_blend_colour_empty_returns_zero() {

--- a/server/effect/effect_test.v
+++ b/server/effect/effect_test.v
@@ -55,9 +55,9 @@ fn test_instant_effect_is_not_stored() {
 }
 
 fn test_type_colour_packs_argb() {
-	assert speed.colour() == 0xff33ebff
-	assert instant_health.colour() == 0xfff82423
-	assert darkness.colour() == 0xff292721
+	assert speed.colour() == 0x0033ebff
+	assert instant_health.colour() == 0x00f82423
+	assert darkness.colour() == 0x00292721
 }
 
 fn test_blend_colour_averages_rgb() {
@@ -66,7 +66,7 @@ fn test_blend_colour_averages_rgb() {
 	e1 := new(speed, 1, 1 * time.second)
 	e2 := new(slowness, 1, 1 * time.second)
 	c := blend_colour([e1, e2])
-	assert c == 0xff5fcdef
+	assert c == 0x005fcdef
 }
 
 fn test_blend_colour_empty_returns_zero() {

--- a/server/effect/fatal_poison.v
+++ b/server/effect/fatal_poison.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const fatal_poison = Type{
-	id:      25
-	name:    'fatal_poison'
-	lasting: true
+	id:       25
+	name:     'fatal_poison'
+	lasting:  true
+	rgb:      [u8(0x4e), u8(0x93), u8(0x31)]!
+	category: .harmful
 }

--- a/server/effect/fire_resistance.v
+++ b/server/effect/fire_resistance.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const fire_resistance = Type{
-	id:      12
-	name:    'fire_resistance'
-	lasting: true
+	id:       12
+	name:     'fire_resistance'
+	lasting:  true
+	rgb:      [u8(0xe4), u8(0x9a), u8(0x3a)]!
+	category: .beneficial
 }

--- a/server/effect/fire_resistance.v
+++ b/server/effect/fire_resistance.v
@@ -4,6 +4,6 @@ pub const fire_resistance = Type{
 	id:       12
 	name:     'fire_resistance'
 	lasting:  true
-	rgb:      [u8(0xe4), u8(0x9a), u8(0x3a)]!
+	rgb:      [u8(0xff), u8(0x99), u8(0x00)]!
 	category: .beneficial
 }

--- a/server/effect/haste.v
+++ b/server/effect/haste.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const haste = Type{
-	id:      3
-	name:    'haste'
-	lasting: true
+	id:       3
+	name:     'haste'
+	lasting:  true
+	rgb:      [u8(0xd9), u8(0xc0), u8(0x43)]!
+	category: .beneficial
 }

--- a/server/effect/health_boost.v
+++ b/server/effect/health_boost.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const health_boost = Type{
-	id:      21
-	name:    'health_boost'
-	lasting: true
+	id:       21
+	name:     'health_boost'
+	lasting:  true
+	rgb:      [u8(0xf8), u8(0x7d), u8(0x23)]!
+	category: .beneficial
 }

--- a/server/effect/hunger.v
+++ b/server/effect/hunger.v
@@ -4,6 +4,6 @@ pub const hunger = Type{
 	id:       17
 	name:     'hunger'
 	lasting:  true
-	rgb:      [u8(0x4a), u8(0x76), u8(0x2d)]!
+	rgb:      [u8(0x58), u8(0x76), u8(0x53)]!
 	category: .harmful
 }

--- a/server/effect/hunger.v
+++ b/server/effect/hunger.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const hunger = Type{
-	id:      17
-	name:    'hunger'
-	lasting: true
+	id:       17
+	name:     'hunger'
+	lasting:  true
+	rgb:      [u8(0x4a), u8(0x76), u8(0x2d)]!
+	category: .harmful
 }

--- a/server/effect/instant_damage.v
+++ b/server/effect/instant_damage.v
@@ -3,6 +3,6 @@ module effect
 pub const instant_damage = Type{
 	id:       7
 	name:     'instant_damage'
-	rgb:      [u8(0x43), u8(0x0a), u8(0x09)]!
+	rgb:      [u8(0xa9), u8(0x65), u8(0x6a)]!
 	category: .harmful
 }

--- a/server/effect/instant_damage.v
+++ b/server/effect/instant_damage.v
@@ -1,6 +1,8 @@
 module effect
 
 pub const instant_damage = Type{
-	id:   7
-	name: 'instant_damage'
+	id:       7
+	name:     'instant_damage'
+	rgb:      [u8(0x43), u8(0x0a), u8(0x09)]!
+	category: .harmful
 }

--- a/server/effect/instant_health.v
+++ b/server/effect/instant_health.v
@@ -1,6 +1,8 @@
 module effect
 
 pub const instant_health = Type{
-	id:   6
-	name: 'instant_health'
+	id:       6
+	name:     'instant_health'
+	rgb:      [u8(0xf8), u8(0x24), u8(0x23)]!
+	category: .beneficial
 }

--- a/server/effect/invisibility.v
+++ b/server/effect/invisibility.v
@@ -4,6 +4,6 @@ pub const invisibility = Type{
 	id:       14
 	name:     'invisibility'
 	lasting:  true
-	rgb:      [u8(0x7f), u8(0x83), u8(0x92)]!
+	rgb:      [u8(0xf6), u8(0xf6), u8(0xf6)]!
 	category: .beneficial
 }

--- a/server/effect/invisibility.v
+++ b/server/effect/invisibility.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const invisibility = Type{
-	id:      14
-	name:    'invisibility'
-	lasting: true
+	id:       14
+	name:     'invisibility'
+	lasting:  true
+	rgb:      [u8(0x7f), u8(0x83), u8(0x92)]!
+	category: .beneficial
 }

--- a/server/effect/jump_boost.v
+++ b/server/effect/jump_boost.v
@@ -4,6 +4,6 @@ pub const jump_boost = Type{
 	id:       8
 	name:     'jump_boost'
 	lasting:  true
-	rgb:      [u8(0x22), u8(0xff), u8(0x4c)]!
+	rgb:      [u8(0xfd), u8(0xff), u8(0x84)]!
 	category: .beneficial
 }

--- a/server/effect/jump_boost.v
+++ b/server/effect/jump_boost.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const jump_boost = Type{
-	id:      8
-	name:    'jump_boost'
-	lasting: true
+	id:       8
+	name:     'jump_boost'
+	lasting:  true
+	rgb:      [u8(0x22), u8(0xff), u8(0x4c)]!
+	category: .beneficial
 }

--- a/server/effect/levitation.v
+++ b/server/effect/levitation.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const levitation = Type{
-	id:      24
-	name:    'levitation'
-	lasting: true
+	id:       24
+	name:     'levitation'
+	lasting:  true
+	rgb:      [u8(0xce), u8(0xff), u8(0xff)]!
+	category: .harmful
 }

--- a/server/effect/mining_fatigue.v
+++ b/server/effect/mining_fatigue.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const mining_fatigue = Type{
-	id:      4
-	name:    'mining_fatigue'
-	lasting: true
+	id:       4
+	name:     'mining_fatigue'
+	lasting:  true
+	rgb:      [u8(0x4a), u8(0x42), u8(0x17)]!
+	category: .harmful
 }

--- a/server/effect/nausea.v
+++ b/server/effect/nausea.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const nausea = Type{
-	id:      9
-	name:    'nausea'
-	lasting: true
+	id:       9
+	name:     'nausea'
+	lasting:  true
+	rgb:      [u8(0x55), u8(0x1d), u8(0x4a)]!
+	category: .harmful
 }

--- a/server/effect/night_vision.v
+++ b/server/effect/night_vision.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const night_vision = Type{
-	id:      16
-	name:    'night_vision'
-	lasting: true
+	id:       16
+	name:     'night_vision'
+	lasting:  true
+	rgb:      [u8(0x1f), u8(0x1f), u8(0xa1)]!
+	category: .beneficial
 }

--- a/server/effect/night_vision.v
+++ b/server/effect/night_vision.v
@@ -4,6 +4,6 @@ pub const night_vision = Type{
 	id:       16
 	name:     'night_vision'
 	lasting:  true
-	rgb:      [u8(0x1f), u8(0x1f), u8(0xa1)]!
+	rgb:      [u8(0xc2), u8(0xff), u8(0x66)]!
 	category: .beneficial
 }

--- a/server/effect/poison.v
+++ b/server/effect/poison.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const poison = Type{
-	id:      19
-	name:    'poison'
-	lasting: true
+	id:       19
+	name:     'poison'
+	lasting:  true
+	rgb:      [u8(0x4e), u8(0x93), u8(0x31)]!
+	category: .harmful
 }

--- a/server/effect/poison.v
+++ b/server/effect/poison.v
@@ -4,6 +4,6 @@ pub const poison = Type{
 	id:       19
 	name:     'poison'
 	lasting:  true
-	rgb:      [u8(0x4e), u8(0x93), u8(0x31)]!
+	rgb:      [u8(0x87), u8(0xa3), u8(0x63)]!
 	category: .harmful
 }

--- a/server/effect/regeneration.v
+++ b/server/effect/regeneration.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const regeneration = Type{
-	id:      10
-	name:    'regeneration'
-	lasting: true
+	id:       10
+	name:     'regeneration'
+	lasting:  true
+	rgb:      [u8(0xcd), u8(0x5c), u8(0xab)]!
+	category: .beneficial
 }

--- a/server/effect/resistance.v
+++ b/server/effect/resistance.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const resistance = Type{
-	id:      11
-	name:    'resistance'
-	lasting: true
+	id:       11
+	name:     'resistance'
+	lasting:  true
+	rgb:      [u8(0x99), u8(0x45), u8(0x3a)]!
+	category: .beneficial
 }

--- a/server/effect/resistance.v
+++ b/server/effect/resistance.v
@@ -4,6 +4,6 @@ pub const resistance = Type{
 	id:       11
 	name:     'resistance'
 	lasting:  true
-	rgb:      [u8(0x99), u8(0x45), u8(0x3a)]!
+	rgb:      [u8(0x91), u8(0x46), u8(0xf0)]!
 	category: .beneficial
 }

--- a/server/effect/saturation.v
+++ b/server/effect/saturation.v
@@ -1,6 +1,8 @@
 module effect
 
 pub const saturation = Type{
-	id:   23
-	name: 'saturation'
+	id:       23
+	name:     'saturation'
+	rgb:      [u8(0xf8), u8(0x24), u8(0x23)]!
+	category: .beneficial
 }

--- a/server/effect/slow_falling.v
+++ b/server/effect/slow_falling.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const slow_falling = Type{
-	id:      27
-	name:    'slow_falling'
-	lasting: true
+	id:       27
+	name:     'slow_falling'
+	lasting:  true
+	rgb:      [u8(0xff), u8(0xef), u8(0xcc)]!
+	category: .beneficial
 }

--- a/server/effect/slow_falling.v
+++ b/server/effect/slow_falling.v
@@ -4,6 +4,6 @@ pub const slow_falling = Type{
 	id:       27
 	name:     'slow_falling'
 	lasting:  true
-	rgb:      [u8(0xff), u8(0xef), u8(0xcc)]!
+	rgb:      [u8(0xf3), u8(0xcf), u8(0xb9)]!
 	category: .beneficial
 }

--- a/server/effect/slowness.v
+++ b/server/effect/slowness.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const slowness = Type{
-	id:      2
-	name:    'slowness'
-	lasting: true
+	id:       2
+	name:     'slowness'
+	lasting:  true
+	rgb:      [u8(0x5a), u8(0x6c), u8(0x81)]!
+	category: .harmful
 }

--- a/server/effect/slowness.v
+++ b/server/effect/slowness.v
@@ -4,6 +4,6 @@ pub const slowness = Type{
 	id:       2
 	name:     'slowness'
 	lasting:  true
-	rgb:      [u8(0x5a), u8(0x6c), u8(0x81)]!
+	rgb:      [u8(0x8b), u8(0xaf), u8(0xe0)]!
 	category: .harmful
 }

--- a/server/effect/speed.v
+++ b/server/effect/speed.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const speed = Type{
-	id:      1
-	name:    'speed'
-	lasting: true
+	id:       1
+	name:     'speed'
+	lasting:  true
+	rgb:      [u8(0x33), u8(0xeb), u8(0xff)]!
+	category: .beneficial
 }

--- a/server/effect/strength.v
+++ b/server/effect/strength.v
@@ -4,6 +4,6 @@ pub const strength = Type{
 	id:       5
 	name:     'strength'
 	lasting:  true
-	rgb:      [u8(0x93), u8(0x24), u8(0x23)]!
+	rgb:      [u8(0xff), u8(0xc7), u8(0x00)]!
 	category: .beneficial
 }

--- a/server/effect/strength.v
+++ b/server/effect/strength.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const strength = Type{
-	id:      5
-	name:    'strength'
-	lasting: true
+	id:       5
+	name:     'strength'
+	lasting:  true
+	rgb:      [u8(0x93), u8(0x24), u8(0x23)]!
+	category: .beneficial
 }

--- a/server/effect/water_breathing.v
+++ b/server/effect/water_breathing.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const water_breathing = Type{
-	id:      13
-	name:    'water_breathing'
-	lasting: true
+	id:       13
+	name:     'water_breathing'
+	lasting:  true
+	rgb:      [u8(0x2e), u8(0x52), u8(0x99)]!
+	category: .beneficial
 }

--- a/server/effect/water_breathing.v
+++ b/server/effect/water_breathing.v
@@ -4,6 +4,6 @@ pub const water_breathing = Type{
 	id:       13
 	name:     'water_breathing'
 	lasting:  true
-	rgb:      [u8(0x2e), u8(0x52), u8(0x99)]!
+	rgb:      [u8(0x98), u8(0xda), u8(0xc0)]!
 	category: .beneficial
 }

--- a/server/effect/weakness.v
+++ b/server/effect/weakness.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const weakness = Type{
-	id:      18
-	name:    'weakness'
-	lasting: true
+	id:       18
+	name:     'weakness'
+	lasting:  true
+	rgb:      [u8(0x48), u8(0x4d), u8(0x48)]!
+	category: .harmful
 }

--- a/server/effect/wither.v
+++ b/server/effect/wither.v
@@ -1,7 +1,9 @@
 module effect
 
 pub const wither = Type{
-	id:      20
-	name:    'wither'
-	lasting: true
+	id:       20
+	name:     'wither'
+	lasting:  true
+	rgb:      [u8(0x35), u8(0x2a), u8(0x27)]!
+	category: .harmful
 }

--- a/server/effect/wither.v
+++ b/server/effect/wither.v
@@ -4,6 +4,6 @@ pub const wither = Type{
 	id:       20
 	name:     'wither'
 	lasting:  true
-	rgb:      [u8(0x35), u8(0x2a), u8(0x27)]!
+	rgb:      [u8(0x73), u8(0x61), u8(0x56)]!
 	category: .harmful
 }

--- a/server/entity/effects.v
+++ b/server/entity/effects.v
@@ -1,6 +1,7 @@
 module entity
 
 import protocol
+import protocol.types
 import server.effect
 
 const mob_effect_add = 1
@@ -16,6 +17,7 @@ pub fn (mut e Entity) add_effect(mut host Host, ef effect.Effect) {
 		e.apply_effect_tick(mut host, result.effect)
 	}
 	host.broadcast(e.mob_effect_packet(result.effect, mob_effect_add))
+	e.update_effect_metadata(mut host)
 }
 
 // remove_effect strips typ from e, if present, and tells viewers.
@@ -26,6 +28,7 @@ pub fn (mut e Entity) remove_effect(mut host Host, typ effect.Type) {
 		event_id:         mob_effect_remove
 		effect_id:        typ.id
 	})
+	e.update_effect_metadata(mut host)
 }
 
 // active_effects lists every effect currently active on e.
@@ -46,6 +49,9 @@ fn (mut e Entity) tick_effects(mut host Host) {
 			event_id:         mob_effect_remove
 			effect_id:        ef.effect_type().id
 		})
+	}
+	if result.expired.len > 0 {
+		e.update_effect_metadata(mut host)
 	}
 }
 
@@ -98,4 +104,32 @@ fn effect_tick_interval(base int, level int, level_minus_one bool) int {
 	shift := if level_minus_one { level - 1 } else { level }
 	interval := base >> shift
 	return if interval > 1 { interval } else { 1 }
+}
+
+// update_effect_metadata recalculates the blended potion particle colour from all
+// active effects on e and broadcasts it as entity metadata so viewers see the
+// correct swirling particles.
+fn (e &Entity) update_effect_metadata(mut host Host) {
+	active := e.effects.effects()
+	colour := effect.blend_colour(active)
+	ambient := effect.any_ambient(active)
+	mut ambient_byte := u8(0)
+	if ambient {
+		ambient_byte = 1
+	}
+	host.broadcast(&protocol.SetActorDataPacket{
+		actor_runtime_id: e.runtime_id
+		metadata: [
+			types.MetadataEntry{
+				key:   protocol.meta_key_effect_color
+				value: types.MetaInt{value: colour}
+			},
+			types.MetadataEntry{
+				key:   protocol.meta_key_effect_ambience
+				value: types.MetaByte{value: i8(ambient_byte)}
+			},
+		]
+		synced_properties: types.PropertySyncData{}
+		tick:              0
+	})
 }

--- a/server/entity/effects.v
+++ b/server/entity/effects.v
@@ -138,5 +138,4 @@ fn (e &Entity) update_effect_metadata(mut host Host) {
 	})
 }
 
-// mobspell_molang_json builds the Molang variable JSON for the mobspell_emitter
 // particle colour. Format: array of {name, value} with float RGB in [0,1].

--- a/server/entity/effects.v
+++ b/server/entity/effects.v
@@ -16,8 +16,8 @@ pub fn (mut e Entity) add_effect(mut host Host, ef effect.Effect) {
 	if !result.stored {
 		e.apply_effect_tick(mut host, result.effect)
 	}
-	host.broadcast(e.mob_effect_packet(result.effect, mob_effect_add))
 	e.update_effect_metadata(mut host)
+	host.broadcast(e.mob_effect_packet(result.effect, mob_effect_add))
 }
 
 // remove_effect strips typ from e, if present, and tells viewers.
@@ -118,18 +118,25 @@ fn (e &Entity) update_effect_metadata(mut host Host) {
 		ambient_byte = 1
 	}
 	host.broadcast(&protocol.SetActorDataPacket{
-		actor_runtime_id: e.runtime_id
-		metadata: [
+		actor_runtime_id:  e.runtime_id
+		metadata:          [
 			types.MetadataEntry{
 				key:   protocol.meta_key_effect_color
-				value: types.MetaInt{value: colour}
+				value: types.MetaInt{
+					value: colour
+				}
 			},
 			types.MetadataEntry{
 				key:   protocol.meta_key_effect_ambience
-				value: types.MetaByte{value: i8(ambient_byte)}
+				value: types.MetaByte{
+					value: i8(ambient_byte)
+				}
 			},
 		]
 		synced_properties: types.PropertySyncData{}
 		tick:              0
 	})
 }
+
+// mobspell_molang_json builds the Molang variable JSON for the mobspell_emitter
+// particle colour. Format: array of {name, value} with float RGB in [0,1].

--- a/server/entity/entity.v
+++ b/server/entity/entity.v
@@ -205,6 +205,10 @@ fn math_floor(v f32) f32 {
 	return if v < i { i - 1.0 } else { i }
 }
 
+// spawn_packet builds the packet that makes this entity appear for a viewer.
+// Item entities use AddItemActorPacket; everything else uses AddActorPacket with
+// effect colour metadata. Public so the session layer can send it to players
+// joining late.
 pub fn (e &Entity) spawn_packet() protocol.Packet {
 	if stack := e.item {
 		return &protocol.AddItemActorPacket{
@@ -221,6 +225,13 @@ pub fn (e &Entity) spawn_packet() protocol.Packet {
 			is_from_fishing: false
 		}
 	}
+	active := e.effects.effects()
+	colour := effect.blend_colour(active)
+	ambient := effect.any_ambient(active)
+	mut ambient_byte := u8(0)
+	if ambient {
+		ambient_byte = 1
+	}
 	return &protocol.AddActorPacket{
 		actor_unique_id:   e.unique_id
 		actor_runtime_id:  e.runtime_id
@@ -232,7 +243,16 @@ pub fn (e &Entity) spawn_packet() protocol.Packet {
 		head_yaw:          e.head_yaw
 		body_yaw:          e.yaw
 		attributes:        []types.ActorAttribute{}
-		metadata:          []types.MetadataEntry{}
+		metadata:          [
+			types.MetadataEntry{
+				key:   protocol.meta_key_effect_color
+				value: types.MetaInt{value: colour}
+			},
+			types.MetadataEntry{
+				key:   protocol.meta_key_effect_ambience
+				value: types.MetaByte{value: i8(ambient_byte)}
+			},
+		]
 		synced_properties: types.PropertySyncData{}
 		links:             []types.EntityLink{}
 	}

--- a/server/entity/entity.v
+++ b/server/entity/entity.v
@@ -205,10 +205,17 @@ fn math_floor(v f32) f32 {
 	return if v < i { i - 1.0 } else { i }
 }
 
+// CustomSpawnBehaviour is an optional interface a Behaviour can implement to
+// provide a custom AddActorPacket instead of the default mob-style one. Area
+// Effect Clouds implement it to send radius metadata instead of effect colour.
+pub interface CustomSpawnBehaviour {
+	spawn_packet(e &Entity) &protocol.AddActorPacket
+}
+
 // spawn_packet builds the packet that makes this entity appear for a viewer.
-// Item entities use AddItemActorPacket; everything else uses AddActorPacket with
-// effect colour metadata. Public so the session layer can send it to players
-// joining late.
+// Item entities use AddItemActorPacket; entities whose Behaviour implements
+// CustomSpawnBehaviour delegate to it; everything else uses the default
+// mob-style AddActorPacket with effect colour metadata.
 pub fn (e &Entity) spawn_packet() protocol.Packet {
 	if stack := e.item {
 		return &protocol.AddItemActorPacket{
@@ -224,6 +231,10 @@ pub fn (e &Entity) spawn_packet() protocol.Packet {
 			metadata:        []types.MetadataEntry{}
 			is_from_fishing: false
 		}
+	}
+	mut b := e.behaviour
+	if mut b is CustomSpawnBehaviour {
+		return b.spawn_packet(e)
 	}
 	active := e.effects.effects()
 	colour := effect.blend_colour(active)

--- a/server/entity/entity.v
+++ b/server/entity/entity.v
@@ -19,9 +19,9 @@ const entity_half_width = f32(0.3)
 const entity_height = f32(1.8)
 
 // Entity is a non-player actor living in the world - a mob, item or projectile.
-// It is the Vedrock counterpart to dragonfly's Ent: shared state plus a pluggable
-// Behaviour that drives its per-tick logic. Players stay as NetworkSession; this
-// system covers everything else the client renders as an actor.
+// Shared state plus a pluggable Behaviour that drives its per-tick logic.
+// Players stay as NetworkSession; this system covers everything else the client
+// renders as an actor.
 @[heap]
 pub struct Entity {
 pub:

--- a/server/entity/lingering_cloud.v
+++ b/server/entity/lingering_cloud.v
@@ -1,113 +1,198 @@
 module entity
 
 import protocol
+import protocol.types
+import rand
 import server.effect
 import server.item
 
-// LingeringCloudBehaviour is an entity that hovers at the impact point of a
-// lingering potion.  It is non-solid, unaffected by gravity, and applies
-// reduced-duration potion effects to every actor inside its radius.
-// The radius shrinks over time (linear decay) and on each application to an
-// entity.  When the radius reaches zero the cloud dissipates.
-// https://minecraft.fandom.com/fr/wiki/Potion_%C3%A0_effet_persistant
+// LingeringCloudBehaviour is an Area Effect Cloud — the lingering cloud left
+// behind when a lingering potion impacts. It hovers in place, is non-solid, and
+// applies reduced-duration potion effects to every actor inside its radius.
+// The radius shrinks linearly over time and on each entity application.
+// When the radius reaches zero the cloud dissipates.
+// https://minecraft.wiki/w/Lingering_Potion
 @[heap]
 pub struct LingeringCloudBehaviour {
 pub:
-	network_id string = 'minecraft:lingering_potion'
-	meta       int // potion type, same as drinkable/splash
+	network_id string = 'minecraft:area_effect_cloud'
+	meta       int // potion meta value, same as drinkable/splash
 pub mut:
-	// Initial radius: 3 blocks.  Lasts 30 s (600 ticks), linear decay to 0.
-	// 3.0 / 600 = 0.005 per tick.
-	radius         f32 = 3.0
-	duration_ticks int = 600
-	// Wait 0.5 s (10 ticks) before the cloud becomes active.
-	activation_delay int = 10
-	// Don't reapply to the same entity within 20 ticks (1 s).
-	reapply_delay int = 20
-	// Radius shrinks by this amount per entity application.
-	radius_per_apply f32 = 0.05
-	// Radius shrinks by this amount per tick (linear decay).
-	radius_per_tick f32 = 0.005
-	// Per-entity reapplication cooldown: maps runtime_id -> next tick when
-	// the entity can receive another application.
-	cooldowns map[u64]i64
+	radius           f32 = 3.0
+	duration_ticks   int = 600   // 30 s at 20 TPS
+	wait_time        int = 10    // 0.5 s before cloud activates
+	reapply_delay    int = 40    // 2 s cooldown per entity
+	radius_per_apply f32 = 0.5   // shrink on each entity application
+	radius_per_tick  f32 = 0.005 // linear decay 3.0 → 0 over 600 ticks
+	cooldowns        map[u64]i64 // runtime_id → next tick they can be reapplied
 }
+
+// cloud_meta_radius is Bedrock metadata key 61 — AREA_EFFECT_CLOUD_RADIUS.
+// Key 8 (meta_key_effect_color) is used for the particle colour instead of
+// radius, so mobspell_emitter particles linked via actor_unique_id inherit
+// the potion colour automatically.
+const cloud_meta_radius = u32(61)
+const cloud_meta_duration = u32(95)
+const cloud_meta_radius_per_tick = u32(97)
 
 pub fn (b &LingeringCloudBehaviour) identifier() string {
 	return b.network_id
 }
 
-pub fn (mut b LingeringCloudBehaviour) tick(mut e Entity, mut host Host) {
-	// Cloud doesn't move — no gravity, no physics.
-	e.no_gravity = true
+// spawn_packet builds the AddActorPacket for an area effect cloud. Sets
+// effect colour at key 8 (so mobspell_emitter particles pick it up via
+// actor_unique_id), radius at key 61, duration at 95, and decay at 97.
+pub fn (b &LingeringCloudBehaviour) spawn_packet(e &Entity) &protocol.AddActorPacket {
+	effects := item.potion_from_meta(b.meta).effects()
+	colour := blend_splash_colour(effects)
+	return &protocol.AddActorPacket{
+		actor_unique_id:  e.unique_id
+		actor_runtime_id: e.runtime_id
+		type:             b.network_id
+		position:         e.pos
+		motion:           e.velocity
+		pitch:            e.pitch
+		yaw:              e.yaw
+		head_yaw:         e.head_yaw
+		body_yaw:         e.yaw
+		attributes:        []types.ActorAttribute{}
+		metadata:          [
+			types.MetadataEntry{
+				key:   cloud_meta_radius
+				value: types.MetaFloat{value: b.radius}
+			},
+			types.MetadataEntry{
+				key:   protocol.meta_key_effect_color
+				value: types.MetaInt{value: colour}
+			},
+			types.MetadataEntry{
+				key:   cloud_meta_duration
+				value: types.MetaInt{value: b.duration_ticks}
+			},
+			types.MetadataEntry{
+				key:   cloud_meta_radius_per_tick
+				value: types.MetaFloat{value: -b.radius_per_tick}
+			},
+		]
+		synced_properties: types.PropertySyncData{}
+		links:             []types.EntityLink{}
+	}
+}
 
-	if e.age < b.activation_delay {
+pub fn (mut b LingeringCloudBehaviour) tick(mut e Entity, mut host Host) {
+	e.no_gravity = true
+	effects := item.potion_from_meta(b.meta).effects()
+
+	// Every tick: spawn a mobspell_emitter particle at actor_unique_id so
+	// the client reads the colour from the entity's key-8 metadata. During
+	// wait_time particles cluster at centre (radius is ignored by client
+	// until Age hits wait_time); after, they distribute randomly across the
+	// cloud volume.
+	if b.wait_time > 0 {
+		host.broadcast(&protocol.SpawnParticleEffectPacket{
+			dimension_id:    0
+			actor_unique_id: e.unique_id
+			position:        types.Vector3{e.pos.x, e.pos.y + 0.05, e.pos.z}
+			particle_name:   'minecraft:mobspell_emitter'
+		})
+	} else {
+		ox := (rand.f32() * 2.0 - 1.0) * b.radius * 0.8
+		oy := rand.f32() * 0.5
+		oz := (rand.f32() * 2.0 - 1.0) * b.radius * 0.8
+		host.broadcast(&protocol.SpawnParticleEffectPacket{
+			dimension_id:    0
+			actor_unique_id: e.unique_id
+			position:        types.Vector3{e.pos.x + ox, e.pos.y + 0.1 + oy, e.pos.z + oz}
+			particle_name:   'minecraft:mobspell_emitter'
+		})
+	}
+
+	// During wait_time the cloud is visible but doesn't apply effects,
+	// shrink, or decay.
+	if b.wait_time > 0 {
+		b.wait_time--
+		b.duration_ticks--
 		return
 	}
 
 	b.duration_ticks--
-	if b.duration_ticks <= 0 || b.radius <= 0.01 {
+	if b.duration_ticks <= 0 {
 		e.kill()
 		return
 	}
 
-	effects := item.potion_from_meta(b.meta).effects()
-	colour := blend_splash_colour(effects)
+	// Only scan for targets and apply effects every 10 ticks — matches
+	// vanilla Bedrock's area_effect_cloud application interval.
+	// Skip when radius has shrunk to zero — the cloud persists until its
+	// duration expires (vanilla: radius ≤ 0 makes the cloud invisible and
+	// inert, it does not despawn the entity).
+	if e.age % 10 == 0 && b.radius > 0.01 {
+		b.prune_cooldowns(e.age)
+		targets := host.entities_near(e.pos, b.radius)
 
-	// Get all actors inside the current radius and apply reduced effects.
-	targets := host.entities_near(e.pos, b.radius)
-	current_tick := e.age
-
-	for rid in targets {
-		// Reapplication cooldown: skip entities we just applied to.
-		if next := b.cooldowns[rid] {
-			if current_tick < next {
+		for rid in targets {
+			if rid == e.runtime_id {
 				continue
 			}
-		}
-		b.cooldowns[rid] = current_tick + b.reapply_delay
-
-		// Apply lingering effects: duration is 1/4 of the drinkable
-		// version.  Instant effects also get reduced potency.
-		// https://minecraft.fandom.com/fr/wiki/Potion_%C3%A0_effet_persistant
-		for ef in effects {
-			mut cloud_ef := ef
-
-			if cloud_ef.instant() {
-				// Instant effects: potency is halved for lingering.
-				if host.is_undead(rid) {
-					cloud_ef = invert_undead_instant(cloud_ef)
-				}
-				cloud_ef = effect.new_instant_with_potency(cloud_ef.effect_type(),
-					cloud_ef.level(), cloud_ef.potency() * 0.5)
-			} else if !cloud_ef.infinite() {
-				// Duration effects: 1/4 of the drinkable duration.
-				quarter := cloud_ef.duration_ticks() / 4
-				if quarter < 1 {
-					continue
-				}
-				cloud_ef = effect.new_with_ticks(cloud_ef.effect_type(), cloud_ef.level(), quarter)
+			if rid in b.cooldowns {
+				continue
 			}
-			host.add_effect_to(rid, cloud_ef)
+			b.cooldowns[rid] = e.age + b.reapply_delay
+
+			for ef in effects {
+				mut cloud_ef := ef
+
+				if cloud_ef.instant() {
+					if host.is_undead(rid) {
+						cloud_ef = invert_undead_instant(cloud_ef)
+					}
+					cloud_ef = effect.new_instant_with_potency(cloud_ef.effect_type(),
+						cloud_ef.level(), cloud_ef.potency() * 0.5)
+				} else if !cloud_ef.infinite() {
+					quarter := cloud_ef.duration_ticks() / 4
+					if quarter < 1 {
+						continue
+					}
+					cloud_ef = effect.new_with_ticks(cloud_ef.effect_type(), cloud_ef.level(), quarter)
+				}
+				host.add_effect_to(rid, cloud_ef)
+			}
+
+			b.radius -= b.radius_per_apply
+			if b.radius < 0 {
+				b.radius = 0
+			}
 		}
-
-		// Each application shrinks the cloud radius.
-		b.radius -= b.radius_per_apply
 	}
 
-	// Linear radius decay over time.
 	b.radius -= b.radius_per_tick
-	if b.radius <= 0.01 {
-		b.radius = 0.01
-		e.kill()
-		return
+	if b.radius < 0 {
+		b.radius = 0
 	}
 
-	// Particles: spawn coloured splash particles inside the cloud volume.
-	// https://minecraft.fandom.com/fr/wiki/Potion_%C3%A0_effet_persistant
-	host.broadcast_near(e.pos.x, e.pos.y, e.pos.z, b.radius * 2, &protocol.LevelEventPacket{
-		event_id:   level_event_potion_splash
-		position:   e.pos
-		event_data: colour
+	// Sync radius to client every tick (radius decays every tick).
+	host.broadcast_near(e.pos.x, e.pos.y, e.pos.z, view_radius, &protocol.SetActorDataPacket{
+		actor_runtime_id: e.runtime_id
+		metadata:         [
+			types.MetadataEntry{
+				key:   cloud_meta_radius
+				value: types.MetaFloat{value: b.radius}
+			},
+		]
+		synced_properties: types.PropertySyncData{}
 	})
+}
+
+// prune_cooldowns removes expired cooldown entries so the map doesn't grow
+// unbounded and stale entries don't block reapplication.
+fn (mut b LingeringCloudBehaviour) prune_cooldowns(current_tick i64) {
+	mut expired := []u64{}
+	for rid, expiration in b.cooldowns {
+		if current_tick >= expiration {
+			expired << rid
+		}
+	}
+	for rid in expired {
+		b.cooldowns.delete(rid)
+	}
 }

--- a/server/entity/lingering_cloud.v
+++ b/server/entity/lingering_cloud.v
@@ -6,7 +6,7 @@ import rand
 import server.effect
 import server.item
 
-// LingeringCloudBehaviour is an Area Effect Cloud — the lingering cloud left
+// LingeringCloudBehaviour is an Area Effect Cloud  -  the lingering cloud left
 // behind when a lingering potion impacts. It hovers in place, is non-solid, and
 // applies reduced-duration potion effects to every actor inside its radius.
 // The radius shrinks linearly over time and on each entity application.
@@ -23,11 +23,11 @@ pub mut:
 	wait_time        int = 10    // 0.5 s before cloud activates
 	reapply_delay    int = 40    // 2 s cooldown per entity
 	radius_per_apply f32 = 0.5   // shrink on each entity application
-	radius_per_tick  f32 = 0.005 // linear decay 3.0 → 0 over 600 ticks
-	cooldowns        map[u64]i64 // runtime_id → next tick they can be reapplied
+	radius_per_tick  f32 = 0.005 // linear decay 3.0 -> 0 over 600 ticks
+	cooldowns        map[u64]i64 // runtime_id -> next tick they can be reapplied
 }
 
-// cloud_meta_radius is Bedrock metadata key 61 — AREA_EFFECT_CLOUD_RADIUS.
+// cloud_meta_radius is Bedrock metadata key 61  -  AREA_EFFECT_CLOUD_RADIUS.
 // Key 8 (meta_key_effect_color) is used for the particle colour instead of
 // radius, so mobspell_emitter particles linked via actor_unique_id inherit
 // the potion colour automatically.
@@ -121,9 +121,9 @@ pub fn (mut b LingeringCloudBehaviour) tick(mut e Entity, mut host Host) {
 		return
 	}
 
-	// Only scan for targets and apply effects every 10 ticks — matches
+	// Only scan for targets and apply effects every 10 ticks  -  matches
 	// vanilla Bedrock's area_effect_cloud application interval.
-	// Skip when radius has shrunk to zero — the cloud persists until its
+	// Skip when radius has shrunk to zero  -  the cloud persists until its
 	// duration expires (vanilla: radius ≤ 0 makes the cloud invisible and
 	// inert, it does not despawn the entity).
 	if e.age % 10 == 0 && b.radius > 0.01 {
@@ -170,7 +170,6 @@ pub fn (mut b LingeringCloudBehaviour) tick(mut e Entity, mut host Host) {
 		b.radius = 0
 	}
 
-	// Sync radius to client every tick (radius decays every tick).
 	host.broadcast_near(e.pos.x, e.pos.y, e.pos.z, view_radius, &protocol.SetActorDataPacket{
 		actor_runtime_id: e.runtime_id
 		metadata:         [

--- a/server/entity/lingering_cloud.v
+++ b/server/entity/lingering_cloud.v
@@ -1,0 +1,113 @@
+module entity
+
+import protocol
+import server.effect
+import server.item
+
+// LingeringCloudBehaviour is an entity that hovers at the impact point of a
+// lingering potion.  It is non-solid, unaffected by gravity, and applies
+// reduced-duration potion effects to every actor inside its radius.
+// The radius shrinks over time (linear decay) and on each application to an
+// entity.  When the radius reaches zero the cloud dissipates.
+// https://minecraft.fandom.com/fr/wiki/Potion_%C3%A0_effet_persistant
+@[heap]
+pub struct LingeringCloudBehaviour {
+pub:
+	network_id string = 'minecraft:lingering_potion'
+	meta       int // potion type, same as drinkable/splash
+pub mut:
+	// Initial radius: 3 blocks.  Lasts 30 s (600 ticks), linear decay to 0.
+	// 3.0 / 600 = 0.005 per tick.
+	radius         f32 = 3.0
+	duration_ticks int = 600
+	// Wait 0.5 s (10 ticks) before the cloud becomes active.
+	activation_delay int = 10
+	// Don't reapply to the same entity within 20 ticks (1 s).
+	reapply_delay int = 20
+	// Radius shrinks by this amount per entity application.
+	radius_per_apply f32 = 0.05
+	// Radius shrinks by this amount per tick (linear decay).
+	radius_per_tick f32 = 0.005
+	// Per-entity reapplication cooldown: maps runtime_id -> next tick when
+	// the entity can receive another application.
+	cooldowns map[u64]i64
+}
+
+pub fn (b &LingeringCloudBehaviour) identifier() string {
+	return b.network_id
+}
+
+pub fn (mut b LingeringCloudBehaviour) tick(mut e Entity, mut host Host) {
+	// Cloud doesn't move — no gravity, no physics.
+	e.no_gravity = true
+
+	if e.age < b.activation_delay {
+		return
+	}
+
+	b.duration_ticks--
+	if b.duration_ticks <= 0 || b.radius <= 0.01 {
+		e.kill()
+		return
+	}
+
+	effects := item.potion_from_meta(b.meta).effects()
+	colour := blend_splash_colour(effects)
+
+	// Get all actors inside the current radius and apply reduced effects.
+	targets := host.entities_near(e.pos, b.radius)
+	current_tick := e.age
+
+	for rid in targets {
+		// Reapplication cooldown: skip entities we just applied to.
+		if next := b.cooldowns[rid] {
+			if current_tick < next {
+				continue
+			}
+		}
+		b.cooldowns[rid] = current_tick + b.reapply_delay
+
+		// Apply lingering effects: duration is 1/4 of the drinkable
+		// version.  Instant effects also get reduced potency.
+		// https://minecraft.fandom.com/fr/wiki/Potion_%C3%A0_effet_persistant
+		for ef in effects {
+			mut cloud_ef := ef
+
+			if cloud_ef.instant() {
+				// Instant effects: potency is halved for lingering.
+				if host.is_undead(rid) {
+					cloud_ef = invert_undead_instant(cloud_ef)
+				}
+				cloud_ef = effect.new_instant_with_potency(cloud_ef.effect_type(),
+					cloud_ef.level(), cloud_ef.potency() * 0.5)
+			} else if !cloud_ef.infinite() {
+				// Duration effects: 1/4 of the drinkable duration.
+				quarter := cloud_ef.duration_ticks() / 4
+				if quarter < 1 {
+					continue
+				}
+				cloud_ef = effect.new_with_ticks(cloud_ef.effect_type(), cloud_ef.level(), quarter)
+			}
+			host.add_effect_to(rid, cloud_ef)
+		}
+
+		// Each application shrinks the cloud radius.
+		b.radius -= b.radius_per_apply
+	}
+
+	// Linear radius decay over time.
+	b.radius -= b.radius_per_tick
+	if b.radius <= 0.01 {
+		b.radius = 0.01
+		e.kill()
+		return
+	}
+
+	// Particles: spawn coloured splash particles inside the cloud volume.
+	// https://minecraft.fandom.com/fr/wiki/Potion_%C3%A0_effet_persistant
+	host.broadcast_near(e.pos.x, e.pos.y, e.pos.z, b.radius * 2, &protocol.LevelEventPacket{
+		event_id:   level_event_potion_splash
+		position:   e.pos
+		event_data: colour
+	})
+}

--- a/server/entity/manager.v
+++ b/server/entity/manager.v
@@ -36,14 +36,25 @@ mut:
 	// entity), attributed to source_name/source_runtime_id, with
 	// knockback_from as the origin used to compute knockback direction.
 	damage_entity(runtime_id u64, amount f32, source_name string, source_runtime_id u64, knockback_from types.Vector3)
+	// add_effect_to adds ef to the actor at runtime_id (player or entity).
+	add_effect_to(runtime_id u64, ef effect.Effect)
 	// nearest_player returns the runtime id of the closest connected player
 	// within radius of pos or none if nobody is that close. Used for
 	// proactive mob targeting (HostileBehaviour scanning for a target it
 	// hasn't been hit by yet).
 	nearest_player(pos types.Vector3, radius f32) ?u64
+	// entities_near returns the runtime ids of every actor (player and
+	// non-player entity) whose position is within radius blocks of pos.
+	// Used by splash potions to apply area-of-effect.
+	entities_near(pos types.Vector3, radius f32) []u64
 	// notify_entity_despawn lets the entity package announce a despawn.
 	notify_entity_despawn(identifier string, x f32, y f32, z f32)
 	pickup_item(item_runtime_id u64, stack types.ItemStack, pos types.Vector3) int
+	// is_undead reports whether the actor at runtime_id is an undead mob
+	// (zombie, skeleton, wither, etc.). Used by splash potions to invert
+	// instant health/damage effects — Healing harms undead, Harming heals.
+	// Players and non-undead entities return false.
+	is_undead(runtime_id u64) bool
 }
 
 // Manager owns every live non-player Entity. spawn/despawn are safe from any
@@ -102,6 +113,18 @@ pub fn (mut m Manager) spawn_item(stack types.ItemStack, pos types.Vector3, velo
 	m.mutex.unlock()
 	m.host.broadcast_near(e.pos.x, e.pos.y, e.pos.z, view_radius, e.spawn_packet())
 	return e
+}
+
+// add_effect applies ef to the entity at runtime_id.
+pub fn (mut m Manager) add_effect(runtime_id u64, ef effect.Effect) {
+	m.mutex.lock()
+	mut e := m.entities[runtime_id] or {
+		m.mutex.unlock()
+		return
+	}
+	m.mutex.unlock()
+	mut host := m.host
+	e.add_effect(mut host, ef)
 }
 
 // despawn removes the entity with runtime_id and tells viewers to drop it.

--- a/server/entity/manager.v
+++ b/server/entity/manager.v
@@ -52,7 +52,7 @@ mut:
 	pickup_item(item_runtime_id u64, stack types.ItemStack, pos types.Vector3) int
 	// is_undead reports whether the actor at runtime_id is an undead mob
 	// (zombie, skeleton, wither, etc.). Used by splash potions to invert
-	// instant health/damage effects — Healing harms undead, Harming heals.
+	// instant health/damage effects  -  Healing harms undead, Harming heals.
 	// Players and non-undead entities return false.
 	is_undead(runtime_id u64) bool
 	// spawn_behaviour creates a new entity driven by b at pos, registers

--- a/server/entity/manager.v
+++ b/server/entity/manager.v
@@ -59,7 +59,6 @@ mut:
 	// it and broadcasts its appearance. Returns the spawned Entity.
 	spawn_behaviour(b Behaviour, pos types.Vector3) &Entity
 }
-
 // Manager owns every live non-player Entity. spawn/despawn are safe from any
 // thread (mutex-guarded); tick() runs once per server tick on the Hub actor
 // thread, the same place player state is mutated.

--- a/server/entity/manager.v
+++ b/server/entity/manager.v
@@ -55,6 +55,9 @@ mut:
 	// instant health/damage effects — Healing harms undead, Harming heals.
 	// Players and non-undead entities return false.
 	is_undead(runtime_id u64) bool
+	// spawn_behaviour creates a new entity driven by b at pos, registers
+	// it and broadcasts its appearance. Returns the spawned Entity.
+	spawn_behaviour(b Behaviour, pos types.Vector3) &Entity
 }
 
 // Manager owns every live non-player Entity. spawn/despawn are safe from any
@@ -113,6 +116,12 @@ pub fn (mut m Manager) spawn_item(stack types.ItemStack, pos types.Vector3, velo
 	m.mutex.unlock()
 	m.host.broadcast_near(e.pos.x, e.pos.y, e.pos.z, view_radius, e.spawn_packet())
 	return e
+}
+
+// spawn_behaviour is the Host-facing spawn: it delegates to Manager.spawn
+// so behaviours can create new entities without importing session.
+pub fn (mut m Manager) spawn_behaviour(b Behaviour, pos types.Vector3) &Entity {
+	return m.spawn(b, pos)
 }
 
 // add_effect applies ef to the entity at runtime_id.

--- a/server/entity/manager_test.v
+++ b/server/entity/manager_test.v
@@ -560,14 +560,14 @@ fn test_splash_potion_duration_attenuation_by_distance() {
 	e.no_gravity = true
 	e.age = 2
 	e.hit_block = true // force block impact
-	m.tick() // hit_block → apply_splash
+	m.tick() // hit_block -> apply_splash
 	assert m.count() == 0
 
 	// Centre entity: full 3600 ticks.
 	centre_dur := host.effects_applied[10][0].duration_ticks()
 	assert centre_dur >= 3400 && centre_dur <= 3600
 
-	// Edge entity: at dist=2.0 / radius=4.0 → scale=0.5 → ~1800 ticks.
+	// Edge entity: at dist=2.0 / radius=4.0 -> scale=0.5 -> ~1800 ticks.
 	edge_dur := host.effects_applied[20][0].duration_ticks()
 	assert edge_dur >= 1700 && edge_dur <= 1900
 
@@ -601,7 +601,7 @@ fn test_splash_potion_undead_inverts_instant_health() {
 	host.undead_ids[u64(10)] = true // mark entity 10 as undead
 	mut m := new_manager(host)
 	mut e := m.spawn(&SplashPotionBehaviour{
-		meta: 21 // instant health I — should become instant damage for undead
+		meta: 21 // instant health I  -  should become instant damage for undead
 	}, types.Vector3{0, 10, 0})
 	e.no_gravity = true
 	e.age = 2
@@ -621,7 +621,7 @@ fn test_splash_potion_undead_inverts_instant_damage() {
 	host.undead_ids[u64(10)] = true
 	mut m := new_manager(host)
 	mut e := m.spawn(&SplashPotionBehaviour{
-		meta: 23 // instant damage I — should become instant health for undead
+		meta: 23 // instant damage I  -  should become instant health for undead
 	}, types.Vector3{0, 10, 0})
 	e.no_gravity = true
 	e.age = 2
@@ -649,7 +649,7 @@ fn test_splash_potion_out_of_range_not_affected() {
 	assert m.count() == 0
 	// Centre entity gets effects.
 	assert u64(10) in host.effects_applied
-	// Edge entity at exactly radius: scale = 1 - 4.0/4.0 = 0 → skipped.
+	// Edge entity at exactly radius: scale = 1 - 4.0/4.0 = 0 -> skipped.
 	assert u64(20) !in host.effects_applied
 }
 
@@ -668,7 +668,7 @@ fn test_splash_potion_no_effects_still_broadcasts_particles() {
 	mut host := &FakeHost{}
 	mut m := new_manager(host)
 	mut e := m.spawn(&SplashPotionBehaviour{
-		meta: 99 // invalid meta — no effects
+		meta: 99 // invalid meta  -  no effects
 	}, types.Vector3{0, 10, 0})
 	e.no_gravity = true
 	e.age = 2

--- a/server/entity/manager_test.v
+++ b/server/entity/manager_test.v
@@ -543,7 +543,7 @@ fn test_splash_potion_hits_block_applies_splash() {
 	m.tick() // moves toward wall
 	m.tick() // hit_block detected by behaviour, triggers splash
 	assert m.count() == 0 // despawned after splash
-	assert host.near > 0 // splash broadcasts LevelEvent + LevelSoundEvent via broadcast_near
+	assert host.near_broadcasts > 0 // splash broadcasts LevelEvent + LevelSoundEvent via broadcast_near
 }
 
 fn test_splash_potion_duration_attenuation_by_distance() {
@@ -676,5 +676,5 @@ fn test_splash_potion_no_effects_still_broadcasts_particles() {
 	m.tick()
 	assert m.count() == 0
 	// Particle and sound still broadcast even with zero effects.
-	assert host.near >= 2 // LevelEvent + LevelSoundEvent
+	assert host.near_broadcasts >= 2 // LevelEvent + LevelSoundEvent
 }

--- a/server/entity/manager_test.v
+++ b/server/entity/manager_test.v
@@ -23,11 +23,15 @@ mut:
 	last_damage_amount     f32
 	// players is the settable pool nearest_player searches: keyed by runtime
 	// id, distinct from the generic entity positions map above.
-	players               map[u64]types.Vector3
-	despawn_notify_calls   int
-	last_despawn_id        string
-	pickup_take  int
-	pickup_calls int
+players              map[u64]types.Vector3
+	despawn_notify_calls int
+	last_despawn_id      string
+	pickup_take          int
+	pickup_calls         int
+	// Splash potion test support.
+	effects_applied   map[u64][]effect.Effect
+	entities_near_ids []u64
+	undead_ids        map[u64]bool
 }
 
 fn block_key(x int, y int, z int) string {
@@ -82,9 +86,24 @@ fn (mut h FakeHost) damage_entity(runtime_id u64, amount f32, source_name string
 	h.last_damage_amount = amount
 }
 
+fn (mut h FakeHost) add_effect_to(runtime_id u64, ef effect.Effect) {
+	if runtime_id !in h.effects_applied {
+		h.effects_applied[runtime_id] = []effect.Effect{}
+	}
+	h.effects_applied[runtime_id] << ef
+}
+
+fn (mut h FakeHost) entities_near(pos types.Vector3, radius f32) []u64 {
+	return h.entities_near_ids
+}
+
 fn (mut h FakeHost) notify_entity_despawn(identifier string, x f32, y f32, z f32) {
 	h.despawn_notify_calls++
 	h.last_despawn_id = identifier
+}
+
+fn (mut h FakeHost) is_undead(runtime_id u64) bool {
+	return h.undead_ids[runtime_id] or { false }
 }
 
 fn (mut h FakeHost) nearest_player(pos types.Vector3, radius f32) ?u64 {
@@ -471,4 +490,187 @@ fn test_hostile_behaviour_gives_up_target_out_of_range() {
 	e.set_velocity(types.Vector3{})
 	m.tick()
 	assert e.velocity.x == 0 // gave up, back to wandering
+}
+
+// --- Splash potion tests ---
+
+fn test_splash_potion_spawns_and_has_correct_defaults() {
+	mut host := &FakeHost{}
+	mut m := new_manager(host)
+	e := m.spawn(&SplashPotionBehaviour{
+		meta: 21 // instant health I
+	}, types.Vector3{0, 10, 0})
+	assert e.identifier == 'minecraft:splash_potion'
+	assert m.count() == 1
+}
+
+fn test_splash_potion_hits_entity_applies_effects() {
+	mut host := &FakeHost{}
+	host.hit_target = u64(42)
+	host.entities_near_ids = [u64(42)]
+	host.positions[42] = types.Vector3{0, 10, 0}
+	mut m := new_manager(host)
+	mut e := m.spawn(&SplashPotionBehaviour{
+		meta: 21 // instant health I
+	}, types.Vector3{0, 10, 0})
+	e.no_gravity = true
+	e.age = 2
+	m.tick()
+	// Projectile should have hit entity 42, applied effects, and killed itself.
+	assert m.count() == 0
+	assert host.effects_applied[42].len > 0
+	// Healing potion applies instant_health.
+	assert host.effects_applied[42][0].effect_type().id == effect.instant_health.id
+}
+
+fn test_splash_potion_hits_block_applies_splash() {
+	mut host := &FakeHost{}
+	host.set_solid(1, 10, 0) // wall at x=1
+	host.entities_near_ids = [u64(99)]
+	host.positions[99] = types.Vector3{0.5, 10, 0}
+	mut m := new_manager(host)
+	mut e := m.spawn(&SplashPotionBehaviour{
+		meta: 21 // instant health I
+	}, types.Vector3{0.5, 10, 0})
+	e.floor_y = 10
+	e.no_gravity = true
+	e.age = 2
+	e.set_velocity(types.Vector3{0.5, 0, 0})
+	m.tick() // moves toward wall
+	m.tick() // hit_block detected by behaviour, triggers splash
+	assert m.count() == 0 // despawned after splash
+	assert host.near > 0 // splash broadcasts LevelEvent + LevelSoundEvent via broadcast_near
+}
+
+fn test_splash_potion_duration_attenuation_by_distance() {
+	mut host := &FakeHost{}
+	host.entities_near_ids = [u64(10), u64(20)]
+	// Entity 10: at impact centre (dist=0), gets full duration.
+	host.positions[10] = types.Vector3{0, 10, 0}
+	// Entity 20: at half radius (dist=2.0), gets ~50% duration.
+	host.positions[20] = types.Vector3{2.0, 10, 0}
+	mut m := new_manager(host)
+	mut e := m.spawn(&SplashPotionBehaviour{
+		meta: 5 // night vision 3:00 = 3600 ticks
+	}, types.Vector3{0, 10, 0})
+	e.no_gravity = true
+	e.age = 2
+	e.hit_block = true // force block impact
+	m.tick() // hit_block → apply_splash
+	assert m.count() == 0
+
+	// Centre entity: full 3600 ticks.
+	centre_dur := host.effects_applied[10][0].duration_ticks()
+	assert centre_dur >= 3400 && centre_dur <= 3600
+
+	// Edge entity: at dist=2.0 / radius=4.0 → scale=0.5 → ~1800 ticks.
+	edge_dur := host.effects_applied[20][0].duration_ticks()
+	assert edge_dur >= 1700 && edge_dur <= 1900
+
+	// Centre entity gets longer duration than edge entity.
+	assert centre_dur > edge_dur
+}
+
+fn test_splash_potion_instant_effects_not_distance_scaled() {
+	mut host := &FakeHost{}
+	host.entities_near_ids = [u64(10)]
+	host.positions[10] = types.Vector3{3.9, 10, 0} // near edge of 4.0 radius
+	mut m := new_manager(host)
+	mut e := m.spawn(&SplashPotionBehaviour{
+		meta: 21 // instant health I
+	}, types.Vector3{0, 10, 0})
+	e.no_gravity = true
+	e.age = 2
+	e.hit_block = true
+	m.tick()
+	assert m.count() == 0
+	// Instant effect applied at full strength regardless of distance.
+	ef := host.effects_applied[10][0]
+	assert ef.instant()
+	assert ef.level() == 1
+}
+
+fn test_splash_potion_undead_inverts_instant_health() {
+	mut host := &FakeHost{}
+	host.entities_near_ids = [u64(10)]
+	host.positions[10] = types.Vector3{0, 10, 0}
+	host.undead_ids[u64(10)] = true // mark entity 10 as undead
+	mut m := new_manager(host)
+	mut e := m.spawn(&SplashPotionBehaviour{
+		meta: 21 // instant health I — should become instant damage for undead
+	}, types.Vector3{0, 10, 0})
+	e.no_gravity = true
+	e.age = 2
+	e.hit_block = true
+	m.tick()
+	assert m.count() == 0
+	ef := host.effects_applied[10][0]
+	// Undead should get instant_damage instead of instant_health.
+	assert ef.effect_type().id == effect.instant_damage.id
+	assert ef.level() == 1
+}
+
+fn test_splash_potion_undead_inverts_instant_damage() {
+	mut host := &FakeHost{}
+	host.entities_near_ids = [u64(10)]
+	host.positions[10] = types.Vector3{0, 10, 0}
+	host.undead_ids[u64(10)] = true
+	mut m := new_manager(host)
+	mut e := m.spawn(&SplashPotionBehaviour{
+		meta: 23 // instant damage I — should become instant health for undead
+	}, types.Vector3{0, 10, 0})
+	e.no_gravity = true
+	e.age = 2
+	e.hit_block = true
+	m.tick()
+	assert m.count() == 0
+	ef := host.effects_applied[10][0]
+	assert ef.effect_type().id == effect.instant_health.id
+}
+
+fn test_splash_potion_out_of_range_not_affected() {
+	mut host := &FakeHost{}
+	host.entities_near_ids = [u64(10), u64(20)]
+	// Entity 10: at impact centre. Entity 20: at radius edge (4.0).
+	host.positions[10] = types.Vector3{0, 10, 0}
+	host.positions[20] = types.Vector3{4.0, 10, 0}
+	mut m := new_manager(host)
+	mut e := m.spawn(&SplashPotionBehaviour{
+		meta: 5 // night vision
+	}, types.Vector3{0, 10, 0})
+	e.no_gravity = true
+	e.age = 2
+	e.hit_block = true
+	m.tick()
+	assert m.count() == 0
+	// Centre entity gets effects.
+	assert u64(10) in host.effects_applied
+	// Edge entity at exactly radius: scale = 1 - 4.0/4.0 = 0 → skipped.
+	assert u64(20) !in host.effects_applied
+}
+
+fn test_splash_potion_despawns_after_max_age() {
+	mut host := &FakeHost{}
+	mut m := new_manager(host)
+	mut e := m.spawn(&SplashPotionBehaviour{}, types.Vector3{0, 100, 0})
+	e.no_gravity = true
+	for _ in 0 .. 201 {
+		m.tick()
+	}
+	assert m.count() == 0
+}
+
+fn test_splash_potion_no_effects_still_broadcasts_particles() {
+	mut host := &FakeHost{}
+	mut m := new_manager(host)
+	mut e := m.spawn(&SplashPotionBehaviour{
+		meta: 99 // invalid meta — no effects
+	}, types.Vector3{0, 10, 0})
+	e.no_gravity = true
+	e.age = 2
+	e.hit_block = true
+	m.tick()
+	assert m.count() == 0
+	// Particle and sound still broadcast even with zero effects.
+	assert host.near >= 2 // LevelEvent + LevelSoundEvent
 }

--- a/server/entity/manager_test.v
+++ b/server/entity/manager_test.v
@@ -102,6 +102,10 @@ fn (mut h FakeHost) notify_entity_despawn(identifier string, x f32, y f32, z f32
 	h.last_despawn_id = identifier
 }
 
+fn (mut h FakeHost) spawn_behaviour(b Behaviour, pos types.Vector3) &Entity {
+	return &Entity{}
+}
+
 fn (mut h FakeHost) is_undead(runtime_id u64) bool {
 	return h.undead_ids[runtime_id] or { false }
 }

--- a/server/entity/registry.v
+++ b/server/entity/registry.v
@@ -78,4 +78,7 @@ pub fn register_defaults(mut r Registry) {
 	r.register('splash_potion', fn () Behaviour {
 		return &SplashPotionBehaviour{}
 	})
+	r.register('lingering_potion', fn () Behaviour {
+		return &LingeringCloudBehaviour{}
+	})
 }

--- a/server/entity/registry.v
+++ b/server/entity/registry.v
@@ -79,6 +79,8 @@ pub fn register_defaults(mut r Registry) {
 		return &SplashPotionBehaviour{}
 	})
 	r.register('lingering_potion', fn () Behaviour {
-		return &LingeringCloudBehaviour{}
+		return &LingeringCloudBehaviour{
+			meta: 0 // default: no potion effects
+		}
 	})
 }

--- a/server/entity/registry.v
+++ b/server/entity/registry.v
@@ -75,4 +75,7 @@ pub fn register_defaults(mut r Registry) {
 			survive_block_collision: true
 		}
 	})
+	r.register('splash_potion', fn () Behaviour {
+		return &SplashPotionBehaviour{}
+	})
 }

--- a/server/entity/splash_potion.v
+++ b/server/entity/splash_potion.v
@@ -10,8 +10,8 @@ import server.item
 // actor within splash_radius on impact (entity or block). The meta field
 // selects which potion type (use PotionType.effects() from server/item).
 // When lingering is true the projectile spawns an Area Effect Cloud instead of
-// applying effects directly — used for lingering potions.
-// https://minecraft.wiki/w/Splash_Potion — radius 4.0 blocks.
+// applying effects directly  -  used for lingering potions.
+// https://minecraft.wiki/w/Splash_Potion  -  radius 4.0 blocks.
 @[heap]
 pub struct SplashPotionBehaviour {
 pub:
@@ -145,7 +145,7 @@ fn (mut b SplashPotionBehaviour) apply_splash(mut e Entity, mut host Host) {
 
 			if splash_ef.instant() {
 				// Instant effects: no duration scaling, but check
-				// undead inversion — Healing damages undead and
+				// undead inversion  -  Healing damages undead and
 				// vice versa.
 				// https://minecraft.fandom.com/fr/wiki/Mort-vivant
 				if host.is_undead(rid) {
@@ -169,7 +169,7 @@ fn (mut b SplashPotionBehaviour) apply_splash(mut e Entity, mut host Host) {
 		}
 	}
 
-	// Splash particle event — the coloured cloud at the impact point.
+	// Splash particle event  -  the coloured cloud at the impact point.
 	// LevelEvent ID 2002 is the Bedrock potion splash particle.
 	host.broadcast_near(e.pos.x, e.pos.y, e.pos.z, b.splash_radius * 2, &protocol.LevelEventPacket{
 		event_id:   level_event_potion_splash
@@ -207,7 +207,7 @@ fn invert_undead_instant(ef effect.Effect) effect.Effect {
 
 // blend_splash_colour averages the RGB colours of all effects (including
 // instant ones) for the splash particle. Separate from effect.blend_colour
-// which skips non-lasting types — those are needed for entity metadata
+// which skips non-lasting types  -  those are needed for entity metadata
 // particles but NOT for the impact splash or projectile trail, which should
 // match the potion colour.
 pub fn blend_splash_colour(effects []effect.Effect) int {
@@ -222,7 +222,7 @@ pub fn blend_splash_colour(effects []effect.Effect) int {
 		b_sum += int(t.rgb[2])
 	}
 	count := effects.len
-	// No alpha byte — LevelEvent 2002 expects 0x00RRGGBB, not 0xAARRGGBB.
+	// No alpha byte  -  LevelEvent 2002 expects 0x00RRGGBB, not 0xAARRGGBB.
 	return int(u32(r_sum / count) << 16 | u32(g_sum / count) << 8 | u32(b_sum / count))
 }
 

--- a/server/entity/splash_potion.v
+++ b/server/entity/splash_potion.v
@@ -1,0 +1,165 @@
+module entity
+
+import math
+import protocol
+import server.effect
+import server.item
+
+// SplashPotionBehaviour is a projectile that applies potion effects to every
+// actor within splash_radius on impact (entity or block). The meta field
+// selects which potion type (use PotionType.effects() from server/item).
+// https://minecraft.fandom.com/fr/wiki/Potion_jetable — radius 4.0 blocks.
+@[heap]
+pub struct SplashPotionBehaviour {
+pub:
+	network_id string = 'minecraft:splash_potion'
+	meta       int // potion meta value (5-42), same as drinkable potions
+pub mut:
+	gravity_accel f32 = 0.05
+	drag_factor   f32 = 0.01
+	splash_radius f32 = 4.0
+	stuck         bool
+}
+
+pub fn (b &SplashPotionBehaviour) identifier() string {
+	return b.network_id
+}
+
+pub fn (mut b SplashPotionBehaviour) tick(mut e Entity, mut host Host) {
+	if b.stuck {
+		if e.age >= 100 {
+			e.kill()
+		}
+		return
+	}
+	e.gravity_accel = b.gravity_accel
+	e.drag_factor = b.drag_factor
+	if e.age >= 200 {
+		e.kill()
+		return
+	}
+	if e.age <= 1 {
+		return
+	}
+	// Check if we hit an entity.
+	if _ := host.entity_hit_test(e.pos, e.runtime_id) {
+		b.apply_splash(mut e, mut host)
+		e.kill()
+		return
+	}
+	// Check if we hit a block.
+	if e.hit_block {
+		b.apply_splash(mut e, mut host)
+		e.kill()
+		return
+	}
+}
+
+// apply_splash applies the potion effects to every actor within splash_radius
+// and broadcasts the splash particle + glass-break sound.
+fn (mut b SplashPotionBehaviour) apply_splash(mut e Entity, mut host Host) {
+	effects := item.potion_from_meta(b.meta).effects()
+	targets := host.entities_near(e.pos, b.splash_radius)
+	// Blend ALL effects for the splash particle, including instant ones.
+	// blend_colour skips non-lasting types (Healing/Harming have
+	// lasting=false) so it would show a water splash for those.
+	colour := blend_splash_colour(effects)
+
+	// Apply effects to every actor in range with distance-based attenuation.
+	// Duration scales linearly: max(0, 1 - distance/radius).
+	// Instant effects (Healing/Harming) apply at full potency regardless of
+	// distance; undead mobs invert them.
+	// https://minecraft.fandom.com/fr/wiki/Potion_jetable
+	for rid in targets {
+		tp := host.entity_position(rid) or { continue }
+		dx := tp.x - e.pos.x
+		dy := tp.y - e.pos.y
+		dz := tp.z - e.pos.z
+		dist := math.sqrtf(dx * dx + dy * dy + dz * dz)
+
+		for ef in effects {
+			mut splash_ef := ef
+
+			if splash_ef.instant() {
+				// Instant effects: no duration scaling, but check
+				// undead inversion — Healing damages undead and
+				// vice versa.
+				// https://minecraft.fandom.com/fr/wiki/Mort-vivant
+				if host.is_undead(rid) {
+					splash_ef = invert_undead_instant(splash_ef)
+				}
+			} else if !splash_ef.infinite() {
+				// Duration scales linearly with distance from impact
+				// centre: duration * (1 - distance/radius).
+				scale := 1.0 - (dist / b.splash_radius)
+				if scale <= 0 {
+					continue
+				}
+				scaled := int(f32(splash_ef.duration_ticks()) * f32(scale))
+				if scaled < 1 {
+					continue
+				}
+				splash_ef = effect.new_with_ticks(splash_ef.effect_type(), splash_ef.level(),
+					scaled)
+			}
+			host.add_effect_to(rid, splash_ef)
+		}
+	}
+
+	// Splash particle event — the coloured cloud at the impact point.
+	// LevelEvent ID 2002 is the Bedrock potion splash particle.
+	host.broadcast_near(e.pos.x, e.pos.y, e.pos.z, b.splash_radius * 2, &protocol.LevelEventPacket{
+		event_id:   level_event_potion_splash
+		position:   e.pos
+		event_data: colour
+	})
+
+	// Glass break sound at impact.
+	// https://minecraft.fandom.com/fr/wiki/Potion_jetable
+	host.broadcast_near(e.pos.x, e.pos.y, e.pos.z, b.splash_radius * 2, &protocol.LevelSoundEventPacket{
+		sound:           'random.glass'
+		position:        e.pos
+		extra_data:      -1
+		entity_type:     'minecraft:splash_potion'
+		actor_unique_id: e.unique_id
+	})
+}
+
+// invert_undead_instant swaps instant health and instant damage for undead
+// targets. Instant Health (beneficial to living) damages undead; Instant Damage
+// (harmful to living) heals undead.
+// https://minecraft.fandom.com/fr/wiki/Mort-vivant
+fn invert_undead_instant(ef effect.Effect) effect.Effect {
+	if ef.effect_type().id == effect.instant_health.id {
+		return effect.new_instant_with_potency(effect.instant_damage, ef.level(), ef.potency())
+	}
+	if ef.effect_type().id == effect.instant_damage.id {
+		return effect.new_instant_with_potency(effect.instant_health, ef.level(), ef.potency())
+	}
+	return ef
+}
+
+// level_event_potion_splash is the Bedrock LevelEvent ID for the coloured
+// splash potion particle cloud. Vanilla constant is 2002.
+
+// blend_splash_colour averages the RGB colours of all effects (including
+// instant ones) for the splash particle. Separate from effect.blend_colour
+// which skips non-lasting types — those are needed for entity metadata
+// particles but NOT for the impact splash, which should match the potion.
+fn blend_splash_colour(effects []effect.Effect) int {
+	if effects.len == 0 {
+		return 0
+	}
+	mut r_sum, mut g_sum, mut b_sum := 0, 0, 0
+	for ef in effects {
+		t := ef.effect_type()
+		r_sum += int(t.rgb[0])
+		g_sum += int(t.rgb[1])
+		b_sum += int(t.rgb[2])
+	}
+	count := effects.len
+	// No alpha byte — LevelEvent 2002 expects 0x00RRGGBB, not 0xAARRGGBB.
+	return int(u32(r_sum / count) << 16 | u32(g_sum / count) << 8 | u32(b_sum / count))
+}
+
+const level_event_potion_splash = 2002

--- a/server/entity/splash_potion.v
+++ b/server/entity/splash_potion.v
@@ -2,18 +2,24 @@ module entity
 
 import math
 import protocol
+import protocol.types
 import server.effect
 import server.item
 
 // SplashPotionBehaviour is a projectile that applies potion effects to every
 // actor within splash_radius on impact (entity or block). The meta field
 // selects which potion type (use PotionType.effects() from server/item).
-// https://minecraft.fandom.com/fr/wiki/Potion_jetable — radius 4.0 blocks.
+// When lingering is true the projectile spawns an Area Effect Cloud instead of
+// applying effects directly — used for lingering potions.
+// https://minecraft.wiki/w/Splash_Potion — radius 4.0 blocks.
 @[heap]
 pub struct SplashPotionBehaviour {
 pub:
 	network_id string = 'minecraft:splash_potion'
 	meta       int // potion meta value (5-42), same as drinkable potions
+	// lingering makes the projectile spawn an Area Effect Cloud on impact
+	// rather than applying effects immediately.
+	lingering bool
 pub mut:
 	gravity_accel f32 = 0.05
 	drag_factor   f32 = 0.01
@@ -23,6 +29,43 @@ pub mut:
 
 pub fn (b &SplashPotionBehaviour) identifier() string {
 	return b.network_id
+}
+
+// spawn_packet builds the AddActorPacket for a thrown potion projectile.
+// Sets the effect colour and ambience metadata so the client renders the
+// correct coloured particle trail while the potion is in flight.
+pub fn (b &SplashPotionBehaviour) spawn_packet(e &Entity) &protocol.AddActorPacket {
+	effects := item.potion_from_meta(b.meta).effects()
+	colour := blend_splash_colour(effects)
+	ambient := effect.any_ambient(effects)
+	mut ambient_byte := u8(0)
+	if ambient {
+		ambient_byte = 1
+	}
+	return &protocol.AddActorPacket{
+		actor_unique_id:  e.unique_id
+		actor_runtime_id: e.runtime_id
+		type:             e.identifier
+		position:         e.pos
+		motion:           e.velocity
+		pitch:            e.pitch
+		yaw:              e.yaw
+		head_yaw:         e.head_yaw
+		body_yaw:         e.yaw
+		attributes:        []types.ActorAttribute{}
+		metadata:          [
+			types.MetadataEntry{
+				key:   protocol.meta_key_effect_color
+				value: types.MetaInt{value: colour}
+			},
+			types.MetadataEntry{
+				key:   protocol.meta_key_effect_ambience
+				value: types.MetaByte{value: i8(ambient_byte)}
+			},
+		]
+		synced_properties: types.PropertySyncData{}
+		links:             []types.EntityLink{}
+	}
 }
 
 pub fn (mut b SplashPotionBehaviour) tick(mut e Entity, mut host Host) {
@@ -55,27 +98,22 @@ pub fn (mut b SplashPotionBehaviour) tick(mut e Entity, mut host Host) {
 	}
 }
 
-// resolve_impact either applies splash effects immediately (splash
-// potion) or spawns a lingering cloud entity (lingering potion).
+// resolve_impact either applies splash effects immediately (splash potion)
+// or spawns an area effect cloud (lingering potion).
 fn (mut b SplashPotionBehaviour) resolve_impact(mut e Entity, mut host Host) {
-	if b.network_id.contains('lingering') {
-		// Lingering potion: spawn Area Effect Cloud that applies
-		// reduced effects over time and broadcasts the impact sound.
-		cloud := &LingeringCloudBehaviour{
-			network_id: 'minecraft:lingering_potion'
-			meta:       b.meta
-		}
-		host.spawn_behaviour(cloud, e.pos)
-		// Glass break sound at impact (same as splash).
+	if b.lingering {
+		e.kill()
+		host.spawn_behaviour(&LingeringCloudBehaviour{
+			meta: b.meta
+		}, e.pos)
 		host.broadcast_near(e.pos.x, e.pos.y, e.pos.z, 8.0, &protocol.LevelSoundEventPacket{
 			sound:           'random.glass'
 			position:        e.pos
 			extra_data:      -1
-			entity_type:     'minecraft:lingering_potion'
+			entity_type:     'minecraft:area_effect_cloud'
 			actor_unique_id: e.unique_id
 		})
 	} else {
-		// Splash potion: immediate area-of-effect.
 		b.apply_splash(mut e, mut host)
 	}
 }
@@ -170,8 +208,9 @@ fn invert_undead_instant(ef effect.Effect) effect.Effect {
 // blend_splash_colour averages the RGB colours of all effects (including
 // instant ones) for the splash particle. Separate from effect.blend_colour
 // which skips non-lasting types — those are needed for entity metadata
-// particles but NOT for the impact splash, which should match the potion.
-fn blend_splash_colour(effects []effect.Effect) int {
+// particles but NOT for the impact splash or projectile trail, which should
+// match the potion colour.
+pub fn blend_splash_colour(effects []effect.Effect) int {
 	if effects.len == 0 {
 		return 0
 	}

--- a/server/entity/splash_potion.v
+++ b/server/entity/splash_potion.v
@@ -43,15 +43,40 @@ pub fn (mut b SplashPotionBehaviour) tick(mut e Entity, mut host Host) {
 	}
 	// Check if we hit an entity.
 	if _ := host.entity_hit_test(e.pos, e.runtime_id) {
-		b.apply_splash(mut e, mut host)
+		b.resolve_impact(mut e, mut host)
 		e.kill()
 		return
 	}
 	// Check if we hit a block.
 	if e.hit_block {
-		b.apply_splash(mut e, mut host)
+		b.resolve_impact(mut e, mut host)
 		e.kill()
 		return
+	}
+}
+
+// resolve_impact either applies splash effects immediately (splash
+// potion) or spawns a lingering cloud entity (lingering potion).
+fn (mut b SplashPotionBehaviour) resolve_impact(mut e Entity, mut host Host) {
+	if b.network_id.contains('lingering') {
+		// Lingering potion: spawn Area Effect Cloud that applies
+		// reduced effects over time and broadcasts the impact sound.
+		cloud := &LingeringCloudBehaviour{
+			network_id: 'minecraft:lingering_potion'
+			meta:       b.meta
+		}
+		host.spawn_behaviour(cloud, e.pos)
+		// Glass break sound at impact (same as splash).
+		host.broadcast_near(e.pos.x, e.pos.y, e.pos.z, 8.0, &protocol.LevelSoundEventPacket{
+			sound:           'random.glass'
+			position:        e.pos
+			extra_data:      -1
+			entity_type:     'minecraft:lingering_potion'
+			actor_unique_id: e.unique_id
+		})
+	} else {
+		// Splash potion: immediate area-of-effect.
+		b.apply_splash(mut e, mut host)
 	}
 }
 

--- a/server/item/potion.v
+++ b/server/item/potion.v
@@ -3,9 +3,9 @@ module item
 import time
 import server.effect
 
-// TODO: 1.21 potion types (wind_charged, weaving, oozing, infested) — need
+// TODO: 1.21 potion types (wind_charged, weaving, oozing, infested)  -  need
 // corresponding effect Type definitions in server/effect/ first.
-// TODO: brewing stand — needs block entity, UI form, recipe matching, blaze
+// TODO: brewing stand  -  needs block entity, UI form, recipe matching, blaze
 // powder fuel, and 20-second brew timer. Out of scope for initial potion
 // drinking.
 

--- a/server/item/potion.v
+++ b/server/item/potion.v
@@ -3,11 +3,20 @@ module item
 import time
 import server.effect
 
+// TODO: 1.21 potion types (wind_charged, weaving, oozing, infested) — need
+// corresponding effect Type definitions in server/effect/ first.
+// TODO: brewing stand — needs block entity, UI form, recipe matching, blaze
+// powder fuel, and 20-second brew timer. Out of scope for initial potion
+// drinking.
+
+
+
 pub struct ConsumeResult {
 pub:
 	effects           []effect.Effect
 	replacement_id    string
 	replacement_count int
+	sound             string
 }
 
 pub struct PotionType {
@@ -202,5 +211,6 @@ pub fn (i PotionItem) consume_result(meta int) ConsumeResult {
 		effects:           potion_from_meta(meta).effects()
 		replacement_id:    'minecraft:glass_bottle'
 		replacement_count: 1
+		sound:             'random.drink'
 	}
 }

--- a/server/item/potion_test.v
+++ b/server/item/potion_test.v
@@ -19,11 +19,27 @@ fn test_registered_potion_is_consumable_and_returns_bottle() {
 
 	assert it.max_stack_size() == 1
 	assert it is PotionItem
+	assert it is ConsumableItem
 	if it is PotionItem {
 		result := it.consume_result(21)
 		assert result.effects.len == 1
 		assert result.effects[0].effect_type() == effect.instant_health
 		assert result.replacement_id == 'minecraft:glass_bottle'
 		assert result.replacement_count == 1
+		assert result.sound == 'random.drink'
+	}
+}
+
+fn test_registry_consume_result_works_for_potion() {
+	r := new_registry()
+	result := r.consume_result('minecraft:potion', 21) or { panic('expected ConsumeResult') }
+	assert result.effects.len == 1
+	assert result.sound == 'random.drink'
+}
+
+fn test_registry_consume_result_returns_none_for_non_consumable() {
+	r := new_registry()
+	if _ := r.consume_result('minecraft:stick', 0) {
+		assert false, 'stick should not be consumable'
 	}
 }

--- a/server/session/blocks.v
+++ b/server/session/blocks.v
@@ -320,12 +320,43 @@ fn (mut s NetworkSession) damage_held_item(amount int) {
 	s.send_slot_update(s.held_slot, s.held_item)
 }
 
-// use_held_item_in_air runs a UseableItem's on use behaviour (e.g. goat_horn's sound).
+// use_held_item_in_air runs a UseableItem or ConsumableItem's behaviour when
+// the player right-clicks in air (goat horn sound, drinking a potion).
 fn (mut s NetworkSession) use_held_item_in_air() {
 	if s.dead || !s.can_interact() {
 		return
 	}
 	stack, name := s.held_stack_and_name()
+
+	// ConsumableItem path — potions and other drinkables. The client sends
+	// this packet when the drinking animation completes, carrying the
+	// inventory action (old item → replacement) in the transaction.
+	if consume := s.hub.items.consume_result(name, stack.meta) {
+		mut use_ctx := event.new_context(event.ItemUseData{
+			player:    s
+			item_name: name
+			meta:      stack.meta
+		})
+		s.hub.events.item_use(mut use_ctx)
+		if use_ctx.is_cancelled() {
+			return
+		}
+		for e in consume.effects {
+			s.apply_add_effect(e)
+		}
+		if consume.sound != '' {
+			s.hub.broadcast(&protocol.LevelSoundEventPacket{
+				sound:           consume.sound
+				position:        s.current_position()
+				extra_data:      -1
+				entity_type:     'minecraft:player'
+				actor_unique_id: i64(s.runtime_id)
+			})
+		}
+		return
+	}
+
+	// UseableItem path — goat horn, etc.
 	if cooldown := s.hub.items.cooldown_ticks(name) {
 		if s.hub.current_tick < s.cooldown_until[name] {
 			return
@@ -333,13 +364,13 @@ fn (mut s NetworkSession) use_held_item_in_air() {
 		s.cooldown_until[name] = s.hub.current_tick + i64(cooldown)
 	}
 	result := s.hub.items.use_result(name, stack.meta) or { return }
-	mut use_ctx := event.new_context(event.ItemUseData{
+	mut use_ctx2 := event.new_context(event.ItemUseData{
 		player:    s
 		item_name: name
 		meta:      stack.meta
 	})
-	s.hub.events.item_use(mut use_ctx)
-	if use_ctx.is_cancelled() {
+	s.hub.events.item_use(mut use_ctx2)
+	if use_ctx2.is_cancelled() {
 		return
 	}
 	if result.sound == '' {

--- a/server/session/blocks.v
+++ b/server/session/blocks.v
@@ -331,7 +331,7 @@ fn (mut s NetworkSession) use_held_item_in_air() {
 	}
 	stack, name := s.held_stack_and_name()
 
-	// Splash/lingering potions — throw as projectile.
+	// Splash/lingering potions  -  throw as projectile.
 	if name == 'minecraft:splash_potion' || name == 'minecraft:lingering_potion' {
 		mut use_ctx := event.new_context(event.ItemUseData{
 			player:    s
@@ -346,7 +346,7 @@ fn (mut s NetworkSession) use_held_item_in_air() {
 		return
 	}
 
-	// ConsumableItem — potions, drinkables.
+	// ConsumableItem  -  potions, drinkables.
 	if consume := s.hub.items.consume_result(name, stack.meta) {
 		mut use_ctx := event.new_context(event.ItemUseData{
 			player:    s
@@ -374,7 +374,7 @@ fn (mut s NetworkSession) use_held_item_in_air() {
 		return
 	}
 
-	// UseableItem — goat horn etc.
+	// UseableItem  -  goat horn etc.
 	if cooldown := s.hub.items.cooldown_ticks(name) {
 		if s.hub.current_tick < s.cooldown_until[name] {
 			return
@@ -759,13 +759,13 @@ fn (mut s NetworkSession) consume_held_item() {
 
 // replace_held_stack_with swaps the held item stack for replacement_id (count
 // items). Does nothing in creative mode. An empty replacement_id leaves the
-// slot empty — used after drinking a potion to give back a glass bottle.
+// slot empty  -  used after drinking a potion to give back a glass bottle.
 fn (mut s NetworkSession) replace_held_stack_with(replacement_id string, count int) {
 	if s.game_mode == protocol.game_type_creative || s.game_mode == protocol.game_type_creative_spectator {
 		return
 	}
 	if replacement_id == '' || count <= 0 {
-		// No replacement — just remove the held stack.
+		// No replacement  -  just remove the held stack.
 		s.consume_held_item()
 		return
 	}

--- a/server/session/blocks.v
+++ b/server/session/blocks.v
@@ -321,16 +321,17 @@ fn (mut s NetworkSession) damage_held_item(amount int) {
 }
 
 // use_held_item_in_air runs a UseableItem or ConsumableItem's behaviour when
-// the player right-clicks in air (goat horn sound, drinking a potion).
+// the player right-clicks in air. For potions the drinking animation plays
+// client-side; the server applies effects as soon as the click arrives.
+// TODO: defer ConsumableItem processing until the client's use-duration
+// (32 ticks for potions) elapses, once the protocol carries use_duration.
 fn (mut s NetworkSession) use_held_item_in_air() {
 	if s.dead || !s.can_interact() {
 		return
 	}
 	stack, name := s.held_stack_and_name()
 
-	// ConsumableItem path — potions and other drinkables. The client sends
-	// this packet when the drinking animation completes, carrying the
-	// inventory action (old item → replacement) in the transaction.
+	// ConsumableItem — potions, drinkables.
 	if consume := s.hub.items.consume_result(name, stack.meta) {
 		mut use_ctx := event.new_context(event.ItemUseData{
 			player:    s
@@ -353,10 +354,12 @@ fn (mut s NetworkSession) use_held_item_in_air() {
 				actor_unique_id: i64(s.runtime_id)
 			})
 		}
+		// Replace the held potion with the empty bottle (or nothing in creative).
+		s.replace_held_stack_with(consume.replacement_id, consume.replacement_count)
 		return
 	}
 
-	// UseableItem path — goat horn, etc.
+	// UseableItem — goat horn etc.
 	if cooldown := s.hub.items.cooldown_ticks(name) {
 		if s.hub.current_tick < s.cooldown_until[name] {
 			return
@@ -364,13 +367,13 @@ fn (mut s NetworkSession) use_held_item_in_air() {
 		s.cooldown_until[name] = s.hub.current_tick + i64(cooldown)
 	}
 	result := s.hub.items.use_result(name, stack.meta) or { return }
-	mut use_ctx2 := event.new_context(event.ItemUseData{
+	mut use_ctx := event.new_context(event.ItemUseData{
 		player:    s
 		item_name: name
 		meta:      stack.meta
 	})
-	s.hub.events.item_use(mut use_ctx2)
-	if use_ctx2.is_cancelled() {
+	s.hub.events.item_use(mut use_ctx)
+	if use_ctx.is_cancelled() {
 		return
 	}
 	if result.sound == '' {
@@ -735,6 +738,43 @@ fn (mut s NetworkSession) consume_held_item() {
 	} else {
 		s.inv_slots.delete(s.held_slot)
 	}
+	s.held_item = wrapped
+	s.send_slot_update(s.held_slot, wrapped)
+}
+
+// replace_held_stack_with swaps the held item stack for replacement_id (count
+// items). Does nothing in creative mode. An empty replacement_id leaves the
+// slot empty — used after drinking a potion to give back a glass bottle.
+fn (mut s NetworkSession) replace_held_stack_with(replacement_id string, count int) {
+	if s.game_mode == protocol.game_type_creative || s.game_mode == protocol.game_type_creative_spectator {
+		return
+	}
+	if replacement_id == '' || count <= 0 {
+		// No replacement — just remove the held stack.
+		s.consume_held_item()
+		return
+	}
+	// Remove the current held item.
+	_, net := s.inventory_stack_at(s.held_slot)
+	if net != 0 {
+		s.inv_stacks.delete(net)
+		s.inv_slots.delete(s.held_slot)
+	}
+	numeric_id := s.hub.data.item_id(replacement_id)
+	if numeric_id == 0 && replacement_id != 'minecraft:air' {
+		s.held_item = empty_stack()
+		s.send_slot_update(s.held_slot, s.held_item)
+		return
+	}
+	replacement := types.ItemStack{
+		id:               numeric_id
+		count:            count
+		block_runtime_id: 0
+		raw_extra_data:   []u8{}
+	}
+	new_net := s.track_stack(replacement)
+	s.inv_slots[s.held_slot] = new_net
+	wrapped := wrap_stack_id(replacement, new_net)
 	s.held_item = wrapped
 	s.send_slot_update(s.held_slot, wrapped)
 }

--- a/server/session/blocks.v
+++ b/server/session/blocks.v
@@ -331,6 +331,21 @@ fn (mut s NetworkSession) use_held_item_in_air() {
 	}
 	stack, name := s.held_stack_and_name()
 
+	// Splash/lingering potions — throw as projectile.
+	if name == 'minecraft:splash_potion' || name == 'minecraft:lingering_potion' {
+		mut use_ctx := event.new_context(event.ItemUseData{
+			player:    s
+			item_name: name
+			meta:      stack.meta
+		})
+		s.hub.events.item_use(mut use_ctx)
+		if use_ctx.is_cancelled() {
+			return
+		}
+		s.throw_splash_potion(name, stack.meta)
+		return
+	}
+
 	// ConsumableItem — potions, drinkables.
 	if consume := s.hub.items.consume_result(name, stack.meta) {
 		mut use_ctx := event.new_context(event.ItemUseData{

--- a/server/session/effects.v
+++ b/server/session/effects.v
@@ -101,6 +101,17 @@ fn (mut s NetworkSession) tick_effects() {
 	if result.expired.len > 0 {
 		s.update_effect_metadata()
 	}
+	// LevelEvent 2002 at three body heights every 25 ticks
+	// while effects active.  Same packet as splash impact.
+	if result.active.len > 0 && s.hub.current_tick % 25 == 0 {
+		colour := effect.blend_colour(s.effects.effects())
+		feet := types.Vector3{s.position.x, s.position.y - 1.6, s.position.z}
+		s.hub.broadcast(&protocol.LevelEventPacket{
+			event_id:   2002
+			position:   feet
+			event_data: colour
+		})
+	}
 }
 
 fn (mut s NetworkSession) send_active_effects() {
@@ -110,7 +121,6 @@ fn (mut s NetworkSession) send_active_effects() {
 }
 
 fn (mut s NetworkSession) send_effect(e effect.Effect) {
-	s.send_effect_removal(e.effect_type())
 	s.send_mob_effect(e, mob_effect_add)
 }
 
@@ -125,6 +135,12 @@ fn (mut s NetworkSession) send_effect_removal(typ effect.Type) {
 	})
 }
 
+// send_mob_effect delivers a MobEffectPacket.  Effect particles
+// do not render client-side: StartGamePacket is from an older
+// protocol revision than the client (1.26.30).  The handshake
+// succeeds but the client enters a degraded state.
+// Workaround: LevelEvent 2002 spawned each tick in tick_effects.
+// TODO: update StartGamePacket to the current protocol revision.
 fn (mut s NetworkSession) send_mob_effect(e effect.Effect, event_id int) {
 	if !s.spawned {
 		return
@@ -235,35 +251,13 @@ fn (mut s NetworkSession) damage_from_effect(amount f32, fatal bool) {
 	}
 }
 
-// update_effect_metadata recalculates the blended potion particle colour from all
-// active effects and pushes it, together with the ambient flag, as entity metadata
-// so the client renders the correct swirling particles around the player.
+// update_effect_metadata pushes the full entity metadata block so
+// viewers see the blended potion particle colour around the player.
 fn (mut s NetworkSession) update_effect_metadata() {
 	if !s.spawned {
 		return
 	}
-	active := s.effects.effects()
-	colour := effect.blend_colour(active)
-	ambient := effect.any_ambient(active)
-	mut ambient_byte := u8(0)
-	if ambient {
-		ambient_byte = 1
-	}
-	s.hub.broadcast(&protocol.SetActorDataPacket{
-		actor_runtime_id: s.runtime_id
-		metadata: [
-			types.MetadataEntry{
-				key:   protocol.meta_key_effect_color
-				value: types.MetaInt{value: colour}
-			},
-			types.MetadataEntry{
-				key:   protocol.meta_key_effect_ambience
-				value: types.MetaByte{value: i8(ambient_byte)}
-			},
-		]
-		synced_properties: types.PropertySyncData{}
-		tick:              0
-	})
+	s.hub.broadcast(s.set_actor_data())
 }
 
 fn (mut s NetworkSession) send_health() {

--- a/server/session/effects.v
+++ b/server/session/effects.v
@@ -2,6 +2,7 @@ module session
 
 import math
 import protocol
+import protocol.types
 import server.effect
 import server.event
 
@@ -64,6 +65,7 @@ fn (mut s NetworkSession) apply_add_effect(e effect.Effect) {
 		}
 	}
 	s.send_effect(result.effect)
+	s.update_effect_metadata()
 }
 
 fn (mut s NetworkSession) apply_remove_effect(typ effect.Type) {
@@ -78,6 +80,7 @@ fn (mut s NetworkSession) apply_remove_effect(typ effect.Type) {
 	removed := s.effects.remove(typ) or { return }
 	s.apply_effect_end(removed)
 	s.send_effect_removal(typ)
+	s.update_effect_metadata()
 }
 
 fn (mut h Hub) tick_effects() {
@@ -94,6 +97,9 @@ fn (mut s NetworkSession) tick_effects() {
 	for e in result.expired {
 		s.apply_effect_end(e)
 		s.send_effect_removal(e.effect_type())
+	}
+	if result.expired.len > 0 {
+		s.update_effect_metadata()
 	}
 }
 
@@ -227,6 +233,37 @@ fn (mut s NetworkSession) damage_from_effect(amount f32, fatal bool) {
 	if s.health <= 0 {
 		s.die('%death.attack.magic', [s.identity.display_name])
 	}
+}
+
+// update_effect_metadata recalculates the blended potion particle colour from all
+// active effects and pushes it, together with the ambient flag, as entity metadata
+// so the client renders the correct swirling particles around the player.
+fn (mut s NetworkSession) update_effect_metadata() {
+	if !s.spawned {
+		return
+	}
+	active := s.effects.effects()
+	colour := effect.blend_colour(active)
+	ambient := effect.any_ambient(active)
+	mut ambient_byte := u8(0)
+	if ambient {
+		ambient_byte = 1
+	}
+	s.hub.broadcast(&protocol.SetActorDataPacket{
+		actor_runtime_id: s.runtime_id
+		metadata: [
+			types.MetadataEntry{
+				key:   protocol.meta_key_effect_color
+				value: types.MetaInt{value: colour}
+			},
+			types.MetadataEntry{
+				key:   protocol.meta_key_effect_ambience
+				value: types.MetaByte{value: i8(ambient_byte)}
+			},
+		]
+		synced_properties: types.PropertySyncData{}
+		tick:              0
+	})
 }
 
 fn (mut s NetworkSession) send_health() {

--- a/server/session/effects.v
+++ b/server/session/effects.v
@@ -103,7 +103,7 @@ fn (mut s NetworkSession) tick_effects() {
 	}
 	// mobspell_emitter particle every 5 ticks while effects active.
 	// Linked via actor_unique_id so the client reads the entity colour
-	// from key-8 metadata — same system as the area effect cloud.
+	// from key-8 metadata  -  same system as the area effect cloud.
 	if result.active.len > 0 && s.hub.current_tick % 5 == 0 {
 		feet := types.Vector3{s.position.x, s.position.y - 1.6, s.position.z}
 		s.hub.broadcast_near(feet.x, feet.y, feet.z, 32.0, &protocol.SpawnParticleEffectPacket{
@@ -136,13 +136,11 @@ fn (mut s NetworkSession) send_effect_removal(typ effect.Type) {
 	})
 }
 
-// send_mob_effect delivers a MobEffectPacket.  Effect particles
-// do not render client-side: StartGamePacket is from an older
-// protocol revision than the client (1.26.30).  The handshake
-// succeeds but the client enters a degraded state.
-// Workaround: mobspell_emitter particle every 5 ticks in tick_effects,
-// linked via actor_unique_id so the client reads colour from key-8
-// metadata.
+// send_mob_effect delivers a MobEffectPacket. Effect particles do not
+// render client-side: StartGamePacket is from an older protocol revision
+// than the client (1.26.30). Workaround: mobspell_emitter particle every
+// 5 ticks in tick_effects, linked via actor_unique_id so the client
+// reads colour from key-8 metadata.
 // TODO: update StartGamePacket to the current protocol revision.
 fn (mut s NetworkSession) send_mob_effect(e effect.Effect, event_id int) {
 	if !s.spawned {
@@ -256,7 +254,7 @@ fn (mut s NetworkSession) damage_from_effect(amount f32, fatal bool) {
 
 // update_effect_metadata pushes the blended potion particle colour
 // and ambience flag as entity metadata so viewers see the swirling
-// particles around the player. Only keys 8-9 are updated — the full
+// particles around the player. Only keys 8-9 are updated  -  the full
 // metadata block is sent at spawn via visible_name_metadata.
 fn (mut s NetworkSession) update_effect_metadata() {
 	if !s.spawned {

--- a/server/session/effects.v
+++ b/server/session/effects.v
@@ -101,15 +101,16 @@ fn (mut s NetworkSession) tick_effects() {
 	if result.expired.len > 0 {
 		s.update_effect_metadata()
 	}
-	// LevelEvent 2002 at three body heights every 25 ticks
-	// while effects active.  Same packet as splash impact.
-	if result.active.len > 0 && s.hub.current_tick % 25 == 0 {
-		colour := effect.blend_colour(s.effects.effects())
+	// mobspell_emitter particle every 5 ticks while effects active.
+	// Linked via actor_unique_id so the client reads the entity colour
+	// from key-8 metadata — same system as the area effect cloud.
+	if result.active.len > 0 && s.hub.current_tick % 5 == 0 {
 		feet := types.Vector3{s.position.x, s.position.y - 1.6, s.position.z}
-		s.hub.broadcast(&protocol.LevelEventPacket{
-			event_id:   2002
-			position:   feet
-			event_data: colour
+		s.hub.broadcast_near(feet.x, feet.y, feet.z, 32.0, &protocol.SpawnParticleEffectPacket{
+			dimension_id:    0
+			actor_unique_id: i64(s.runtime_id)
+			position:        feet
+			particle_name:   'minecraft:mobspell_emitter'
 		})
 	}
 }
@@ -139,7 +140,9 @@ fn (mut s NetworkSession) send_effect_removal(typ effect.Type) {
 // do not render client-side: StartGamePacket is from an older
 // protocol revision than the client (1.26.30).  The handshake
 // succeeds but the client enters a degraded state.
-// Workaround: LevelEvent 2002 spawned each tick in tick_effects.
+// Workaround: mobspell_emitter particle every 5 ticks in tick_effects,
+// linked via actor_unique_id so the client reads colour from key-8
+// metadata.
 // TODO: update StartGamePacket to the current protocol revision.
 fn (mut s NetworkSession) send_mob_effect(e effect.Effect, event_id int) {
 	if !s.spawned {
@@ -251,13 +254,36 @@ fn (mut s NetworkSession) damage_from_effect(amount f32, fatal bool) {
 	}
 }
 
-// update_effect_metadata pushes the full entity metadata block so
-// viewers see the blended potion particle colour around the player.
+// update_effect_metadata pushes the blended potion particle colour
+// and ambience flag as entity metadata so viewers see the swirling
+// particles around the player. Only keys 8-9 are updated — the full
+// metadata block is sent at spawn via visible_name_metadata.
 fn (mut s NetworkSession) update_effect_metadata() {
 	if !s.spawned {
 		return
 	}
-	s.hub.broadcast(s.set_actor_data())
+	active := s.effects.effects()
+	colour := effect.blend_colour(active)
+	ambient := effect.any_ambient(active)
+	mut ambient_byte := u8(0)
+	if ambient {
+		ambient_byte = 1
+	}
+	s.hub.broadcast(&protocol.SetActorDataPacket{
+		actor_runtime_id: s.runtime_id
+		metadata:         [
+			types.MetadataEntry{
+				key:   protocol.meta_key_effect_color
+				value: types.MetaInt{value: colour}
+			},
+			types.MetadataEntry{
+				key:   protocol.meta_key_effect_ambience
+				value: types.MetaByte{value: i8(ambient_byte)}
+			},
+		]
+		synced_properties: types.PropertySyncData{}
+		tick:              0
+	})
 }
 
 fn (mut s NetworkSession) send_health() {

--- a/server/session/entity_view.v
+++ b/server/session/entity_view.v
@@ -175,6 +175,13 @@ pub fn (mut h Hub) drop_item(stack types.ItemStack, x f32, y f32, z f32, vx f32,
 // is_undead reports whether the actor at runtime_id is an undead mob.
 // Players and non-undead entities return false.
 // https://minecraft.fandom.com/fr/wiki/Mort-vivant
+
+// spawn_behaviour creates a new entity from a behaviour at the given
+// position and returns the live Entity reference.
+pub fn (mut h Hub) spawn_behaviour(b entity.Behaviour, pos types.Vector3) &entity.Entity {
+	return h.entities.spawn(b, pos)
+}
+
 pub fn (mut h Hub) is_undead(runtime_id u64) bool {
 	if h.session_by_runtime(runtime_id) != none {
 		return false

--- a/server/session/entity_view.v
+++ b/server/session/entity_view.v
@@ -311,7 +311,7 @@ fn (mut s NetworkSession) throw_splash_potion(entity_type string, meta int) {
 	// the potion arcs freely.
 	projectile.floor_y = -64
 
-	// Throw sound - broadcast at the player's position.
+		// Throw sound - broadcast at the player's position.
 	s.hub.broadcast(&protocol.LevelSoundEventPacket{
 		sound:           'random.bow'
 		position:        s.current_position()
@@ -330,8 +330,7 @@ fn (mut s NetworkSession) throw_splash_potion(entity_type string, meta int) {
 // throwable_offset applies a pitch correction for thrown projectiles so they
 // arc upward rather than leaving straight from the crosshair. The correction is
 // strongest when looking horizontally and tapers to zero when looking straight
-// up or down. Dragonfly formula.
-// https://github.com/df-mc/dragonfly
+// up or down.
 fn throwable_offset(pitch f32) f32 {
 	p2 := pitch * pitch
 	max_p2 := f32(89.9 * 89.9)

--- a/server/session/entity_view.v
+++ b/server/session/entity_view.v
@@ -1,7 +1,10 @@
 module session
 
+import math
 import protocol
 import protocol.types
+import server.effect
+import server.entity
 import server.event
 
 // broadcast_near delivers p only to players whose position is within radius of
@@ -65,6 +68,44 @@ pub fn (mut h Hub) nearest_player(pos types.Vector3, radius f32) ?u64 {
 		return none
 	}
 	return rid
+}
+
+// add_effect_to applies ef to the actor at runtime_id (player or entity).
+pub fn (mut h Hub) add_effect_to(runtime_id u64, ef effect.Effect) {
+	if mut target := h.session_by_runtime(runtime_id) {
+		target.add_effect(ef)
+		return
+	}
+	h.entities.add_effect(runtime_id, ef)
+}
+
+// entities_near returns the runtime ids of every actor (player and non-player
+// entity) whose position is within radius blocks of pos. Used by splash
+// potions and other area-of-effect behaviours.
+pub fn (mut h Hub) entities_near(pos types.Vector3, radius f32) []u64 {
+	mut ids := []u64{}
+	radius_sq := radius * radius
+	for e in h.entities.snapshot() {
+		if e.dead {
+			continue
+		}
+		dx := e.pos.x - pos.x
+		dy := e.pos.y - pos.y
+		dz := e.pos.z - pos.z
+		if dx * dx + dy * dy + dz * dz <= radius_sq {
+			ids << e.runtime_id
+		}
+	}
+	for mut target in h.snapshot() {
+		tp := target.current_position()
+		dx := tp.x - pos.x
+		dy := tp.y - pos.y
+		dz := tp.z - pos.z
+		if dx * dx + dy * dy + dz * dz <= radius_sq {
+			ids << target.runtime_id
+		}
+	}
+	return ids
 }
 
 // notify_entity_despawn dispatches EntityDespawnData. Observational only,
@@ -131,6 +172,36 @@ pub fn (mut h Hub) drop_item(stack types.ItemStack, x f32, y f32, z f32, vx f32,
 	h.entities.spawn_item(stack, types.Vector3{x, y, z}, types.Vector3{vx, vy, vz}, pickup_delay)
 }
 
+// is_undead reports whether the actor at runtime_id is an undead mob.
+// Players and non-undead entities return false.
+// https://minecraft.fandom.com/fr/wiki/Mort-vivant
+pub fn (mut h Hub) is_undead(runtime_id u64) bool {
+	if h.session_by_runtime(runtime_id) != none {
+		return false
+	}
+	e := h.entities.by_runtime_id(runtime_id) or { return false }
+	return e.identifier in undead_mobs
+}
+
+// undead_mobs is the set of Bedrock entity identifiers that invert instant
+// health/damage effects (Healing harms them, Harming heals them).
+// https://minecraft.fandom.com/fr/wiki/Mort-vivant
+const undead_mobs = [
+	'minecraft:zombie',
+	'minecraft:skeleton',
+	'minecraft:wither_skeleton',
+	'minecraft:stray',
+	'minecraft:husk',
+	'minecraft:drowned',
+	'minecraft:zombified_piglin',
+	'minecraft:zombie_pigman',
+	'minecraft:zoglin',
+	'minecraft:wither',
+	'minecraft:skeleton_horse',
+	'minecraft:zombie_horse',
+	'minecraft:phantom',
+]
+
 // nearest_player_name is the plugin.ServerView facing form of nearest_player.
 // It resolves the runtime id back to a display name rather than leaking the
 // internal runtime id concept into the plugin surface.
@@ -166,4 +237,79 @@ fn (mut h Hub) find_nearest_player(pos types.Vector3, radius f32) (u64, types.Ve
 		}
 	}
 	return best_rid, best_pos, found
+}
+
+// throw_splash_potion spawns a splash potion projectile from the player's eye
+// level, offset slightly forward so it appears in front of the face rather than
+// inside the head. Removes the held item unless in creative.
+fn (mut s NetworkSession) throw_splash_potion(entity_type string, meta int) {
+	// Vedrock stores player position at eye level (feet + 1.62).
+	// Bump it up slightly so the entity clears the player head
+	mut pos := s.current_position()
+	pos.y += 0.1
+
+	// Compute throw direction from pitch and yaw.
+	// Apply throwableOffset: pitch correction that arcs the projectile
+	// upward to compensate for hand position vs eye level.
+	// Dragonfly formula: pitch -= sqrt(89.9^2 - pitch^2) * (26.5 / 89.9)
+	adjusted := throwable_offset(s.pitch)
+	pitch_rad := adjusted * f32(math.pi) / 180.0
+	yaw_rad := s.yaw * f32(math.pi) / 180.0
+	vx := -math.sinf(yaw_rad) * math.cosf(pitch_rad)
+	vy := -math.sinf(pitch_rad)
+	vz := math.cosf(yaw_rad) * math.cosf(pitch_rad)
+
+	// Nudge the spawn point forward along the horizontal look direction
+	// so the entity is visible in front of the player's face, not clipped
+	// inside their head model. Skip when looking straight up/down.
+	horiz := math.sqrtf(vx * vx + vz * vz)
+	if horiz > 0.01 {
+		pos.x += (vx / horiz) * 0.3
+		pos.z += (vz / horiz) * 0.3
+	}
+
+	// Vanilla Bedrock potion throw speed ~ 0.5 blocks/tick.
+	speed := f32(0.5)
+
+	behaviour := &entity.SplashPotionBehaviour{
+		network_id: entity_type
+		meta:       meta
+	}
+	mut projectile := s.hub.entities.spawn(behaviour, pos)
+	projectile.velocity = types.Vector3{vx * speed, vy * speed, vz * speed}
+	projectile.pitch = s.pitch
+	projectile.yaw = s.yaw
+	// floor_y defaults to spawn y, which clamps the projectile to eye
+	// level and prevents gravity from pulling it down. Set it low so
+	// the potion arcs freely.
+	projectile.floor_y = -64
+
+	// Throw sound - broadcast at the player's position.
+	s.hub.broadcast(&protocol.LevelSoundEventPacket{
+		sound:           'random.bow'
+		position:        s.current_position()
+		extra_data:      -1
+		entity_type:     'minecraft:player'
+		actor_unique_id: i64(s.runtime_id)
+	})
+
+	// Remove the thrown item from the held slot (unless creative).
+	if s.game_mode != protocol.game_type_creative
+		&& s.game_mode != protocol.game_type_creative_spectator {
+		s.consume_held_item()
+	}
+}
+
+// throwable_offset applies a pitch correction for thrown projectiles so they
+// arc upward rather than leaving straight from the crosshair. The correction is
+// strongest when looking horizontally and tapers to zero when looking straight
+// up or down. Dragonfly formula.
+// https://github.com/df-mc/dragonfly
+fn throwable_offset(pitch f32) f32 {
+	p2 := pitch * pitch
+	max_p2 := f32(89.9 * 89.9)
+	if p2 >= max_p2 {
+		return pitch
+	}
+	return pitch - f32(math.sqrtf(max_p2 - p2) * (26.5 / 89.9))
 }

--- a/server/session/entity_view.v
+++ b/server/session/entity_view.v
@@ -6,6 +6,7 @@ import protocol.types
 import server.effect
 import server.entity
 import server.event
+import server.item
 
 // broadcast_near delivers p only to players whose position is within radius of
 // the point (x, y, z). Used by the entity Manager for view-distance culling so
@@ -279,10 +280,29 @@ fn (mut s NetworkSession) throw_splash_potion(entity_type string, meta int) {
 	speed := f32(0.5)
 
 	behaviour := &entity.SplashPotionBehaviour{
-		network_id: entity_type
+		network_id: 'minecraft:splash_potion'
 		meta:       meta
+		lingering:  entity_type == 'minecraft:lingering_potion'
 	}
 	mut projectile := s.hub.entities.spawn(behaviour, pos)
+
+	// Set the projectile's particle colour to match the potion. The default
+	// spawn packet has no effects on a fresh projectile, so the client
+	// renders a water-blue trail. Send an immediate metadata update with the
+	// blended potion colour so the trail matches the thrown potion.
+	effects := item.potion_from_meta(meta).effects()
+	colour := entity.blend_splash_colour(effects)
+	s.hub.broadcast_near(pos.x, pos.y, pos.z, 64.0, &protocol.SetActorDataPacket{
+		actor_runtime_id: projectile.runtime_id
+		metadata:         [
+			types.MetadataEntry{
+				key:   protocol.meta_key_effect_color
+				value: types.MetaInt{value: colour}
+			},
+		]
+		synced_properties: types.PropertySyncData{}
+	})
+
 	projectile.velocity = types.Vector3{vx * speed, vy * speed, vz * speed}
 	projectile.pitch = s.pitch
 	projectile.yaw = s.yaw

--- a/server/session/inventory.v
+++ b/server/session/inventory.v
@@ -318,6 +318,15 @@ fn (mut s NetworkSession) apply_consume(action protocol.StackRequestAction) []Sl
 	for e in result.effects {
 		s.apply_add_effect(e)
 	}
+	if result.sound != '' {
+		s.hub.broadcast(&protocol.LevelSoundEventPacket{
+			sound:           result.sound
+			position:        s.current_position()
+			extra_data:      -1
+			entity_type:     'minecraft:player'
+			actor_unique_id: i64(s.runtime_id)
+		})
+	}
 	return s.replace_consumed_stack(action, stack, result)
 }
 

--- a/server/session/metadata.v
+++ b/server/session/metadata.v
@@ -2,13 +2,21 @@ module session
 
 import protocol
 import protocol.types
+import server.effect
 
 fn entity_flag_bit(index int) i64 {
 	return i64(u64(1) << u64(index))
 }
 
-fn visible_name_metadata(name string) []types.MetadataEntry {
+fn (s &NetworkSession) visible_name_metadata(name string) []types.MetadataEntry {
 	flags := entity_flag_bit(protocol.entity_flag_breathing) | entity_flag_bit(protocol.entity_flag_can_climb) | entity_flag_bit(protocol.entity_flag_has_collision) | entity_flag_bit(protocol.entity_flag_affected_by_gravity) | entity_flag_bit(protocol.entity_flag_show_name) | entity_flag_bit(protocol.entity_flag_always_show_name)
+	active := s.effects.effects()
+	colour := effect.blend_colour(active)
+	ambient := effect.any_ambient(active)
+	mut ambient_byte := u8(0)
+	if ambient {
+		ambient_byte = 1
+	}
 	return [
 		types.MetadataEntry{
 			key:   protocol.meta_key_flags
@@ -31,13 +39,13 @@ fn visible_name_metadata(name string) []types.MetadataEntry {
 		types.MetadataEntry{
 			key:   protocol.meta_key_effect_color
 			value: types.MetaInt{
-				value: 0
+				value: colour
 			}
 		},
 		types.MetadataEntry{
 			key:   protocol.meta_key_effect_ambience
 			value: types.MetaByte{
-				value: 0
+				value: i8(ambient_byte)
 			}
 		},
 		types.MetadataEntry{
@@ -64,7 +72,7 @@ fn visible_name_metadata(name string) []types.MetadataEntry {
 fn (s &NetworkSession) set_actor_data() &protocol.SetActorDataPacket {
 	return &protocol.SetActorDataPacket{
 		actor_runtime_id:  s.runtime_id
-		metadata:          visible_name_metadata(s.identity.display_name)
+		metadata:          s.visible_name_metadata(s.identity.display_name)
 		synced_properties: types.PropertySyncData{}
 		tick:              0
 	}

--- a/server/session/player_view.v
+++ b/server/session/player_view.v
@@ -130,7 +130,7 @@ fn (s &NetworkSession) add_player_packet() &protocol.AddPlayerPacket {
 		head_yaw:          s.head_yaw
 		item:              s.held_item
 		game_mode:         s.game_mode
-		metadata:          visible_name_metadata(s.identity.display_name)
+		metadata:          s.visible_name_metadata(s.identity.display_name)
 		synced_properties: types.PropertySyncData{}
 		abilities:         s.build_abilities()
 		links:             []types.EntityLink{}


### PR DESCRIPTION
## Description

Almost full potion system; drinkable, splash, lingering with area effect clouds,
vanilla-accurate effect particle colours, some effects implementations.

## Checklist
- [x] `v -check .` is clean
- [x] `v test server` is fully green
- [x] Follows the conventions in AGENTS.md (OOP, `pub`/capitalized exports, no import cycles, minimal comments)
- [x] Cross-session gameplay state is only mutated on the actor thread (via `hub.submit(...)`)
- [x] No unrelated changes bundled in
