### PR TITLE
ci: bump pinned V compiler to 3c0f8cb

### DIFF
--- a/.github/actions/setup-v/action.yml
+++ b/.github/actions/setup-v/action.yml
@@ -1,5 +1,5 @@
 name: Setup V
-description: Build the pinned V compiler (0.5.2 @ f1ef640, vc @ bd654de) and install module dependencies
+description: Build the pinned V compiler (0.5.2 @ 3c0f8cb, vc @ abc2377) and install module dependencies
 
 runs:
   using: composite
@@ -9,7 +9,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/vlang
-        key: vlang-f1ef640-bd654de-${{ runner.os }}
+        key: vlang-3c0f8cb-abc2377-${{ runner.os }}
 
     - name: Build pinned V
       if: steps.cache-v.outputs.cache-hit != 'true'
@@ -17,9 +17,9 @@ runs:
       run: |
         git clone --filter=blob:none https://github.com/vlang/v ~/vlang
         cd ~/vlang
-        git checkout f1ef640
+        git checkout 3c0f8cb
         git clone --filter=blob:none https://github.com/vlang/vc vc
-        git -C vc checkout bd654de
+        git -C vc checkout abc2377
         git clone --depth 1 --branch thirdparty-linux-amd64 https://github.com/vlang/tccbin thirdparty/tcc
         make local=1
 


### PR DESCRIPTION
The pinned V commit (f1ef640, 2026-07-17) predates `crypto.ecdsa.PublicKey.uncompressed_bytes` / `from_uncompressed_bytes` (added in 53001a23e, 2026-07-31), which the `nethernet` dependency now uses, so `v -check .` failed on `stable`.

Bumps the pin to V 3c0f8cb with a matching recent vc (abc2377). Check, test and build all pass locally on that compiler.