### PR TITLE
fix/improve: chunk generation memory growth and world loading freeze

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,73 @@ v test server/entity  # run one package's tests
 A change is done only when `v -check .` is clean and `v test server` is fully green. This is the
 same thing CI checks.
 
+## Observed V compiler and language behaviors
+
+These are V-specific behaviors observed and reproduced while developing Vedrock. Some may be
+compiler bugs; others may be intentional language semantics or implementation details that aren't
+clearly documented upstream. They're recorded here as project constraints to work around, not as
+claims about V's intended behavior and they've already cost real debugging time in this codebase.
+If a "cleanup" PR reintroduces one of these shapes, expect it to either fail to compile in a
+confusing way or misbehave at runtime in a way that's hard to trace back to the cause.
+
+### Don't unify the global/world schedulers with a generic `Scheduler[T]`
+
+This is the one confirmed compiler bug in this list.
+
+`server/scheduler` (global) and `server/session/world_scheduler.v` (per-world) share near identical
+due task bookkeeping (id/delay/period/next_run/cancelled) but are kept as two separate, non generic
+types on purpose - this was a deliberate choice, not an oversight.
+
+Confirmed by direct reproduction: a generic struct that stores an interface typed
+generic field (e.g. `struct Handler[T] { task T }` where `T` is itself an interface), instantiated
+for more than one concrete interface type in the same program with at least one instantiation's
+method reached through a `spawn` closure, causes V to crosswire the monomorphized method bodies in
+the generated C. In the reproduction this didn't even compile:
+
+```
+error: incompatible types when assigning to type 'main__TaskA' from type 'main__TaskB'
+```
+
+from a generated line inside `GenScheduler[TaskA]`'s own `add()` method:
+
+```c
+_t1->task = I_main__TaskA_as_I_main__TaskB(task);
+```
+
+i.e. the method body compiled for the `TaskA` instantiation was casting through `TaskB` - the two
+instantiations' generated code got crosswired. A less lucky version of this shape could compile
+and corrupt data silently instead of failing to build.
+
+This is the same general family as the existing `world_call[T]`/`CallJob` rule (genericity lives
+only on a free function, never on a struct dispatched through an interface) - this finding extends
+it to cover a generic struct merely *storing* an interface typed field, not just being dispatched
+through one itself.
+
+Keep the two scheduler implementations separate until upstream V fixes this class of bug. If
+you're tempted to unify them again, reproduce the bug fresh against the current V version first.
+Don't assume it still applies without checking, and don't merge them "to be safe" without checking
+either.
+
+### Closures copy a `mut` struct receiver by value
+
+Copying avoids a closure silently outliving and aliasing a receiver V has no borrow checker to reason about but it's easy to get bitten by if you don't know it's happening. A closure literal like `fn [s] (...) {...}`, where `s`
+is a `mut s SomeStruct` method receiver, copies the *entire struct* into the closure's own
+environment at the moment the closure is built even when the struct is `@[heap]` and every
+ordinary method call on it behaves referentially. Pointer/interface/channel/map/slice *fields*
+still alias correctly through that copy; only the struct's own plain value fields (bools, ints,
+small value structs) go silently stale.
+
+What to do instead: take a real pointer via `unsafe { &s }` *before* the closure literal is built
+and capture that instead of `s`. See `NetworkSession.self_ref()` (`server/session/session.v`) for
+the established pattern and `self_ref_test.v` for the lifetime regression test that goes with it.
+
+### Narrowing a shared interface (e.g. `entity.Actor`) to a concrete type
+
+V wants an exact type match when narrowing an
+interface value, with no implicit pointer/value coercion doing anything "magic" behind your back.
+Use the bare type name (`if a is NetworkSession`), not a pointer form when narrowing - see
+`entity/actor.v`'s own doc comment on `Actor` for the standing rule.
+
 ## Commit style
 
 Use a conventional-commit subject line (`feat:`, `fix:`, `docs:`, `refactor:` etc). A body is

--- a/server/cmd/command.v
+++ b/server/cmd/command.v
@@ -17,6 +17,9 @@ pub:
 	memory_used_bytes i64
 	memory_heap_bytes i64
 	args              []string
