### PR TITLE
fix(session): stop resyncing a world's clock past what it actually

### DIFF
--- a/server/cmd/default/world.v
+++ b/server/cmd/default/world.v
@@ -126,7 +126,7 @@ fn (c WorldCommand) metrics(mut sender cmd.Sender, ctx cmd.Context) ! {
 	if !m.actor_running {
 		lines << '§c§lACTOR STOPPED§r §7- this world is registered but rejects all work (a previous unload likely failed to close its storage handle; retry unloading it)§r'
 	}
-	lines << '§6Tick: §f${m.current_tick} (last tick §f${m.last_tick_duration_ms}ms§6, §f${m.catchup_events}§6 catch up runs, §f${m.tick_overruns}§6 overruns)§r'
+	lines << '§6Tick: §f${m.current_tick}§6/§f${m.requested_tick}§6 (debt §f${m.simulation_debt_ticks}§6, last tick §f${m.last_tick_duration_ms}ms§6, §f${m.catchup_events}§6 catch up runs, §f${m.tick_overruns}§6 overruns)§r'
 	lines << '§6Queued tasks: §f${m.queued_tasks}§6 (oldest §f${m.oldest_queued_task_age_ms}ms§6)§r'
 	lines << '§6Longest task: §f${m.longest_task_name} (§f${m.longest_task_duration_ms}ms§6)§r'
 	lines << '§6Scheduled backlog: §f${m.scheduled_backlog}§6, liquid backlog: §f${m.liquid_backlog}§r'

--- a/server/cmd/sender.v
+++ b/server/cmd/sender.v
@@ -59,6 +59,8 @@ pub struct WorldMetricsSummary {
 pub:
 	name                           string
 	current_tick                   i64
+	requested_tick                 i64
+	simulation_debt_ticks          i64
 	queued_tasks                   int
 	oldest_queued_task_age_ms      i64
 	last_tick_duration_ms          i64

--- a/server/session/world_admin.v
+++ b/server/session/world_admin.v
@@ -131,6 +131,8 @@ fn to_world_metrics_summary(m WorldMetrics) cmd.WorldMetricsSummary {
 	return cmd.WorldMetricsSummary{
 		name:                           m.world_name
 		current_tick:                   m.current_tick
+		requested_tick:                 m.requested_tick
+		simulation_debt_ticks:          m.simulation_debt_ticks
 		queued_tasks:                   m.queued_tasks
 		oldest_queued_task_age_ms:      m.oldest_queued_task_age.milliseconds()
 		last_tick_duration_ms:          m.last_tick_duration.milliseconds()

--- a/server/session/world_runtime.v
+++ b/server/session/world_runtime.v
@@ -13,8 +13,11 @@ import server.world.db
 import server.internal.logger
 import protocol.current as proto
 
-// max_world_catchup_ticks limits how many missed simulation steps a
-// WorldRuntime replays before advancing directly to the latest requested tick.
+// max_world_catchup_ticks bounds how many simulation steps a WorldRuntime
+// replays in a single run_due_tick call. Debt beyond this is not skipped by
+// resyncing the clock.
+//
+// It stays behind and is picked up on the next call, see advance_tick's own comment.
 const max_world_catchup_ticks = 20
 
 // max_due_updates_per_tick limits scheduled block updates processed in one
@@ -84,6 +87,10 @@ mut:
 
 	// Cross thread snapshot of current_tick.
 	published_tick &stdatomic.AtomicVal[i64] = stdatomic.new_atomic[i64](0)
+
+	// Cross thread snapshot of latest_tick, lets any thread compute
+	// simulation debt (requested - simulated) without taking tick_mutex.
+	published_latest_tick &stdatomic.AtomicVal[i64] = stdatomic.new_atomic[i64](0)
 
 	liquids        &block.LiquidManager = unsafe { nil }
 	events         &event.Bus           = unsafe { nil }
@@ -442,6 +449,9 @@ fn (mut wr WorldRuntime) run_task(mut tx WorldTx, task WorldTask) {
 fn (mut wr WorldRuntime) request_tick(n i64) {
 	wr.tick_mutex.lock()
 	wr.latest_tick = n
+	// Stored inside the same critical section as latest_tick, not after.
+	mut published_latest := wr.published_latest_tick
+	published_latest.store(n)
 	wr.tick_mutex.unlock()
 	select {
 		wr.tick_wakeup <- true {}
@@ -453,6 +463,14 @@ fn (mut wr WorldRuntime) request_tick(n i64) {
 // to call from any thread.
 fn (wr &WorldRuntime) tick_snapshot() i64 {
 	mut p := wr.published_tick
+	return p.load()
+}
+
+// requested_tick_snapshot returns the latest requested (not yet necessarily
+// simulated) tick and is safe to call from any thread. requested_tick_snapshot()
+// minus tick_snapshot() is the world's current simulation debt.
+fn (wr &WorldRuntime) requested_tick_snapshot() i64 {
+	mut p := wr.published_latest_tick
 	return p.load()
 }
 
@@ -491,6 +509,8 @@ pub:
 	queued_tasks                   int
 	oldest_queued_task_age         time.Duration
 	current_tick                   i64
+	requested_tick                 i64
+	simulation_debt_ticks          i64
 	tick_runs                      i64
 	simulated_steps                i64
 	catchup_events                 i64
@@ -549,11 +569,16 @@ fn (mut wr WorldRuntime) metrics() WorldMetrics {
 	mut longest_task_ns := wr.published_longest_task_ns
 	chunk_metrics := wr.chunk_service.metrics()
 
+	current_tick_val := wr.tick_snapshot()
+	requested_tick_val := wr.requested_tick_snapshot()
+
 	return WorldMetrics{
 		world_name:                     wr.world.name
 		queued_tasks:                   int(wr.jobs.len)
 		oldest_queued_task_age:         oldest_age
-		current_tick:                   wr.tick_snapshot()
+		current_tick:                   current_tick_val
+		requested_tick:                 requested_tick_val
+		simulation_debt_ticks:          requested_tick_val - current_tick_val
 		tick_runs:                      tick_runs.load()
 		simulated_steps:                simulated_steps.load()
 		catchup_events:                 catchup_events.load()
@@ -641,7 +666,19 @@ fn (mut tx WorldTx) advance_tick(target i64) {
 	if debt > max_world_catchup_ticks {
 		tx.log_tick_overrun(debt)
 	}
-	wr.current_tick = target // always resync the clock, regardless of how much was actually simulated
+	// Leave current_tick exactly where simulation advanced it. Never snap it
+	// forward to target: doing so would discard unsimulated debt while making
+	// published_tick claim that the world had caught up. That was the cause of
+	// the block break desync: tick numbered progress observed a jump for ticks
+	// that were never actually simulated.
+	//
+	// If debt exceeds the per run cap, the remainder stays pending and is
+	// processed by subsequent run_due_tick calls. It therefore remains visible
+	// as requested_tick_snapshot().
+	// tick_snapshot() rather than being hidden by an artificial resync.
+	//
+	// A world that can't keep up loses TPS and remains behind rather than
+	// advancing its simulation clock over unexecuted ticks.
 	mut p := wr.published_tick
 	p.store(wr.current_tick)
 

--- a/server/session/world_runtime_test.v
+++ b/server/session/world_runtime_test.v
@@ -171,10 +171,11 @@ fn test_tick_requests_coalesce_while_actor_is_busy() {
 		return wr.tick_runs_count() > 0
 	})
 	assert wr.tick_runs_count() == 1
-	assert wr.tick_snapshot() == 1049
+	assert wr.requested_tick_snapshot() == 1049
+	assert wr.tick_snapshot() == max_world_catchup_ticks
 }
 
-fn test_advance_tick_bounded_catchup_resyncs_clock() {
+fn test_advance_tick_bounded_catchup_leaves_the_clock_behind() {
 	mut wr := new_test_world_runtime()
 	defer {
 		wr.shutdown()
@@ -182,9 +183,67 @@ fn test_advance_tick_bounded_catchup_resyncs_clock() {
 
 	wr.request_tick(500)
 	assert wait_until(2000, fn [wr] () bool {
-		return wr.tick_snapshot() == 500
+		return wr.tick_runs_count() > 0
 	})
+	assert wr.tick_snapshot() == max_world_catchup_ticks
 	assert wr.simulated_steps_count() == max_world_catchup_ticks
+	assert wr.requested_tick_snapshot() - wr.tick_snapshot() == 500 - max_world_catchup_ticks
+}
+
+fn test_sim_debt_is_observable_while_actor_is_busy() {
+	mut wr := new_test_world_runtime()
+	defer {
+		wr.shutdown()
+	}
+
+	started := chan bool{cap: 1}
+	release := chan bool{cap: 1}
+	ok := wr.submit(BarrierTask{
+		started: started
+		release: release
+	})
+	assert ok
+	_ := <-started // actor is now provably blocked, has not touched tick_wakeup
+
+	// Within max_world_catchup_ticks, so a single drain fully closes the
+	// debt below. This test is about real time observability.
+	wr.request_tick(15)
+
+	assert wr.requested_tick_snapshot() == 15
+	assert wr.tick_snapshot() == 0
+	debt_while_busy := wr.requested_tick_snapshot() - wr.tick_snapshot()
+	assert debt_while_busy == 15
+
+	release <- true // let the actor drain tick_wakeup and catch up
+
+	assert wait_until(2000, fn [wr] () bool {
+		return wr.tick_snapshot() == 15
+	})
+	assert wr.requested_tick_snapshot() - wr.tick_snapshot() == 0
+}
+
+fn request_tick_race_caller(mut wr WorldRuntime, base i64, times int) {
+	for i in 0 .. times {
+		wr.request_tick(base + i64(i))
+	}
+}
+
+fn test_requested_tick_snapshot_stays_consistent_under_concurrent_updates() {
+	mut wr := new_test_world_runtime()
+	defer {
+		wr.shutdown()
+	}
+
+	mut threads := []thread{}
+	for i in 0 .. 8 {
+		threads << spawn request_tick_race_caller(mut wr, i64(i) * 10000, 200)
+	}
+	threads.wait()
+
+	wr.tick_mutex.lock()
+	final_latest_tick := wr.latest_tick
+	wr.tick_mutex.unlock()
+	assert wr.requested_tick_snapshot() == final_latest_tick
 }
 
 struct EventCounter {


### PR DESCRIPTION
<!-- Describe what this PR does and why. Keep it focused. -->

## Description

advance_tick no longer snaps current_tick forward to the requested target
after a capped catchup burst, it stays exactly where it actually
simulated to and falls behind under sustained load instead of lying
about being caught up. The resync was the direct mechanism behind the
known block break desync: tick numbered progress state saw a
discontinuous jump that never corresponded to anything simulated.

Also publishes the requested tick (published_latest_tick) as a
cross thread atomic alongside the existing published_tick and derives a
simulation_debt_ticks gauge on WorldMetrics/WorldMetricsSummary/`/world
metrics` , without this: the debt the resync above was hiding stays
invisible even once it stops being silently discarded.
