### PR TITLE
refactor: remove default registry tests from block and item test files

### DIFF
--- a/server/block/block_test.v
+++ b/server/block/block_test.v
@@ -2,11 +2,6 @@ module block
 
 import server.world
 
-fn test_default_registry_has_builtins() {
-	r := new_registry()
-	assert r.len() == 402
-}
-
 fn test_short_grass_and_fern_are_replaceable() {
 	r := new_registry()
 	short_grass := r.get_by_name('minecraft:short_grass') or { panic('missing short_grass') }

--- a/server/item/item_test.v
+++ b/server/item/item_test.v
@@ -1,10 +1,5 @@
 module item
 
-fn test_default_registry_has_builtins() {
-	r := new_registry()
-	assert r.len() == 487
-}
-
 fn test_registered_blocks_carry_runtime_id() {
 	r := new_registry()
 	it := r.get('minecraft:stone') or { panic('missing stone') }


### PR DESCRIPTION
## Description

Just a deletion of two unit tests that will be certainly be a mess later.
Follows: https://github.com/bedrock-v/Vedrock/pull/79#discussion_r3676371990

## Checklist
- [x] `v -check .` is clean
- [x] `v test server` is fully green
- [x] Follows the conventions in AGENTS.md (OOP, `pub`/capitalized exports, no import cycles, minimal comments)
- [x] Cross-session gameplay state is only mutated on the actor thread (via `hub.submit(...)`)
- [x] No unrelated changes bundled in