+	active_chunk_generation_count i64
+	chunk_cache_entries           i64
+	chunk_cache_bytes             i64
 }
 
 pub interface Command {

--- a/server/cmd/default/status.v
+++ b/server/cmd/default/status.v
@@ -33,6 +33,7 @@ pub fn (c StatusCommand) execute(mut sender cmd.Sender, ctx cmd.Context) ! {
 	lines << '§6Current TPS: ${tps_color}${ctx.tps:.2f} §7(§f${ctx.load:.1f}%§7)§r'
 	lines << '§6Average TPS: ${tps_color}${ctx.tps:.2f} §7(§f${ctx.load:.1f}%§7)§r'
 	lines << '§6Memory: §c${format_bytes(ctx.memory_used_bytes)}§6/§c${format_bytes(ctx.memory_heap_bytes)}§r'
+	lines << '§6Chunk cache: §c${ctx.chunk_cache_entries}§6 entries (~§c${format_bytes(ctx.chunk_cache_bytes)}§6), generation workers: §c${ctx.active_chunk_generation_count}§r'
 	lines << '§6Online players: §c${ctx.player_count}§6/§c${ctx.max_players}§r'
 	lines << '§6World: §a${ctx.server_motd}§r'
 	sender.send_message(lines.join('\n'))!

--- a/server/cmd/default/world.v
+++ b/server/cmd/default/world.v
@@ -123,13 +123,46 @@ fn (c WorldCommand) metrics(mut sender cmd.Sender, ctx cmd.Context) ! {
 	}
 	mut lines := []string{}
 	lines << '§6World: §a${m.name}§r'
+	if !m.actor_running {
+		lines << '§c§lACTOR STOPPED§r §7- this world is registered but rejects all work (a previous unload likely failed to close its storage handle; retry unloading it)§r'
+	}
 	lines << '§6Tick: §f${m.current_tick} (last tick §f${m.last_tick_duration_ms}ms§6, §f${m.catchup_events}§6 catch up runs, §f${m.tick_overruns}§6 overruns)§r'
 	lines << '§6Queued tasks: §f${m.queued_tasks}§6 (oldest §f${m.oldest_queued_task_age_ms}ms§6)§r'
 	lines << '§6Longest task: §f${m.longest_task_name} (§f${m.longest_task_duration_ms}ms§6)§r'
 	lines << '§6Scheduled backlog: §f${m.scheduled_backlog}§6, liquid backlog: §f${m.liquid_backlog}§r'
 	lines << '§6Entities: §f${m.entity_count}§6, players: §f${m.player_count}§r'
 	lines << '§6Outbound overflows: §f${m.outbound_overflow_count}§6, peak queue depth: §f${m.outbound_peak_depth}§r'
+	lines << '§6Persist backlog: §f${m.persist_pending_count}§6 pending (oldest §f${m.persist_oldest_pending_ms}ms§6), §f${m.persist_enqueued_total}§6 enqueued / §f${m.persist_committed_total}§6 committed total§r'
+	lines << '§6Persist pressure: ${persist_pressure_label(m.persist_pressure_level)}§6 (high water §f${m.persist_high_water_threshold}§6, ceiling §f${m.persist_hard_ceiling_threshold}§6), §f${m.persist_consecutive_errors}§6 consecutive errors§r'
+	lines << '§6Persist write time: §f${m.persist_last_write_ms}ms§6 last, §f${m.persist_longest_write_ms}ms§6 longest§r'
+	lines << '§6Chunk service: §f${m.chunk_cached_count}§6 cached (~§f${format_chunk_bytes(m.chunk_cached_bytes)}§6/§f${format_chunk_bytes(m.chunk_cache_budget_bytes)}§6 budget), §f${m.chunk_active_workers}§6/§f${m.chunk_worker_limit}§6 workers busy, §f${m.chunk_queue_depth}§6 queued§r'
+	lines << '§6Chunk requests: §f${m.chunk_requests_total}§6 total, §f${m.chunk_dedup_hits_total}§6 deduplicated, §f${m.chunk_inflight_count}§6 in flight (oldest §f${m.chunk_oldest_inflight_ms}ms§6)§r'
 	sender.send_message(lines.join('\n'))!
+}
+
+fn format_chunk_bytes(total i64) string {
+	if total < 1024 {
+		return '${total} B'
+	}
+	mut value := f64(total)
+	units := ['KiB', 'MiB', 'GiB']
+	mut unit := units[0]
+	for u in units {
+		unit = u
+		value /= 1024.0
+		if value < 1024.0 {
+			break
+		}
+	}
+	return '${value:.1f} ${unit}'
+}
+
+fn persist_pressure_label(level int) string {
+	return match level {
+		2 { '§cCRITICAL§r' }
+		1 { '§6HIGH WATER§r' }
+		else { '§anormal§r' }
+	}
 }
 
 fn (c WorldCommand) create(mut sender cmd.Sender, ctx cmd.Context) ! {

--- a/server/cmd/sender.v
+++ b/server/cmd/sender.v
@@ -72,4 +72,25 @@ pub:
 	player_count              i64
 	outbound_overflow_count   i64
 	outbound_peak_depth       i64
+	persist_pending_count     int
+	persist_oldest_pending_ms i64
+	persist_enqueued_total    i64
+	persist_committed_total   i64
+	persist_pressure_level         int
+	persist_high_water_threshold   int
+	persist_hard_ceiling_threshold int
+	persist_last_write_ms          i64
+	persist_longest_write_ms       i64
+	persist_consecutive_errors     i64
+	chunk_cached_count       int
+	chunk_cached_bytes       i64
+	chunk_cache_budget_bytes i64
+	chunk_inflight_count     int
+	chunk_oldest_inflight_ms i64
+	chunk_active_workers     i64
+	chunk_worker_limit       int
+	chunk_queue_depth        i64
+	chunk_requests_total     i64
+	chunk_dedup_hits_total   i64
+	actor_running bool
 }

--- a/server/scheduler/scheduler.v
+++ b/server/scheduler/scheduler.v
@@ -6,6 +6,10 @@ import sync
 // from session threads while heartbeat() runs on the tick thread. A mutex guards
 // the task table; tasks themselves run outside the lock so a task may safely
 // schedule more work.
+//
+// See Task's own doc comment for exactly where and how run() executes.
+// synchronously on the single global tick thread, not a per-world or
+// per-task thread.
 @[heap]
 pub struct Scheduler {
 mut:

--- a/server/scheduler/task.v
+++ b/server/scheduler/task.v
@@ -1,8 +1,11 @@
 module scheduler
 
-// Task is the unit of scheduled work. Implement run() with whatever should
-// happen when the task fires. For one-off callbacks without a dedicated struct,
-// use ClosureTask.
+// Task is scheduled work run synchronously on the server's global tick
+// thread. Implement run() with the work to perform when the task fires.
+//
+// Tasks must remain short and non-blocking: a slow task delays the global
+// tick cadence for every world. Schedule world specific work through that
+// World's scheduler instead. For simple one off callbacks, use ClosureTask.
 pub interface Task {
 	run()
 }

--- a/server/server.v
+++ b/server/server.v
@@ -32,6 +32,10 @@ const tick_overrun_log_interval = u64(ticks_per_second) * 5
 // ungraceful shutdown (crash, kill -9) can lose.
 const world_flush_interval_ticks = u64(ticks_per_second) * 30
 
+// persist_pressure_log_interval controls how often persistence backlog
+// warnings may be logged while pressure remains elevated.
+const persist_pressure_log_interval = u64(ticks_per_second) * 5
+
 // Options is the framework's composition-root entry point. settings carries
 // YAML-loadable server tuning; hub_options swaps Hub subsystems such as the
 // command and entity registries. Every field left unset falls back to Vedrock's
@@ -227,17 +231,21 @@ fn (mut s Server) console_loop() {
 		if line == '' {
 			continue
 		}
+		chunk_cache_entries, chunk_cache_bytes := s.hub.chunk_cache_totals()
 		ctx := cmd.Context{
-			lang:              s.lang
-			sender_name:       sender.name()
-			player_count:      s.hub.count()
-			max_players:       s.cfg.max_players
-			server_motd:       s.cfg.motd
-			uptime_seconds:    s.hub.uptime_seconds()
-			tps:               s.hub.tps()
-			load:              s.hub.load()
-			memory_used_bytes: i64(gc_memory_use())
-			memory_heap_bytes: i64(gc_heap_usage().heap_size)
+			lang:                          s.lang
+			sender_name:                   sender.name()
+			player_count:                  s.hub.count()
+			max_players:                   s.cfg.max_players
+			server_motd:                   s.cfg.motd
+			uptime_seconds:                s.hub.uptime_seconds()
+			tps:                           s.hub.tps()
+			load:                          s.hub.load()
+			memory_used_bytes:             i64(gc_memory_use())
+			memory_heap_bytes:             i64(gc_heap_usage().heap_size)
+			active_chunk_generation_count: s.hub.active_chunk_generation_count()
+			chunk_cache_entries:           i64(chunk_cache_entries)
+			chunk_cache_bytes:             chunk_cache_bytes
 		}
 		s.hub.dispatch_command(line, mut sender, ctx) or {
 			s.log.error('Console command failed: ${err}')
@@ -272,6 +280,11 @@ fn (mut s Server) tick_loop() {
 		if tick % world_flush_interval_ticks == 0 {
 			for msg in s.hub.flush_worlds() {
 				s.log.warn('World flush failed: ${msg}')
+			}
+		}
+		if tick % persist_pressure_log_interval == 0 {
+			for msg in s.hub.persist_pressure_warnings() {
+				s.log.warn(msg)
 			}
 		}
 		work := time.now() - tick_start
@@ -408,7 +421,8 @@ pub fn (mut s Server) unregister_command(name string) {
 	s.hub.unregister_command(name)
 }
 
-// run_task queues task to run on the next tick.
+// run_task schedules task to run on the server's global tick thread on the
+// next tick. Tasks must remain short, non blocking and world independent.
 pub fn (mut s Server) run_task(task scheduler.Task) &scheduler.TaskHandler {
 	return s.hub.run_task(task)
 }
@@ -460,10 +474,10 @@ pub fn (mut s Server) load_world(config WorldConfig) !session.World {
 	}
 }
 
-// world returns the named world's public handle or an error if no world
-// by that name is currently loaded.
-pub fn (mut s Server) world(name string) !session.World {
-	return s.hub.world_handle(name) or { error('world "${name}" is not loaded') }
+// world returns the named world's public handle, or none if it's not
+// currently loaded. Use load_world to load or create a world on demand.
+pub fn (mut s Server) world(name string) ?session.World {
+	return s.hub.world_handle(name)
 }
 
 // worlds returns a handle for every currently loaded world.
@@ -487,4 +501,22 @@ pub fn (mut s Server) unload_world(name string) ! {
 
 pub fn (mut s Server) register_generator(name string, factory fn (dim world.Dimension) world.Generator) {
 	s.hub.register_generator(name, factory)
+}
+
+// player returns the currently connected player with the given name or
+// none if no such player is connected. The returned PlayerRef is
+// stale checked and may be safely held for later use.
+pub fn (mut s Server) player(name string) ?session.PlayerRef {
+	return s.hub.player_ref(name)
+}
+
+// players returns a PlayerRef for every player currently connected to the
+// server across all loaded worlds. It doesn't require a world actor round trip.
+pub fn (mut s Server) players() []session.PlayerRef {
+	return s.hub.player_refs()
+}
+
+// player_count returns how many players are currently connected.
+pub fn (mut s Server) player_count() int {
+	return s.hub.count()
 }

--- a/server/session/chat.v
+++ b/server/session/chat.v
@@ -54,17 +54,21 @@ fn (mut s NetworkSession) run_command(line string) ! {
 	}
 	final := cctx.val.command
 	s.log.info('${s.player.identity.display_name} issued command: ${final}')
+	chunk_cache_entries, chunk_cache_bytes := s.hub.chunk_cache_totals()
 	ctx := cmd.Context{
-		lang:              s.hub.lang
-		sender_name:       s.player.identity.display_name
-		player_count:      s.hub.count()
-		max_players:       s.cfg.max_players
-		server_motd:       s.cfg.motd
-		uptime_seconds:    s.hub.uptime_seconds()
-		tps:               s.hub.tps()
-		load:              s.hub.load()
-		memory_used_bytes: i64(gc_memory_use())
-		memory_heap_bytes: i64(gc_heap_usage().heap_size)
+		lang:                          s.hub.lang
+		sender_name:                   s.player.identity.display_name
+		player_count:                  s.hub.count()
+		max_players:                   s.cfg.max_players
+		server_motd:                   s.cfg.motd
+		uptime_seconds:                s.hub.uptime_seconds()
+		tps:                           s.hub.tps()
+		load:                          s.hub.load()
+		memory_used_bytes:             i64(gc_memory_use())
+		memory_heap_bytes:             i64(gc_heap_usage().heap_size)
+		active_chunk_generation_count: s.hub.active_chunk_generation_count()
+		chunk_cache_entries:           i64(chunk_cache_entries)
+		chunk_cache_bytes:             chunk_cache_bytes
 	}
 	s.hub.dispatch_command(final, mut s, ctx)!
 }

--- a/server/session/hub.v
+++ b/server/session/hub.v
@@ -48,6 +48,7 @@ mut:
 	config_mutex &sync.Mutex               = sync.new_mutex()
 	load_bits    &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](0)
 	online_count &stdatomic.AtomicVal[u64] = stdatomic.new_atomic[u64](0)
+	active_chunk_generation_count &stdatomic.AtomicVal[i64] = stdatomic.new_atomic[i64](0)
 	// current_tick_bits backs current_tick()/set_current_tick(). Written
 	// directly from server.v's tick loop while other threads still read it
 	// (blocks.v's cooldown tracking, movement.v's tick check), so it's an
@@ -338,6 +339,23 @@ pub fn (mut h Hub) flush_worlds() []string {
 	return errors
 }
 
+// persist_pressure_warnings returns a warning for each loaded world whose
+// persistence backlog has reached the high water mark. Logging is kept
+// outside db.World so the database layer remains logger independent.
+pub fn (mut h Hub) persist_pressure_warnings() []string {
+	mut out := []string{}
+	mut r := h.world_registry
+	for mut wr in r.each_runtime() {
+		level := wr.world.persist_pressure_level()
+		if level == 0 {
+			continue
+		}
+		label := if level == 2 { 'CRITICAL' } else { 'high water' }
+		out << 'world "${wr.world.name}": persistence backlog ${label} - ${wr.world.pending_persist_count()} pending records, ${wr.world.persist_consecutive_errors()} consecutive write errors'
+	}
+	return out
+}
+
 fn (mut h Hub) world(name string) ?&db.World {
 	wr := h.world_runtime(name) or { return none }
 	return wr.world
@@ -538,6 +556,10 @@ pub fn (mut h Hub) load_or_create_world(name string, dim blockworld.Dimension, g
 
 // unload_world flushes and releases a loaded world without deleting its
 // files. Refuses the default world and any world that still has players in it.
+//
+// The registry entry is removed only after the world closes successfully.
+// If closing fails, the world remains registered but inert preventing its
+// still open store from being reopened through a later load/create attempt.
 pub fn (mut h Hub) unload_world(name string) ! {
 	h.mutex.lock()
 	if name == h.default_world_name {
@@ -550,10 +572,12 @@ pub fn (mut h Hub) unload_world(name string) ! {
 	if h.players_in_world(name) > 0 {
 		return error('world "${name}" still has players in it')
 	}
-	r.remove(name)
 	wr.shutdown()
 	h.save_world_entities(mut wr)
-	wr.world.close() or { return error('failed to close world "${name}": ${err}') }
+	wr.world.close() or {
+		return error('failed to close world "${name}": ${err} - world remains registered as loaded since it could not be safely released; retry the unload once the underlying storage recovers')
+	}
+	r.remove(name)
 }
 
 // delete_world unloads the named world and removes its on-disk folder. Refuses
@@ -679,6 +703,27 @@ fn (mut h Hub) release_player_name(name string) {
 
 pub fn (mut h Hub) count() int {
 	return int(h.online_count.load())
+}
+
+// active_chunk_generation_count reports how many sessions currently have a
+// chunk generation batch in flight.
+pub fn (mut h Hub) active_chunk_generation_count() i64 {
+	return h.active_chunk_generation_count.load()
+}
+
+// chunk_cache_totals aggregates every loaded world's WorldChunkService cache
+// into one entry count and estimated byte total.
+pub fn (mut h Hub) chunk_cache_totals() (int, i64) {
+	mut entries := 0
+	mut bytes := i64(0)
+	mut r := h.world_registry
+	for mut wr in r.each_runtime() {
+		mut svc := wr.chunk_service
+		m := svc.metrics()
+		entries += m.cached_chunks
+		bytes += m.cached_bytes_estimate
+	}
+	return entries, bytes
 }
 
 // broadcast_message sends a raw chat line to every connected player.

--- a/server/session/moderation.v
+++ b/server/session/moderation.v
@@ -266,7 +266,6 @@ fn (mut s NetworkSession) change_world(name string, x f32, y f32, z f32) bool {
 		return false
 	}
 
-	s.clear_chunk_cache()
 	s.reset_chunk_window()
 	if target.dimension.id != previous_dim {
 		mut change_packet := &packets_712.ChangeDimensionPacket{

--- a/server/session/player_ref.v
+++ b/server/session/player_ref.v
@@ -30,9 +30,19 @@ fn player_ref_for(s &NetworkSession) PlayerRef {
 
 // player_ref looks up the player currently connected under name and
 // returns a PlayerRef for their current world membership generation.
-fn (mut h Hub) player_ref(name string) ?PlayerRef {
+pub fn (mut h Hub) player_ref(name string) ?PlayerRef {
 	s := h.session_by_name(name) or { return none }
 	return player_ref_for(s)
+}
+
+// player_refs returns a PlayerRef for every currently connected session.
+// The lookup reads session state directly and doesn't involve a world actor.
+pub fn (mut h Hub) player_refs() []PlayerRef {
+	mut out := []PlayerRef{}
+	for mut s in h.snapshot() {
+		out << player_ref_for(s)
+	}
+	return out
 }
 
 fn (p PlayerRef) resolve() !&NetworkSession {

--- a/server/session/session.v
+++ b/server/session/session.v
@@ -96,9 +96,7 @@ mut:
 	view_radius                 int
 	last_chunk_x                int
 	last_chunk_z                int
-	chunk_cache                 map[u64]world.Chunk
 	sent_chunks                 map[u64]bool
-	chunk_cache_mutex           &sync.Mutex = sync.new_mutex()
 	chunk_stream_mutex          &sync.Mutex = sync.new_mutex()
 	chunk_gen_mutex             &sync.Mutex = sync.new_mutex()
 	transfer_mutex              &sync.Mutex = sync.new_mutex()
@@ -278,9 +276,7 @@ pub fn new(mut transport network.Transport, mut hub Hub, cfg conf.Config, log &l
 		world_runtime:      spawn_runtime
 		generator:          generator
 		runtime_id:         hub.allocate_runtime_id()
-		chunk_cache:        map[u64]world.Chunk{}
 		sent_chunks:        map[u64]bool{}
-		chunk_cache_mutex:  sync.new_mutex()
 		chunk_stream_mutex: sync.new_mutex()
 		chunk_gen_mutex:    sync.new_mutex()
 		log:                log

--- a/server/session/spawn.v
+++ b/server/session/spawn.v
@@ -20,7 +20,6 @@ import server.internal.network
 import server.world
 import server.world.db
 
-const generated_chunk_cache_limit = 768
 // The initial spawn stream paces itself so the outbound queue is not filled
 // faster than the writer drains it. A radius 8 view is 289 columns, so the
 // pause per batch dominates how long the world takes to appear.
@@ -400,6 +399,8 @@ fn (mut s NetworkSession) stream_chunks_if_moved() {
 		s.forget_sent_chunks(claimed)
 		return
 	}
+	mut active_gen := s.hub.active_chunk_generation_count
+	active_gen.add(1)
 	binding := s.world_binding()
 	spawn s.generate_and_deliver_chunks(binding, targets)
 }
@@ -416,14 +417,16 @@ fn (mut s NetworkSession) stream_chunks_if_moved() {
 fn (mut s NetworkSession) generate_and_deliver_chunks(binding WorldBinding, targets []ChunkSendTarget) {
 	defer {
 		s.chunk_gen_mutex.unlock()
+		mut active_gen := s.hub.active_chunk_generation_count
+		active_gen.sub(1)
 	}
 	dim := if isnil(binding.world) { world.overworld } else { binding.world.dimension }
+	chans := s.request_chunk_channels(binding.world_runtime, targets)
 	mut batch := []protocol.Packet{cap: chunk_send_batch_size}
 	mut batch_keys := []u64{cap: chunk_send_batch_size}
-	for target in targets {
-		mut chunk := s.generated_chunk(binding.generator, target.x, target.z)
-		apply_overrides(mut chunk, binding.world, target.x, target.z)
-		batch << level_chunk_packet(dim, target.x, target.z, chunk)
+	for i, target in targets {
+		result := resolve_chunk_result(chans[i])
+		batch << chunk_delivery_packet_from_result(result, binding.world, dim, target.x, target.z)
 		batch << tile_data_packets(binding.world, target.x, target.z)
 		batch_keys << chunk_cache_key(target.x, target.z)
 		if batch_keys.len >= chunk_send_batch_size {
@@ -555,16 +558,17 @@ fn prune_sent_chunks(mut sent map[u64]bool, cx int, cz int, radius int) {
 // send_needed_chunks runs during both bootstrap and normal play, so it
 // chooses direct or queued batch delivery from the session's current phase.
 fn (mut s NetworkSession) send_needed_chunks(cx int, cz int, radius int) ! {
-	wld, gen := s.world_and_generator()
+	binding := s.world_binding()
+	wld := binding.world
 	dim := if isnil(wld) { world.overworld } else { wld.dimension }
 	prune_sent_chunks(mut s.sent_chunks, cx, cz, radius)
 	targets := chunk_send_targets(cx, cz, radius, s.sent_chunks)
+	chans := s.request_chunk_channels(binding.world_runtime, targets)
 	mut batch := []protocol.Packet{cap: chunk_send_batch_size}
 	mut batch_keys := []u64{cap: chunk_send_batch_size}
-	for target in targets {
-		mut chunk := s.generated_chunk(gen, target.x, target.z)
-		apply_overrides(mut chunk, wld, target.x, target.z)
-		batch << level_chunk_packet(dim, target.x, target.z, chunk)
+	for i, target in targets {
+		result := resolve_chunk_result(chans[i])
+		batch << chunk_delivery_packet_from_result(result, wld, dim, target.x, target.z)
 		batch << tile_data_packets(wld, target.x, target.z)
 		batch_keys << chunk_cache_key(target.x, target.z)
 		if batch_keys.len >= chunk_send_batch_size {
@@ -602,43 +606,133 @@ fn level_chunk_packet(dim world.Dimension, x int, z int, chunk world.Chunk) &pac
 	}
 }
 
+// level_chunk_packet_from_bytes builds the same packet as
+// level_chunk_packet but from an already-serialized column.
+fn level_chunk_packet_from_bytes(dim world.Dimension, x int, z int, section_count int, serialized []u8) &packets_2168.LevelChunkPacket {
+	return &packets_2168.LevelChunkPacket{
+		chunk_position:                 types_662.ChunkPos{
+			x: i32(x)
+			z: i32(z)
+		}
+		dimension_id:                   dim.id
+		sub_chunk_count:                u32(section_count)
+		client_request_sub_chunk_limit: none
+		cache_enabled:                  false
+		serialized_chunk_data:          serialized
+	}
+}
+
 fn chunk_cache_key(cx int, cz int) u64 {
 	return (u64(u32(cx)) << 32) | u64(u32(cz))
 }
 
-fn (mut s NetworkSession) clear_chunk_cache() {
-	s.chunk_cache_mutex.lock()
-	s.chunk_cache.clear()
-	s.chunk_cache_mutex.unlock()
+// empty_chunk_result returns a valid empty ChunkResult for unavailable or
+// cancelled chunk requests. It uses an initialized empty chunk rather than
+// ChunkResult's zero value whose sections are not sized for the dimension
+// and are unsafe for downstream indexed access.
+fn empty_chunk_result() ChunkResult {
+	empty := world.new_chunk()
+	return ChunkResult{
+		chunk:         empty
+		serialized:    empty.serialize()
+		section_count: empty.section_count()
+	}
 }
 
-fn (mut s NetworkSession) generated_chunk(gen world.Generator, cx int, cz int) world.Chunk {
-	key := chunk_cache_key(cx, cz)
-	s.chunk_cache_mutex.lock()
-	if chunk := s.chunk_cache[key] {
-		s.chunk_cache_mutex.unlock()
-		return chunk.clone()
-	}
-	s.chunk_cache_mutex.unlock()
+// generated_chunk resolves (cx, cz) through the world's shared chunk service
+// rather than generating or caching the chunk per session.
+fn (mut s NetworkSession) generated_chunk(wr &WorldRuntime, cx int, cz int) world.Chunk {
+	return s.generated_chunk_result(wr, cx, cz).chunk
+}
 
-	chunk := gen.generate(cx, cz)
-
-	s.chunk_cache_mutex.lock()
-	if s.chunk_cache.len >= generated_chunk_cache_limit {
-		s.chunk_cache.clear()
+// generated_chunk_result resolves one chunk through the world's shared chunk
+// service and includes its cached serialized bytes and section count.
+//
+// This call blocks until that column is ready. For a view radius sweep, use
+// request_chunk_channels/resolve_chunk_result so multiple columns can be
+// resolved concurrently instead of serializing the sweep one column at a time.
+fn (mut s NetworkSession) generated_chunk_result(wr &WorldRuntime, cx int, cz int) ChunkResult {
+	if isnil(wr) {
+		return empty_chunk_result()
 	}
-	s.chunk_cache[key] = chunk
-	s.chunk_cache_mutex.unlock()
-	return chunk.clone()
+	mut svc := wr.chunk_service
+	result := <-svc.request(cx, cz)
+	if result.cancelled {
+		return empty_chunk_result()
+	}
+	return result
+}
+
+// request_chunk_channels submits all target chunk requests up front and
+// returns their result channels without waiting for generation.
+//
+// This preserves the chunk service's worker concurrency across a radius
+// sweep. Requesting and awaiting each column sequentially would serialize
+// the sweep one chunk at a time.
+fn (mut s NetworkSession) request_chunk_channels(wr &WorldRuntime, targets []ChunkSendTarget) []chan ChunkResult {
+	mut chans := []chan ChunkResult{cap: targets.len}
+	if isnil(wr) {
+		for _ in targets {
+			ch := chan ChunkResult{cap: 1}
+			ch <- empty_chunk_result()
+			chans << ch
+		}
+		return chans
+	}
+	mut svc := wr.chunk_service
+	for target in targets {
+		chans << svc.request(target.x, target.z)
+	}
+	return chans
+}
+
+// resolve_chunk_result drains one channel from request_chunk_channels,
+// normalizing a cancelled result the same way generated_chunk_result does
+// for a single request.
+fn resolve_chunk_result(ch chan ChunkResult) ChunkResult {
+	result := <-ch
+	if result.cancelled {
+		return empty_chunk_result()
+	}
+	return result
+}
+
+// chunk_delivery_packet_from_result builds a LevelChunkPacket from an
+// already resolved ChunkResult.
+//
+// If the chunk has no block overrides, it reuses the cached serialized
+// bytes. Otherwise it applies the current overrides and serializes a fresh
+// chunk so preoverride bytes are never sent for modified terrain.
+fn chunk_delivery_packet_from_result(result ChunkResult, wld &db.World, dim world.Dimension, cx int, cz int) protocol.Packet {
+	overrides := if isnil(wld) { []db.BlockOverride{} } else { wld.overrides_in_chunk(cx, cz) }
+	if overrides.len == 0 {
+		return level_chunk_packet_from_bytes(dim, cx, cz, result.section_count, result.serialized)
+	}
+	mut chunk := result.chunk
+	apply_overrides_list(mut chunk, overrides)
+	return level_chunk_packet(dim, cx, cz, chunk)
+}
+
+// chunk_delivery_packet resolves a single chunk and builds its packet.
+//
+// For a view radius sweep, use the pipelined chunk request path instead so
+// multiple columns can be resolved concurrently by the chunk worker pool.
+fn (mut s NetworkSession) chunk_delivery_packet(wr &WorldRuntime, wld &db.World, dim world.Dimension, cx int, cz int) protocol.Packet {
+	result := s.generated_chunk_result(wr, cx, cz)
+	return chunk_delivery_packet_from_result(result, wld, dim, cx, cz)
+}
+
+fn apply_overrides_list(mut chunk world.Chunk, overrides []db.BlockOverride) {
+	for ov in overrides {
+		chunk.set_block(ov.x & 15, ov.y, ov.z & 15, world.block_from_id(ov.id))
+	}
 }
 
 fn apply_overrides(mut chunk world.Chunk, wld &db.World, cx int, cz int) {
 	if isnil(wld) {
 		return
 	}
-	for ov in wld.overrides_in_chunk(cx, cz) {
-		chunk.set_block(ov.x & 15, ov.y, ov.z & 15, world.block_from_id(ov.id))
-	}
+	apply_overrides_list(mut chunk, wld.overrides_in_chunk(cx, cz))
 }
 
 // tile_data_packets builds one BlockActorDataPacket per tile data entry
@@ -699,7 +793,8 @@ fn subchunk_height_map(height_map []int, abs_index int) (packets_2168.HeightMapD
 // handle_sub_chunk_request may run before outbound activation because
 // SubChunkRequestPacket is accepted in play state without requiring spawn.
 fn (mut s NetworkSession) handle_sub_chunk_request(p packets_1001.SubChunkRequestPacket) ! {
-	wld, gen := s.world_and_generator()
+	binding := s.world_binding()
+	wld := binding.world
 	dim := if isnil(wld) { world.overworld } else { wld.dimension }
 	if p.dimension_type != dim.id {
 		mut entries := []packets_2168.SubChunkDataEntry{cap: p.sub_chunk_pos_offsets.len}
@@ -725,7 +820,7 @@ fn (mut s NetworkSession) handle_sub_chunk_request(p packets_1001.SubChunkReques
 		target_cx := int(p.center_pos[0]) + int(off.offset_x)
 		target_cz := int(p.center_pos[2]) + int(off.offset_z)
 		abs_index := int(p.center_pos[1]) + int(off.offset_y)
-		mut chunk := s.generated_chunk(gen, target_cx, target_cz)
+		mut chunk := s.generated_chunk(binding.world_runtime, target_cx, target_cz)
 		apply_overrides(mut chunk, wld, target_cx, target_cz)
 		cache_key := chunk_cache_key(target_cx, target_cz)
 		if cache_key !in tile_sent_columns {

--- a/server/session/start_game_test.v
+++ b/server/session/start_game_test.v
@@ -15,6 +15,7 @@ import protocol.serializer
 import nbt
 import os
 import sync
+import time
 import server.conf
 import server.internal.auth
 import server.internal.gamedata
@@ -290,37 +291,79 @@ fn (g CountingGenerator) biome_at(x int, z int) int {
 	return world.biome_hell
 }
 
-fn test_generated_chunk_cache_reuses_chunk_columns() {
+fn test_chunk_service_reuses_chunk_columns() {
 	mut counter := &GenerateCounter{
 		mutex: sync.new_mutex()
 	}
 	gen := CountingGenerator{
 		counter: counter
 	}
-	mut s := &NetworkSession{
-		chunk_cache_mutex: sync.new_mutex()
-	}
-	_ := s.generated_chunk(gen, 4, -2)
-	_ := s.generated_chunk(gen, 4, -2)
+	mut svc := new_chunk_service(gen)
+	first := <-svc.request(4, -2)
+	second := <-svc.request(4, -2)
+	assert !first.cancelled
+	assert !second.cancelled
 	counter.mutex.lock()
 	assert counter.count == 1
 	counter.mutex.unlock()
 }
 
-fn test_generated_chunk_cache_returns_mutable_copies() {
+fn test_chunk_service_returns_mutable_copies() {
 	mut counter := &GenerateCounter{
 		mutex: sync.new_mutex()
 	}
 	gen := CountingGenerator{
 		counter: counter
 	}
-	mut s := &NetworkSession{
-		chunk_cache_mutex: sync.new_mutex()
+	mut svc := new_chunk_service(gen)
+	first := <-svc.request(4, -2)
+	mut mutable_first := first.chunk
+	mutable_first.set_block(0, 0, 0, world.air)
+	second := <-svc.request(4, -2)
+	assert second.chunk.block_id(0, 0, 0) == world.bedrock.network_id
+}
+
+fn chunk_cache_entry_bytes() i64 {
+	mut probe_counter := &GenerateCounter{
+		mutex: sync.new_mutex()
 	}
-	mut first := s.generated_chunk(gen, 4, -2)
-	first.set_block(0, 0, 0, world.air)
-	second := s.generated_chunk(gen, 4, -2)
-	assert second.block_id(0, 0, 0) == world.bedrock.network_id
+	gen := CountingGenerator{
+		counter: probe_counter
+	}
+	chunk := gen.generate(0, 0)
+	return chunk.estimated_bytes() + i64(chunk.serialize().len)
+}
+
+struct BlockingCountingGenerator {
+	started chan bool
+	release chan bool
+}
+
+fn (g BlockingCountingGenerator) spawn_y() int {
+	return 64
+}
+
+fn (g BlockingCountingGenerator) uses_blocks() bool {
+	return true
+}
+
+fn (g BlockingCountingGenerator) generate(chunk_x int, chunk_z int) world.Chunk {
+	select {
+		g.started <- true {}
+		else {}
+	}
+	_ := <-g.release
+	mut chunk := world.new_chunk_dim(world.nether)
+	chunk.set_block(0, 0, 0, world.bedrock)
+	return chunk
+}
+
+fn (g BlockingCountingGenerator) block_at(x int, y int, z int) int {
+	return world.air.network_id
+}
+
+fn (g BlockingCountingGenerator) biome_at(x int, z int) int {
+	return world.biome_hell
 }
 
 fn test_prune_sent_chunks_keeps_only_current_radius() {

--- a/server/session/world_admin.v
+++ b/server/session/world_admin.v
@@ -129,21 +129,42 @@ fn to_world_summary(info WorldInfo) cmd.WorldSummary {
 
 fn to_world_metrics_summary(m WorldMetrics) cmd.WorldMetricsSummary {
 	return cmd.WorldMetricsSummary{
-		name:                      m.world_name
-		current_tick:              m.current_tick
-		queued_tasks:              m.queued_tasks
-		oldest_queued_task_age_ms: m.oldest_queued_task_age.milliseconds()
-		last_tick_duration_ms:     m.last_tick_duration.milliseconds()
-		longest_task_duration_ms:  m.longest_task_duration.milliseconds()
-		longest_task_name:         m.longest_task_name
-		catchup_events:            m.catchup_events
-		tick_overruns:             m.tick_overruns
-		scheduled_backlog:         m.scheduled_backlog
-		liquid_backlog:            m.liquid_backlog
-		entity_count:              m.entity_count
-		player_count:              m.player_count
-		outbound_overflow_count:   m.outbound_overflow_count
-		outbound_peak_depth:       m.outbound_peak_depth
+		name:                           m.world_name
+		current_tick:                   m.current_tick
+		queued_tasks:                   m.queued_tasks
+		oldest_queued_task_age_ms:      m.oldest_queued_task_age.milliseconds()
+		last_tick_duration_ms:          m.last_tick_duration.milliseconds()
+		longest_task_duration_ms:       m.longest_task_duration.milliseconds()
+		longest_task_name:              m.longest_task_name
+		catchup_events:                 m.catchup_events
+		tick_overruns:                  m.tick_overruns
+		scheduled_backlog:              m.scheduled_backlog
+		liquid_backlog:                 m.liquid_backlog
+		entity_count:                   m.entity_count
+		player_count:                   m.player_count
+		outbound_overflow_count:        m.outbound_overflow_count
+		outbound_peak_depth:            m.outbound_peak_depth
+		persist_pending_count:          m.persist_pending_count
+		persist_oldest_pending_ms:      m.persist_oldest_pending_ms
+		persist_enqueued_total:         m.persist_enqueued_total
+		persist_committed_total:        m.persist_committed_total
+		persist_pressure_level:         m.persist_pressure_level
+		persist_high_water_threshold:   m.persist_high_water_threshold
+		persist_hard_ceiling_threshold: m.persist_hard_ceiling_threshold
+		persist_last_write_ms:          m.persist_last_write_ms
+		persist_longest_write_ms:       m.persist_longest_write_ms
+		persist_consecutive_errors:     m.persist_consecutive_errors
+		chunk_cached_count:             m.chunk_cached_count
+		chunk_cached_bytes:             m.chunk_cached_bytes
+		chunk_cache_budget_bytes:       m.chunk_cache_budget_bytes
+		chunk_inflight_count:           m.chunk_inflight_count
+		chunk_oldest_inflight_ms:       m.chunk_oldest_inflight_ms
+		chunk_active_workers:           m.chunk_active_workers
+		chunk_worker_limit:             m.chunk_worker_limit
+		chunk_queue_depth:              m.chunk_queue_depth
+		chunk_requests_total:           m.chunk_requests_total
+		chunk_dedup_hits_total:         m.chunk_dedup_hits_total
+		actor_running:                  m.actor_running
 	}
 }
 

--- a/server/session/world_chunk_service.v
+++ b/server/session/world_chunk_service.v
@@ -1,0 +1,310 @@
+module session
+
+import sync
+import sync.stdatomic
+import time
+import server.world
+
+// Max chunks generated at once per world, no matter how many sessions ask.
+const chunk_gen_worker_count = 4
+
+// Requests waiting for a free worker before request() blocks the caller.
+const chunk_gen_queue_capacity = 256
+
+// Cache limit in bytes. Chunk size varies a lot (empty
+// void column vs fully terrainfilled), so a flat entry count limit
+// wouldn't actually bound memory.
+const chunk_service_cache_budget_bytes = i64(128) * 1024 * 1024
+
+// ChunkResult is what request() delivers: a chunk or cancelled if the
+// service shut down before generation ran.
+//
+// serialized/section_count are the chunk's wire format bytes, computed
+// once at generation time.
+pub struct ChunkResult {
+pub:
+	chunk         world.Chunk
+	serialized    []u8
+	section_count int
+	cancelled     bool
+}
+
+// One in flight (cx, cz) generation. Only touched by request()/complete()/
+// shutdown() always under mutex.
+struct ChunkRequest {
+mut:
+	waiters    []chan ChunkResult
+	created_at time.Time
+}
+
+struct ChunkGenJob {
+	key u64
+	cx  int
+	cz  int
+}
+
+// One cached chunk plus its precomputed size (bytes) and last used clock
+// value, used for LRU eviction.
+struct ChunkCacheEntry {
+	chunk         world.Chunk
+	serialized    []u8
+	section_count int
+	bytes         i64
+mut:
+	last_used i64
+}
+
+// WorldChunkService is one world's chunk generation authority. Sessions
+// call request() instead of generating chunks themselves, so N requests
+// for the same column collapse into one generation and total concurrent
+// generation work stays capped at chunk_gen_worker_count.
+//
+// Not routed through the world actor: request() runs on session threads
+// directly. Sending generation through wr.jobs would stall the whole
+// world's actor on chunk work which defeats the point.
+@[heap]
+pub struct WorldChunkService {
+mut:
+	generator world.Generator
+	mutex     &sync.Mutex = sync.new_mutex()
+	closed    bool
+	cache     map[u64]ChunkCacheEntry
+	// cache_bytes: running total of every entry's bytes. cache_seq: bumped
+	// on every hit/insert, so the entry with the smallest last_used is
+	// always the least recently used.
+	cache_bytes i64
+	cache_seq   i64
+	// Defaults to chunk_service_cache_budget_bytes; overridable in tests so
+	// eviction can be exercised without allocating hundreds of MB.
+	budget_bytes i64 = chunk_service_cache_budget_bytes
+	inflight     map[u64]&ChunkRequest
+	jobs         chan ChunkGenJob = chan ChunkGenJob{cap: chunk_gen_queue_capacity}
+	stop         chan bool        = chan bool{cap: chunk_gen_worker_count}
+
+	published_active_workers &stdatomic.AtomicVal[i64] = stdatomic.new_atomic[i64](0)
+	published_queue_depth    &stdatomic.AtomicVal[i64] = stdatomic.new_atomic[i64](0)
+	published_requests_total &stdatomic.AtomicVal[i64] = stdatomic.new_atomic[i64](0)
+	published_dedup_hits     &stdatomic.AtomicVal[i64] = stdatomic.new_atomic[i64](0)
+}
+
+pub fn new_chunk_service(generator world.Generator) &WorldChunkService {
+	return new_chunk_service_with_budget(generator, chunk_service_cache_budget_bytes)
+}
+
+fn new_chunk_service_with_budget(generator world.Generator, budget_bytes i64) &WorldChunkService {
+	mut svc := &WorldChunkService{
+		generator:    generator
+		budget_bytes: budget_bytes
+	}
+	for _ in 0 .. chunk_gen_worker_count {
+		spawn svc.run_worker()
+	}
+	return svc
+}
+
+// request returns a channel that resolves to (cx, cz)'s chunk: instantly
+// if cached, attached to an already running generation if one exists or
+// queued as a new one. Never blocks the caller beyond a full job queue.
+// Safe to call from any thread.
+pub fn (mut svc WorldChunkService) request(cx int, cz int) chan ChunkResult {
+	key := chunk_cache_key(cx, cz)
+	result := chan ChunkResult{cap: 1}
+
+	svc.mutex.lock()
+	if svc.closed {
+		svc.mutex.unlock()
+		result <- ChunkResult{
+			cancelled: true
+		}
+		return result
+	}
+	if entry := svc.cache[key] {
+		svc.cache_seq++
+		mut touched := entry
+		touched.last_used = svc.cache_seq
+		svc.cache[key] = touched
+		svc.mutex.unlock()
+		result <- ChunkResult{
+			chunk:         entry.chunk.clone()
+			serialized:    entry.serialized.clone()
+			section_count: entry.section_count
+		}
+		return result
+	}
+	mut total := svc.published_requests_total
+	total.add(1)
+	if mut existing := svc.inflight[key] {
+		existing.waiters << result
+		mut hits := svc.published_dedup_hits
+		hits.add(1)
+		svc.mutex.unlock()
+		return result
+	}
+	svc.inflight[key] = &ChunkRequest{
+		waiters:    [result]
+		created_at: time.now()
+	}
+	svc.mutex.unlock()
+
+	mut depth := svc.published_queue_depth
+	depth.add(1)
+	svc.jobs <- ChunkGenJob{
+		key: key
+		cx:  cx
+		cz:  cz
+	}
+	return result
+}
+
+fn (mut svc WorldChunkService) run_worker() {
+	mut active := svc.published_active_workers
+	mut depth := svc.published_queue_depth
+	for {
+		select {
+			job := <-svc.jobs {
+				depth.sub(1)
+				active.add(1)
+				chunk := svc.generator.generate(job.cx, job.cz)
+				active.sub(1)
+				svc.complete(job.key, chunk)
+			}
+			_ := <-svc.stop {
+				return
+			}
+		}
+	}
+}
+
+// complete caches the generated chunk and delivers it to every waiter.
+// Each waiter gets its own clone. Chunk's slices alias their backing
+// arrays on a plain copy, so handing out the shared value would let one
+// session's block overrides corrupt another session's view and the
+// cache.
+fn (mut svc WorldChunkService) complete(key u64, chunk world.Chunk) {
+	// Serialize once here instead of once per waiter
+	serialized := chunk.serialize()
+	section_count := chunk.section_count()
+
+	svc.mutex.lock()
+	bytes := chunk.estimated_bytes() + i64(serialized.len)
+	svc.evict_until_room_locked(bytes)
+	svc.cache_seq++
+	svc.cache[key] = ChunkCacheEntry{
+		chunk:         chunk
+		serialized:    serialized
+		section_count: section_count
+		bytes:         bytes
+		last_used:     svc.cache_seq
+	}
+	svc.cache_bytes += bytes
+	req := svc.inflight[key] or {
+		svc.mutex.unlock()
+		return
+	}
+	svc.inflight.delete(key)
+	waiters := req.waiters.clone()
+	svc.mutex.unlock()
+
+	for w in waiters {
+		mut ch := w
+		select {
+			ch <- ChunkResult{
+				chunk:         chunk.clone()
+				serialized:    serialized.clone()
+				section_count: section_count
+			} {}
+			else {}
+		}
+	}
+}
+
+fn (mut svc WorldChunkService) evict_until_room_locked(incoming_bytes i64) {
+	for svc.cache.len > 0 && svc.cache_bytes + incoming_bytes > svc.budget_bytes {
+		mut oldest_key := u64(0)
+		mut oldest_seq := i64(0)
+		mut found := false
+		for k, entry in svc.cache {
+			if !found || entry.last_used < oldest_seq {
+				oldest_key = k
+				oldest_seq = entry.last_used
+				found = true
+			}
+		}
+		if !found {
+			break
+		}
+		evicted := svc.cache[oldest_key] or { break }
+		svc.cache.delete(oldest_key)
+		svc.cache_bytes -= evicted.bytes
+	}
+}
+
+// shutdown stops every worker and cancels any waiter still stuck on an
+// in flight request then refuses further requests.
+pub fn (mut svc WorldChunkService) shutdown() {
+	svc.mutex.lock()
+	svc.closed = true
+	for _, req in svc.inflight {
+		for w in req.waiters {
+			mut ch := w
+			select {
+				ch <- ChunkResult{
+					cancelled: true
+				} {}
+				else {}
+			}
+		}
+	}
+	svc.inflight = map[u64]&ChunkRequest{}
+	svc.mutex.unlock()
+	for _ in 0 .. chunk_gen_worker_count {
+		svc.stop <- true
+	}
+}
+
+// A snapshot of one world's chunk generation health.
+pub struct ChunkServiceMetrics {
+pub:
+	cached_chunks         int
+	cached_bytes_estimate i64
+	cache_budget_bytes    i64
+	inflight_requests     int
+	oldest_inflight_age   time.Duration
+	active_workers        i64
+	worker_limit          int
+	queue_depth           i64
+	requests_total        i64
+	dedup_hits_total      i64
+}
+
+pub fn (mut svc WorldChunkService) metrics() ChunkServiceMetrics {
+	svc.mutex.lock()
+	cached := svc.cache.len
+	cached_bytes := svc.cache_bytes
+	inflight := svc.inflight.len
+	mut oldest := time.Duration(0)
+	for _, req in svc.inflight {
+		age := time.since(req.created_at)
+		if age > oldest {
+			oldest = age
+		}
+	}
+	svc.mutex.unlock()
+
+	mut active := svc.published_active_workers
+	mut depth := svc.published_queue_depth
+	mut total := svc.published_requests_total
+	mut hits := svc.published_dedup_hits
+	return ChunkServiceMetrics{
+		cached_chunks:         cached
+		cached_bytes_estimate: cached_bytes
+		cache_budget_bytes:    svc.budget_bytes
+		inflight_requests:     inflight
+		oldest_inflight_age:   oldest
+		active_workers:        active.load()
+		worker_limit:          chunk_gen_worker_count
+		queue_depth:           depth.load()
+		requests_total:        total.load()
+		dedup_hits_total:      hits.load()
+	}
+}

--- a/server/session/world_chunk_streaming_test.v
+++ b/server/session/world_chunk_streaming_test.v
@@ -1,5 +1,6 @@
 module session
 
+import sync
 import time
 import protocol.version.v2168.packets as packets_2168
 import protocol.types
@@ -58,6 +59,12 @@ fn (g BlockingGenerator) generate(chunk_x int, chunk_z int) world.Chunk {
 		_ := <-g.release
 	}
 	return g.inner.generate(chunk_x, chunk_z)
+}
+
+fn register_blocking_generator(mut hub Hub, name string, gen BlockingGenerator) {
+	hub.register_generator(name, fn [gen] (dim world.Dimension) world.Generator {
+		return gen
+	})
 }
 
 fn chunk_stream_test_session(mut hub Hub, mut wr WorldRuntime, gen world.Generator, mut transport FakeTransport) &NetworkSession {
@@ -126,18 +133,19 @@ fn wait_for_chunk_packet(transport &FakeTransport, timeout_ms int) bool {
 
 fn test_chunk_streaming_doesnt_block_the_world_actor() {
 	mut hub := new_hub(gamedata.GameData{})
-	w := db.new_world('chunk-stream', none, 'void', world.overworld)
+	started := chan bool{cap: 1}
+	release := chan bool{cap: 1}
+	gen := new_blocking_generator(started, release)
+	register_blocking_generator(mut hub, 'blocking-chunk-stream', gen)
+	w := db.new_world('chunk-stream', none, 'blocking-chunk-stream', world.overworld)
 	hub.add_world(w)
 	mut wr := hub.world_runtime('chunk-stream') or { panic('expected chunk-stream runtime') }
 	defer {
 		hub.close_worlds()
 	}
 
-	started := chan bool{cap: 1}
-	release := chan bool{cap: 1}
 	mut transport := &FakeTransport{}
-	mut s := chunk_stream_test_session(mut hub, mut wr, new_blocking_generator(started, release), mut
-		transport)
+	mut s := chunk_stream_test_session(mut hub, mut wr, gen, mut transport)
 
 	s.stream_chunks_if_moved()
 	_ := <-started // generation is now blocked on its own thread, not the actor
@@ -150,7 +158,11 @@ fn test_chunk_streaming_doesnt_block_the_world_actor() {
 
 fn test_chunk_delivery_dropped_after_a_world_switch() {
 	mut hub := new_hub(gamedata.GameData{})
-	world_a := db.new_world('chunk-switch-a', none, 'void', world.overworld)
+	started := chan bool{cap: 1}
+	release := chan bool{cap: 1}
+	gen := new_blocking_generator(started, release)
+	register_blocking_generator(mut hub, 'blocking-chunk-switch-a', gen)
+	world_a := db.new_world('chunk-switch-a', none, 'blocking-chunk-switch-a', world.overworld)
 	hub.add_world(world_a)
 	world_b := db.new_world('chunk-switch-b', none, 'void', world.overworld)
 	hub.add_world(world_b)
@@ -160,11 +172,8 @@ fn test_chunk_delivery_dropped_after_a_world_switch() {
 		hub.close_worlds()
 	}
 
-	started := chan bool{cap: 1}
-	release := chan bool{cap: 1}
 	mut transport := &FakeTransport{}
-	mut s := chunk_stream_test_session(mut hub, mut wr_a, new_blocking_generator(started, release), mut
-		transport)
+	mut s := chunk_stream_test_session(mut hub, mut wr_a, gen, mut transport)
 
 	s.stream_chunks_if_moved()
 	_ := <-started // generation for world a is now blocked on its own thread
@@ -190,18 +199,123 @@ fn test_chunk_delivery_dropped_after_a_world_switch() {
 	}
 }
 
+struct ConcurrencyTracker {
+mut:
+	mutex     &sync.Mutex = sync.new_mutex()
+	in_flight int
+	peak      int
+}
+
+fn (mut t ConcurrencyTracker) enter() {
+	t.mutex.lock()
+	t.in_flight++
+	if t.in_flight > t.peak {
+		t.peak = t.in_flight
+	}
+	t.mutex.unlock()
+}
+
+fn (mut t ConcurrencyTracker) leave() {
+	t.mutex.lock()
+	t.in_flight--
+	t.mutex.unlock()
+}
+
+struct ConcurrentBlockingGenerator {
+	tracker &ConcurrencyTracker
+	release chan bool
+	inner   world.Generator = world.VoidGenerator{}
+}
+
+fn (g ConcurrentBlockingGenerator) spawn_y() int {
+	return g.inner.spawn_y()
+}
+
+fn (g ConcurrentBlockingGenerator) uses_blocks() bool {
+	return g.inner.uses_blocks()
+}
+
+fn (g ConcurrentBlockingGenerator) block_at(x int, y int, z int) int {
+	return g.inner.block_at(x, y, z)
+}
+
+fn (g ConcurrentBlockingGenerator) biome_at(x int, z int) int {
+	return g.inner.biome_at(x, z)
+}
+
+fn (g ConcurrentBlockingGenerator) generate(chunk_x int, chunk_z int) world.Chunk {
+	mut tracker := g.tracker
+	tracker.enter()
+	_ := <-g.release
+	tracker.leave()
+	return g.inner.generate(chunk_x, chunk_z)
+}
+
+fn test_req_chunk_chans_keeps_worker_pool_busy_concurrently() {
+	mut hub := new_hub(gamedata.GameData{})
+	mut tracker := &ConcurrencyTracker{
+		mutex: sync.new_mutex()
+	}
+	release := chan bool{cap: 512}
+	gen := ConcurrentBlockingGenerator{
+		tracker: tracker
+		release: release
+	}
+	hub.register_generator('concurrent-blocking-stream', fn [gen] (dim world.Dimension) world.Generator {
+		return gen
+	})
+	w := db.new_world('chunk-concurrency', none, 'concurrent-blocking-stream', world.overworld)
+	hub.add_world(w)
+	mut wr := hub.world_runtime('chunk-concurrency') or {
+		panic('expected chunk-concurrency runtime')
+	}
+	defer {
+		hub.close_worlds()
+	}
+
+	mut transport := &FakeTransport{}
+	mut s := chunk_stream_test_session(mut hub, mut wr, gen, mut transport)
+
+	mut targets := []ChunkSendTarget{cap: 20}
+	for i in 0 .. 20 {
+		targets << ChunkSendTarget{
+			x: i
+			z: 0
+		}
+	}
+	chans := s.request_chunk_channels(wr, targets)
+
+	deadline := time.now().add(2000 * time.millisecond)
+	for time.now() < deadline {
+		tracker.mutex.lock()
+		reached := tracker.in_flight >= chunk_gen_worker_count
+		tracker.mutex.unlock()
+		if reached {
+			break
+		}
+		time.sleep(5 * time.millisecond)
+	}
+	tracker.mutex.lock()
+	peak := tracker.peak
+	tracker.mutex.unlock()
+	assert peak == chunk_gen_worker_count, 'expected all ${chunk_gen_worker_count} workers busy at once from one session-style request burst, got peak ${peak}'
+
+	for _ in 0 .. 20 {
+		release <- true
+	}
+	for ch in chans {
+		_ := <-ch
+	}
+}
+
 fn test_chunk_columns_are_released_when_delivery_is_dropped() {
 	mut hub := new_hub(gamedata.GameData{})
 	w := db.new_world('chunk-drop', none, 'void', world.overworld)
 	hub.add_world(w)
 	mut wr := hub.world_runtime('chunk-drop') or { panic('expected chunk-drop runtime') }
 
-	started := chan bool{cap: 1}
-	release := chan bool{cap: 1}
-	release <- true
 	mut transport := &FakeTransport{}
-	mut s := chunk_stream_test_session(mut hub, mut wr, new_blocking_generator(started, release), mut
-		transport)
+	mut s := chunk_stream_test_session(mut hub, mut wr, world.VoidGenerator{}, mut transport)
 
 	// A stopped runtime rejects every delivery task, which is the same outcome
 	// as a full queue: nothing reaches the client.

--- a/server/session/world_handle.v
+++ b/server/session/world_handle.v
@@ -64,3 +64,82 @@ pub fn (mut w World) set_block(x int, y int, z int, b world.Block) ! {
 		return true
 	}) or { return error('world "${w.runtime.world.name}" is shutting down') }
 }
+
+// players returns a PlayerRef for every player currently registered in this
+// world. The lookup runs through the world's actor owned player registry.
+//
+// If the world is shutting down, players returns an empty slice.
+pub fn (mut w World) players() []PlayerRef {
+	return world_call[[]PlayerRef](mut w.runtime, fn (mut tx WorldTx) []PlayerRef {
+		mut out := []PlayerRef{}
+		for mut a in tx.wr.entities.player_actors() {
+			if mut a is NetworkSession {
+				out << player_ref_for(a)
+			}
+		}
+		return out
+	}) or { []PlayerRef{} }
+}
+
+// player_count returns the current number of players in this world.
+// It is a thread safe snapshot and does not require a world actor round trip.
+pub fn (w World) player_count() i64 {
+	return w.runtime.player_count()
+}
+
+// entities returns an EntityRef for every non-player entity currently
+// registered in this world. If the world is shutting down, it returns an
+// empty slice.
+pub fn (mut w World) entities() []EntityRef {
+	return world_call[[]EntityRef](mut w.runtime, fn (mut tx WorldTx) []EntityRef {
+		mut out := []EntityRef{}
+		for e in tx.wr.entities.snapshot() {
+			out << EntityRef{
+				runtime_id: e.runtime_id()
+				world_:     World{
+					runtime: tx.wr
+				}
+			}
+		}
+		return out
+	}) or { []EntityRef{} }
+}
+
+// metrics returns a snapshot of this world's runtime metrics including
+// queue pressure, tick timing, persistence backlog and chunk generation
+// load. It is thread safe and does not block on the world actor.
+pub fn (mut w World) metrics() WorldMetrics {
+	return w.runtime.metrics()
+}
+
+// run_task schedules f to run on this world's actor thread on its next
+// simulated step.
+//
+// The callback must remain short and non blocking. A slow callback stalls
+// only this world. Scheduled callbacks are fire and forget.
+pub fn (mut w World) run_task(f fn (mut tx WorldTransaction)) &WorldTaskHandler {
+	return w.runtime.task_scheduler.add(WorldClosureTask{
+		callback: f
+	}, 0, 0, w.runtime.tick_snapshot())
+}
+
+// run_delayed queues "f" to run once, delay simulated ticks of this world
+// from now.
+pub fn (mut w World) run_delayed(f fn (mut tx WorldTransaction), delay i64) &WorldTaskHandler {
+	return w.runtime.task_scheduler.add(WorldClosureTask{
+		callback: f
+	}, delay, 0, w.runtime.tick_snapshot())
+}
+
+// run_repeating queues "f" to run every period simulated ticks of this
+// world starting on the next step.
+pub fn (mut w World) run_repeating(f fn (mut tx WorldTransaction), period i64) &WorldTaskHandler {
+	return w.runtime.task_scheduler.add(WorldClosureTask{
+		callback: f
+	}, 0, period, w.runtime.tick_snapshot())
+}
+
+// cancel_task stops a previously scheduled world task from running again.
+pub fn (mut w World) cancel_task(id int) {
+	w.runtime.task_scheduler.cancel(id)
+}

--- a/server/session/world_runtime.v
+++ b/server/session/world_runtime.v
@@ -85,9 +85,11 @@ mut:
 	// Cross thread snapshot of current_tick.
 	published_tick &stdatomic.AtomicVal[i64] = stdatomic.new_atomic[i64](0)
 
-	liquids  &block.LiquidManager = unsafe { nil }
-	events   &event.Bus           = unsafe { nil }
-	entities &entity.Manager      = unsafe { nil }
+	liquids        &block.LiquidManager = unsafe { nil }
+	events         &event.Bus           = unsafe { nil }
+	entities       &entity.Manager      = unsafe { nil }
+	chunk_service  &WorldChunkService   = unsafe { nil }
+	task_scheduler &WorldScheduler      = unsafe { nil }
 
 	// Cross thread metric snapshots. The world thread publishes simulation
 	// values, session threads publish outbound values and other threads only
@@ -117,6 +119,8 @@ fn new_world_runtime(hub &Hub, w &db.World) &WorldRuntime {
 	wr.liquids = block.new_manager(WorldLiquidHost{ wr: wr })
 	wr.events = event.new_bus()
 	wr.entities = entity.new_manager(WorldEntityHost{ wr: wr })
+	wr.chunk_service = new_chunk_service(w.make_generator(hub.build_generator(w)))
+	wr.task_scheduler = new_world_scheduler()
 	spawn wr.run_jobs()
 	return wr
 }
@@ -283,6 +287,10 @@ fn (mut wr WorldRuntime) pop_queue_time() ?time.Time {
 // in flight submitter never completes.
 fn (mut wr WorldRuntime) shutdown() {
 	wr.mutex.lock()
+	if wr.lifecycle != .running {
+		wr.mutex.unlock()
+		return
+	}
 	wr.lifecycle = .stopping
 	wr.mutex.unlock()
 	for {
@@ -297,6 +305,7 @@ fn (mut wr WorldRuntime) shutdown() {
 	}
 	wr.stop <- true
 	_ := <-wr.done
+	wr.chunk_service.shutdown()
 	wr.mutex.lock()
 	wr.lifecycle = .closed
 	wr.mutex.unlock()
@@ -483,6 +492,27 @@ pub:
 	player_count            i64
 	outbound_overflow_count i64
 	outbound_peak_depth     i64
+	persist_pending_count     int
+	persist_oldest_pending_ms i64
+	persist_enqueued_total    i64
+	persist_committed_total   i64
+	persist_pressure_level         int
+	persist_high_water_threshold   int
+	persist_hard_ceiling_threshold int
+	persist_last_write_ms          i64
+	persist_longest_write_ms       i64
+	persist_consecutive_errors     i64
+	chunk_cached_count       int
+	chunk_cached_bytes       i64
+	chunk_cache_budget_bytes i64
+	chunk_inflight_count     int
+	chunk_oldest_inflight_ms i64
+	chunk_active_workers     i64
+	chunk_worker_limit       int
+	chunk_queue_depth        i64
+	chunk_requests_total     i64
+	chunk_dedup_hits_total   i64
+	actor_running bool
 }
 
 fn (mut wr WorldRuntime) metrics() WorldMetrics {
@@ -492,6 +522,7 @@ fn (mut wr WorldRuntime) metrics() WorldMetrics {
 		oldest_age = time.since(wr.queue_times[0])
 	}
 	longest_task_name := wr.longest_task_name
+	actor_running := wr.lifecycle == .running
 	wr.mutex.unlock()
 
 	mut tick_runs := wr.published_tick_runs
@@ -504,25 +535,47 @@ fn (mut wr WorldRuntime) metrics() WorldMetrics {
 	mut outbound_overflow_count := wr.published_outbound_overflow_count
 	mut outbound_peak_depth := wr.published_outbound_peak_depth
 	mut longest_task_ns := wr.published_longest_task_ns
+	chunk_metrics := wr.chunk_service.metrics()
 
 	return WorldMetrics{
-		world_name:              wr.world.name
-		queued_tasks:            int(wr.jobs.len)
-		oldest_queued_task_age:  oldest_age
-		current_tick:            wr.tick_snapshot()
-		tick_runs:               tick_runs.load()
-		simulated_steps:         simulated_steps.load()
-		catchup_events:          catchup_events.load()
-		tick_overruns:           tick_overruns.load()
-		last_tick_duration:      time.Duration(last_tick_ns.load())
-		longest_task_duration:   time.Duration(longest_task_ns.load())
-		longest_task_name:       longest_task_name
-		scheduled_backlog:       wr.world.scheduled_backlog_count()
-		liquid_backlog:          int(liquid_backlog.load())
-		entity_count:            wr.entities.count()
-		player_count:            player_count.load()
-		outbound_overflow_count: outbound_overflow_count.load()
-		outbound_peak_depth:     outbound_peak_depth.load()
+		world_name:                     wr.world.name
+		queued_tasks:                   int(wr.jobs.len)
+		oldest_queued_task_age:         oldest_age
+		current_tick:                   wr.tick_snapshot()
+		tick_runs:                      tick_runs.load()
+		simulated_steps:                simulated_steps.load()
+		catchup_events:                 catchup_events.load()
+		tick_overruns:                  tick_overruns.load()
+		last_tick_duration:             time.Duration(last_tick_ns.load())
+		longest_task_duration:          time.Duration(longest_task_ns.load())
+		longest_task_name:              longest_task_name
+		scheduled_backlog:              wr.world.scheduled_backlog_count()
+		liquid_backlog:                 int(liquid_backlog.load())
+		entity_count:                   wr.entities.count()
+		player_count:                   player_count.load()
+		outbound_overflow_count:        outbound_overflow_count.load()
+		outbound_peak_depth:            outbound_peak_depth.load()
+		persist_pending_count:          wr.world.pending_persist_count()
+		persist_oldest_pending_ms:      wr.world.oldest_pending_persist_age().milliseconds()
+		persist_enqueued_total:         wr.world.persist_enqueued_total()
+		persist_committed_total:        wr.world.persist_committed_total()
+		persist_pressure_level:         wr.world.persist_pressure_level()
+		persist_high_water_threshold:   wr.world.persist_high_water_threshold_value()
+		persist_hard_ceiling_threshold: wr.world.persist_hard_ceiling_threshold_value()
+		persist_last_write_ms:          wr.world.last_persist_write_duration().milliseconds()
+		persist_longest_write_ms:       wr.world.longest_persist_write_duration().milliseconds()
+		persist_consecutive_errors:     wr.world.persist_consecutive_errors()
+		chunk_cached_count:             chunk_metrics.cached_chunks
+		chunk_cached_bytes:             chunk_metrics.cached_bytes_estimate
+		chunk_cache_budget_bytes:       chunk_metrics.cache_budget_bytes
+		chunk_inflight_count:           chunk_metrics.inflight_requests
+		chunk_oldest_inflight_ms:       chunk_metrics.oldest_inflight_age.milliseconds()
+		chunk_active_workers:           chunk_metrics.active_workers
+		chunk_worker_limit:             chunk_metrics.worker_limit
+		chunk_queue_depth:              chunk_metrics.queue_depth
+		chunk_requests_total:           chunk_metrics.requests_total
+		chunk_dedup_hits_total:         chunk_metrics.dedup_hits_total
+		actor_running:                  actor_running
 	}
 }
 
@@ -531,6 +584,13 @@ fn (mut wr WorldRuntime) metrics() WorldMetrics {
 fn (mut wr WorldRuntime) publish_player_count() {
 	mut count := wr.published_player_count
 	count.store(wr.entities.player_actor_count())
+}
+
+// player_count returns the latest published player count for this world.
+// It is thread safe and does not block on the world actor.
+pub fn (wr &WorldRuntime) player_count() i64 {
+	mut count := wr.published_player_count
+	return count.load()
 }
 
 // advance_tick owns one centralized catch-up loop - subsystems never run
@@ -564,6 +624,7 @@ fn (mut tx WorldTx) advance_tick(target i64) {
 		}
 		wr.entities.tick()
 		tx.tick_effects()
+		wr.task_scheduler.heartbeat(mut tx, wr.current_tick)
 	}
 	if debt > max_world_catchup_ticks {
 		tx.log_tick_overrun(debt)

--- a/server/session/world_scheduler.v
+++ b/server/session/world_scheduler.v
@@ -1,0 +1,127 @@
+module session
+
+import sync
+
+// WorldScheduler runs scheduled tasks against one world's own simulated
+// tick clock on that world's own actor thread. A slow or blocking
+// callback here only stalls this one world.
+//
+// Kept separate from the global scheduler.Scheduler on purpose, not
+// unified into a generic Scheduler[T] - see CONTRIBUTING.md:Observed V compiler and language behaviors
+@[heap]
+struct WorldScheduler {
+mut:
+	mutex   &sync.Mutex = sync.new_mutex()
+	tasks   map[int]&WorldTaskHandler
+	next_id int = 1
+}
+
+fn new_world_scheduler() &WorldScheduler {
+	return &WorldScheduler{}
+}
+
+// add is the single insertion point. delay <= 0 means "next simulated
+// step"; period <= 0 means "run once". current_tick is the world's own
+// simulated tick, never the global tick.
+fn (mut s WorldScheduler) add(task WorldTask, delay i64, period i64, current_tick i64) &WorldTaskHandler {
+	s.mutex.lock()
+	id := s.next_id
+	s.next_id++
+	start := if delay > 0 { current_tick + delay } else { current_tick }
+	mut handler := &WorldTaskHandler{
+		id:       id
+		delay:    delay
+		period:   period
+		task:     task
+		next_run: start
+	}
+	s.tasks[id] = handler
+	s.mutex.unlock()
+	return handler
+}
+
+// cancel stops and removes the task with the given id, if present. Safe to
+// call from any thread.
+pub fn (mut s WorldScheduler) cancel(id int) {
+	s.mutex.lock()
+	if mut handler := s.tasks[id] {
+		handler.cancelled = true
+		s.tasks.delete(id)
+	}
+	s.mutex.unlock()
+}
+
+fn (mut s WorldScheduler) heartbeat(mut tx WorldTx, tick i64) {
+	s.mutex.lock()
+	mut due := []&WorldTaskHandler{}
+	for _, handler in s.tasks {
+		if !handler.cancelled && handler.next_run <= tick {
+			due << handler
+		}
+	}
+	s.mutex.unlock()
+
+	for mut handler in due {
+		if handler.is_cancelled() {
+			continue
+		}
+		handler.task.run(mut tx)
+	}
+
+	s.mutex.lock()
+	for mut handler in due {
+		if handler.cancelled || !handler.is_repeating() {
+			s.tasks.delete(handler.id)
+		} else {
+			handler.next_run = tick + handler.period
+		}
+	}
+	s.mutex.unlock()
+}
+
+// WorldTaskHandler is the world scheduler's live record of a queued task,
+// returned from every World.run_* call so the caller can cancel it later.
+// delay/period are in this world's own simulated ticks.
+@[heap]
+pub struct WorldTaskHandler {
+	id     int
+	delay  i64
+	period i64
+mut:
+	task      WorldTask
+	next_run  i64
+	cancelled bool
+}
+
+pub fn (h &WorldTaskHandler) id() int {
+	return h.id
+}
+
+pub fn (h &WorldTaskHandler) is_cancelled() bool {
+	return h.cancelled
+}
+
+// cancel stops the task from running again. A repeating task won't fire
+// after this; a pending delayed task never fires.
+pub fn (mut h WorldTaskHandler) cancel() {
+	h.cancelled = true
+}
+
+pub fn (h &WorldTaskHandler) is_repeating() bool {
+	return h.period > 0
+}
+
+struct WorldClosureTask {
+	callback fn (mut tx WorldTransaction) @[required]
+}
+
+fn (t WorldClosureTask) name() string {
+	return 'WorldClosureTask'
+}
+
+fn (t WorldClosureTask) run(mut tx WorldTx) {
+	mut handle := WorldTransaction(&WorldTxHandle{
+		tx: &tx
+	})
+	t.callback(mut handle)
+}

--- a/server/world/chunk.v
+++ b/server/world/chunk.v
@@ -28,6 +28,14 @@ pub fn new_chunk_dim(dim Dimension) Chunk {
 	}
 }
 
+pub fn (c &Chunk) estimated_bytes() i64 {
+	mut total := i64(c.biomes.len) * i64(sizeof(int))
+	for section in c.sections {
+		total += i64(section.len) * i64(sizeof(int))
+	}
+	return total
+}
+
 pub fn (c &Chunk) clone() Chunk {
 	mut sections := [][]int{len: c.sections.len}
 	for i, ids in c.sections {

--- a/server/world/db/world_instance.v
+++ b/server/world/db/world_instance.v
@@ -1,11 +1,26 @@
 module db
 
 import sync
+import sync.stdatomic
 import time
 import server.world
 import protocol.types
 
 const persist_shutdown_timeout = 30 * time.second
+
+// persist_high_water_count and persist_hard_ceiling_count define the
+// persistence backlog thresholds for a world.
+//
+// Reaching the high water mark reports persistence pressure but continues
+// accepting writes. Reaching the hard ceiling blocks new persistence
+// enqueues until the backlog drains. Persistence records are never dropped.
+const persist_high_water_count = 4096
+
+const persist_hard_ceiling_count = 32768
+
+// persist_ceiling_poll_interval controls how often a blocked persistence
+// enqueue rechecks whether the backlog has fallen below the hard ceiling.
+const persist_ceiling_poll_interval = 5 * time.millisecond
 
 // BlockPersist and TilePersist are immutable records of one write already
 // applied to a World's in memory state, handed to the storage worker so the
@@ -41,6 +56,13 @@ struct PersistBarrier {
 
 type PersistRecord = BlockPersist | ContainerPersist | PersistBarrier | TilePersist
 
+// QueuedPersistRecord pairs a persistence record with its enqueue time for
+// measuring backlog depth and age.
+struct QueuedPersistRecord {
+	record      PersistRecord
+	enqueued_at time.Time
+}
+
 // World is a single loaded world, its persistent store plus the in memory
 // cache of block overrides layered on top of the generated/vanilla chunks.
 //
@@ -53,10 +75,10 @@ pub:
 	name      string
 	dimension world.Dimension = world.overworld
 mut:
-	store          ?Provider
-	overrides      map[string]int
-	tile_data      map[string]TileData
-	container_data map[string][]ContainerSlotItem
+	store              ?Provider
+	overrides          map[string]int
+	tile_data          map[string]TileData
+	container_data     map[string][]ContainerSlotItem
 	open_holders       map[string]u64
 	mutex              &sync.Mutex = sync.new_mutex()
 	current_tick       i64
@@ -67,10 +89,37 @@ mut:
 	// must never touch these fields.
 	store_backed    bool
 	persist_mutex   &sync.Mutex = sync.new_mutex()
-	persist_records []PersistRecord
-	persist_wakeup  chan bool = chan bool{cap: 1}
-	persist_stop    chan bool = chan bool{cap: 1}
-	persist_done    chan bool = chan bool{cap: 1}
+	persist_records []QueuedPersistRecord
+	// persist_head points to the first pending persistence record.
+	// Records before it have already been applied and are compacted
+	// periodically, avoiding repeated front deletions from the queue.
+	persist_head   int
+	persist_wakeup chan bool = chan bool{cap: 1}
+	persist_stop   chan bool = chan bool{cap: 1}
+	persist_done   chan bool = chan bool{cap: 1}
+
+	// Monotonic persistence totals used to measure enqueue and commit rates.
+	persist_enqueued_count  &stdatomic.AtomicVal[i64] = stdatomic.new_atomic[i64](0)
+	persist_committed_count &stdatomic.AtomicVal[i64] = stdatomic.new_atomic[i64](0)
+
+	// Provider write latency and error state metrics.
+	// consecutive_errors resets after the next successful write.
+	persist_last_write_ns      &stdatomic.AtomicVal[i64] = stdatomic.new_atomic[i64](0)
+	persist_longest_write_ns   &stdatomic.AtomicVal[i64] = stdatomic.new_atomic[i64](0)
+	persist_consecutive_errors &stdatomic.AtomicVal[i64] = stdatomic.new_atomic[i64](0)
+
+	// Persistence backlog thresholds. Tests may override these values.
+	persist_high_water_threshold   int = persist_high_water_count
+	persist_hard_ceiling_threshold int = persist_hard_ceiling_count
+
+	// Timeout used while waiting for persistence shutdown to complete.
+	persist_shutdown_timeout_value time.Duration = persist_shutdown_timeout
+
+	// closing and closed make close() idempotent. closing prevents duplicate
+	// stop signals while shutdown is still in progress; closed is set only
+	// after the underlying store closes successfully.
+	closing bool
+	closed  bool
 pub mut:
 	generator_name string
 }
@@ -217,16 +266,24 @@ pub fn (mut w World) set_tile_text(x int, y int, z int, text string) {
 	})
 }
 
-// enqueue_persist appends an immutable record to the unbounded persist
-// queue and pings the worker. This never blocks, regardless of how far
-// behind the storage worker has fallen.
+// enqueue_persist queues an immutable persistence record and wakes the
+// storage worker. Enqueues remain non blocking until the hard backlog
+// ceiling is reached; at the ceiling, callers wait for the queue to drain.
 fn (mut w World) enqueue_persist(record PersistRecord) {
 	if !w.store_backed {
 		return
 	}
+	for w.pending_persist_count() >= w.persist_hard_ceiling_threshold {
+		time.sleep(persist_ceiling_poll_interval)
+	}
 	w.persist_mutex.lock()
-	w.persist_records << record
+	w.persist_records << QueuedPersistRecord{
+		record:      record
+		enqueued_at: time.now()
+	}
 	w.persist_mutex.unlock()
+	mut enqueued := w.persist_enqueued_count
+	enqueued.add(1)
 	select {
 		w.persist_wakeup <- true {}
 		else {}
@@ -261,18 +318,29 @@ fn (mut w World) run_persist_worker() {
 // drain_persist_records applies every record currently queued, one at a
 // time, until the queue is empty. A record removed here while still inside
 // apply_persist_record (a slow or stuck disk write) is already gone from
-// persist_records.
+// the pending count (persist_head has already advanced past it).
+//
+// Advancing persist_head is O(1); persist_records itself is only
+// compacted once that prefix reaches half the slice.
 fn (mut w World) drain_persist_records(mut store Provider) {
 	for {
 		w.persist_mutex.lock()
-		if w.persist_records.len == 0 {
+		if w.persist_head >= w.persist_records.len {
+			w.persist_records = []QueuedPersistRecord{}
+			w.persist_head = 0
 			w.persist_mutex.unlock()
 			return
 		}
-		record := w.persist_records[0]
-		w.persist_records.delete(0)
+		queued := w.persist_records[w.persist_head]
+		w.persist_head++
+		if w.persist_head >= w.persist_records.len / 2 + 1 {
+			w.persist_records = w.persist_records[w.persist_head..].clone()
+			w.persist_head = 0
+		}
 		w.persist_mutex.unlock()
-		apply_persist_record(mut w, mut store, record)
+		apply_persist_record(mut w, mut store, queued.record)
+		mut committed := w.persist_committed_count
+		committed.add(1)
 	}
 }
 
@@ -282,29 +350,59 @@ fn (mut w World) drain_persist_records(mut store Provider) {
 fn apply_persist_record(mut w World, mut store Provider, record PersistRecord) {
 	match record {
 		BlockPersist {
+			start := time.now()
+			mut ok := true
 			store.set_block(record.x, record.y, record.z, record.id) or {
 				w.mutex.lock()
 				w.last_persist_error = err.msg()
 				w.mutex.unlock()
+				ok = false
 			}
+			w.record_persist_write_result(start, ok)
 		}
 		TilePersist {
+			start := time.now()
+			mut ok := true
 			store.set_tile_text(record.x, record.y, record.z, record.text) or {
 				w.mutex.lock()
 				w.last_persist_error = err.msg()
 				w.mutex.unlock()
+				ok = false
 			}
+			w.record_persist_write_result(start, ok)
 		}
 		ContainerPersist {
+			start := time.now()
+			mut ok := true
 			store.set_container_items(record.x, record.y, record.z, record.items) or {
 				w.mutex.lock()
 				w.last_persist_error = err.msg()
 				w.mutex.unlock()
+				ok = false
 			}
+			w.record_persist_write_result(start, ok)
 		}
 		PersistBarrier {
 			record.done <- true
 		}
+	}
+}
+
+// record_persist_write_result updates provider write latency and error
+// metrics after a persistence write. Barrier signals are not recorded.
+fn (mut w World) record_persist_write_result(start time.Time, ok bool) {
+	dur := time.since(start).nanoseconds()
+	mut last := w.persist_last_write_ns
+	last.store(dur)
+	mut longest := w.persist_longest_write_ns
+	if dur > longest.load() {
+		longest.store(dur)
+	}
+	mut errors := w.persist_consecutive_errors
+	if ok {
+		errors.store(0)
+	} else {
+		errors.add(1)
 	}
 }
 
@@ -315,6 +413,88 @@ pub fn (w &World) last_persist_error() ?string {
 		m.unlock()
 	}
 	return w.last_persist_error
+}
+
+// pending_persist_count returns the number of persistence records waiting
+// for the storage worker. It is safe to call from any thread.
+pub fn (w &World) pending_persist_count() int {
+	mut m := w.persist_mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	return w.persist_records.len - w.persist_head
+}
+
+// oldest_pending_persist_age returns how long the oldest pending persistence
+// record has been waiting. It returns zero when no records are pending.
+pub fn (w &World) oldest_pending_persist_age() time.Duration {
+	mut m := w.persist_mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	if w.persist_head >= w.persist_records.len {
+		return time.Duration(0)
+	}
+	return time.since(w.persist_records[w.persist_head].enqueued_at)
+}
+
+// persist_high_water_threshold_value and persist_hard_ceiling_threshold_value
+// expose the configured overload policy thresholds for metrics/reporting.
+pub fn (w &World) persist_high_water_threshold_value() int {
+	return w.persist_high_water_threshold
+}
+
+pub fn (w &World) persist_hard_ceiling_threshold_value() int {
+	return w.persist_hard_ceiling_threshold
+}
+
+// persist_pressure_level classifies the current persistence backlog:
+// 0 is normal, 1 is at or above the high-water mark and 2 is at or above
+// the hard ceiling where new persistence enqueues are subject to backpressure.
+pub fn (w &World) persist_pressure_level() int {
+	pending := w.pending_persist_count()
+	if pending >= w.persist_hard_ceiling_threshold {
+		return 2
+	}
+	if pending >= w.persist_high_water_threshold {
+		return 1
+	}
+	return 0
+}
+
+// last_persist_write_duration returns the duration of the most recent
+// provider write. Barrier signals are not included.
+pub fn (w &World) last_persist_write_duration() time.Duration {
+	mut d := w.persist_last_write_ns
+	return time.Duration(d.load())
+}
+
+pub fn (w &World) longest_persist_write_duration() time.Duration {
+	mut d := w.persist_longest_write_ns
+	return time.Duration(d.load())
+}
+
+// persist_consecutive_errors returns the number of consecutive provider
+// write failures since the last successful write.
+pub fn (w &World) persist_consecutive_errors() i64 {
+	mut c := w.persist_consecutive_errors
+	return c.load()
+}
+
+// persist_enqueued_total returns the total number of persistence records
+// enqueued since this world started including writes and barriers.
+pub fn (w &World) persist_enqueued_total() i64 {
+	mut c := w.persist_enqueued_count
+	return c.load()
+}
+
+// persist_committed_total returns the total number of persistence records
+// applied since this world started including writes and barriers.
+pub fn (w &World) persist_committed_total() i64 {
+	mut c := w.persist_committed_count
+	return c.load()
 }
 
 pub fn (w &World) tile_text(x int, y int, z int) ?string {
@@ -465,18 +645,39 @@ pub fn (mut w World) flush() ! {
 	}
 }
 
-// close waits for the storage worker to apply every write already handed to
-// it, then stops it before closing the store.
+pub fn (mut w World) set_persist_shutdown_timeout(d time.Duration) {
+	w.persist_shutdown_timeout_value = d
+}
+
+// close waits for all queued persistence work to finish, stops the storage
+// worker and then closes the underlying store.
+//
+// The operation is idempotent. If a previous close attempt timed out, a
+// retry waits for the existing shutdown to complete instead of sending a
+// second stop signal.
 pub fn (mut w World) close() ! {
-	if mut store := w.store {
+	w.mutex.lock()
+	if w.closed {
+		w.mutex.unlock()
+		return
+	}
+	already_closing := w.closing
+	w.closing = true
+	w.mutex.unlock()
+
+	mut store := w.store or { return }
+	if !already_closing {
 		w.persist_stop <- true
-		select {
-			_ := <-w.persist_done {
-				store.close()!
-			}
-			persist_shutdown_timeout {
-				return error('world "${w.name}": persistence worker did not stop within ${persist_shutdown_timeout} - a disk write may still be stuck; not closing the store out from under it')
-			}
+	}
+	select {
+		_ := <-w.persist_done {
+			store.close()!
+			w.mutex.lock()
+			w.closed = true
+			w.mutex.unlock()
+		}
+		w.persist_shutdown_timeout_value {
+			return error('world "${w.name}": persistence worker did not stop within ${w.persist_shutdown_timeout_value} - a disk write may still be stuck; not closing the store out from under it')
 		}
 	}
 }
@@ -496,8 +697,8 @@ fn (mut w World) await_persist_barrier() ! {
 	})
 	select {
 		_ := <-done {}
-		persist_shutdown_timeout {
-			return error('world "${w.name}": persistence worker did not catch up within ${persist_shutdown_timeout}')
+		w.persist_shutdown_timeout_value {
+			return error('world "${w.name}": persistence worker did not catch up within ${w.persist_shutdown_timeout_value}')
 		}
 	}
 }


### PR DESCRIPTION
<!-- Describe what this PR does and why. Keep it focused. -->

## Description

This is a batch of fixes around how the server generates and delivers chunks (the terrain data sent to players), aimed at two real problems: memory usage growing over time and a multisecond freeze when entering a world.

## What changed?

- No more duplicate work. If multiple players ask for the same chunk at the same time, the server used to generate it separately for each one. Now it's generated once and shared.
- Memory-bounded chunk cache. Each session used to keep its own full copy of every chunk it had seen with no upper limit. This was the main source of memory growth during long play sessions. Chunks are now cached once per world with a hard memory budget and automatic cleanup of old, unused ones.
- Disk writes can't freeze the world anymore.
- Scheduled background tasks are isolated per world.
- Chunk data caching.
- New /world metrics output to see cache size, worker usage, queue depth and persistence backlog live for future debugging.
