### PR TITLE
feat: note block and jukebox interactions

### DIFF
--- a/server/block/note_jukebox_components.v
+++ b/server/block/note_jukebox_components.v
@@ -1,0 +1,40 @@
+module block
+
+import server.world
+
+const noteblock_hardness = f32(0.8)
+const jukebox_hardness = f32(2.0)
+
+pub struct NoteBlock {
+	SimpleBlock
+}
+
+fn note_block() Block {
+	id := 'minecraft:noteblock'
+	return NoteBlock{
+		SimpleBlock: SimpleBlock{
+			id:             id
+			block_runtime:  world.new_block(id).network_id
+			break_hardness: noteblock_hardness
+		}
+	}
+}
+
+pub struct JukeboxBlock {
+	SimpleBlock
+}
+
+fn jukebox_block() Block {
+	id := 'minecraft:jukebox'
+	return JukeboxBlock{
+		SimpleBlock: SimpleBlock{
+			id:             id
+			block_runtime:  world.new_block(id).network_id
+			break_hardness: jukebox_hardness
+		}
+	}
+}
+
+pub fn note_jukebox_blocks() []Block {
+	return [note_block(), jukebox_block()]
+}

--- a/server/block/registry.v
+++ b/server/block/registry.v
@@ -226,6 +226,7 @@ fn default_blocks() []Block {
 	result << decorative_blocks()
 	result << replaceable_plant_blocks()
 	result << shelf_mushroom_blocks()
+	result << note_jukebox_blocks()
 
 	return result
 }

--- a/server/session/blocks.v
+++ b/server/session/blocks.v
@@ -477,6 +477,9 @@ fn (mut tx WorldTx) complete_block_break(mut s NetworkSession, pos types.BlockPo
 		if b is block.ChestBlock {
 			drop_chest_contents(mut tx.wr, mut s, pos.x, pos.y, pos.z)
 		}
+		if b is block.JukeboxBlock {
+			drop_jukebox_disc(mut tx.wr, pos.x, pos.y, pos.z)
+		}
 	}
 
 	if pair := tx.door_pair_pos(pos, old_id) {

--- a/server/session/jukebox.v
+++ b/server/session/jukebox.v
@@ -1,0 +1,57 @@
+module session
+
+import nbt
+import protocol.types
+import server.world.sound
+import protocol.current as proto
+
+const music_disc_prefix = 'minecraft:music_disc_'
+
+// interact_jukebox inserts the held music disc or ejects the one already
+// playing if a right click arrives with no disc to insert (or the jukebox
+// already holds one). Like note blocks, the wire palette carries no
+// per record state for 'minecraft:jukebox' (empty states compound), so the
+// inserted record's item id is tracked as block entity data.
+// Empty string means no record.
+fn (mut tx WorldTx) interact_jukebox(mut s NetworkSession, pos types.BlockPosition) {
+	center := types.Vector3{f32(pos.x) + 0.5, f32(pos.y) + 0.5, f32(pos.z) + 0.5}
+	current := tx.wr.world.tile_text(pos.x, pos.y, pos.z) or { '' }
+	if current != '' {
+		tx.wr.world.set_tile_text(pos.x, pos.y, pos.z, '')
+		tx.wr.broadcast_world(&proto.BlockActorDataPacket{
+			block_position:  proto.block_pos(pos)
+			actor_data_tags: build_jukebox_nbt(pos.x, pos.y, pos.z, '')
+		})
+		spawn_dropped_item_stack(mut tx.wr, current, 1, center)
+		return
+	}
+	_, name := s.held_stack_and_name()
+	if !name.starts_with(music_disc_prefix) {
+		return
+	}
+	tx.consume_held_item(mut s)
+	tx.wr.world.set_tile_text(pos.x, pos.y, pos.z, name)
+	tx.wr.broadcast_world(&proto.BlockActorDataPacket{
+		block_position:  proto.block_pos(pos)
+		actor_data_tags: build_jukebox_nbt(pos.x, pos.y, pos.z, name)
+	})
+	tx.play_sound(center, sound.Record{ track: name.trim_string_left(music_disc_prefix) })
+}
+
+fn build_jukebox_nbt(x int, y int, z int, record_item_name string) nbt.RootTag {
+	mut root := nbt.new_compound()
+	root.set('id', nbt.Tag('RecordPlayer'))
+	root.set('x', nbt.Tag(i32(x)))
+	root.set('y', nbt.Tag(i32(y)))
+	root.set('z', nbt.Tag(i32(z)))
+	if record_item_name != '' {
+		mut record_item := nbt.new_compound()
+		record_item.set('Name', nbt.Tag(record_item_name))
+		record_item.set('Count', nbt.Tag(i8(1)))
+		root.set('RecordItem', nbt.Tag(record_item))
+	}
+	return nbt.RootTag{
+		name: ''
+		tag:  nbt.Tag(root)
+	}
+}

--- a/server/session/jukebox.v
+++ b/server/session/jukebox.v
@@ -38,6 +38,16 @@ fn (mut tx WorldTx) interact_jukebox(mut s NetworkSession, pos types.BlockPositi
 	tx.play_sound(center, sound.Record{ track: name.trim_string_left(music_disc_prefix) })
 }
 
+fn drop_jukebox_disc(mut wr WorldRuntime, x int, y int, z int) {
+	current := wr.world.tile_text(x, y, z) or { return }
+	if current == '' {
+		return
+	}
+	center := types.Vector3{f32(x) + 0.5, f32(y) + 0.5, f32(z) + 0.5}
+	spawn_dropped_item_stack(mut wr, current, 1, center)
+	wr.world.set_tile_text(x, y, z, '')
+}
+
 fn build_jukebox_nbt(x int, y int, z int, record_item_name string) nbt.RootTag {
 	mut root := nbt.new_compound()
 	root.set('id', nbt.Tag('RecordPlayer'))

--- a/server/session/note_block.v
+++ b/server/session/note_block.v
@@ -1,0 +1,42 @@
+module session
+
+import nbt
+import protocol.types
+import server.world.sound
+import protocol.current as proto
+
+// note_block_pitches is the number of distinct pitches a note block cycles
+// through on right click (0..24 inclusive).
+const note_block_pitches = 25
+
+// play_note advances pos's note block to its next pitch, persists that
+// pitch as block entity data, broadcasts the updated block entity and
+// plays the note at the block's center.
+//
+// minecraft:noteblock has no per pitch wire palette state, so the pitch
+// must be tracked separately from the block itself.
+fn (mut tx WorldTx) play_note(mut s NetworkSession, pos types.BlockPosition) {
+	current := tx.wr.world.tile_text(pos.x, pos.y, pos.z) or { '0' }
+	pitch := (current.int() + 1) % note_block_pitches
+	tx.wr.world.set_tile_text(pos.x, pos.y, pos.z, pitch.str())
+	tx.wr.broadcast_world(&proto.BlockActorDataPacket{
+		block_position:  proto.block_pos(pos)
+		actor_data_tags: build_note_block_nbt(pos.x, pos.y, pos.z, pitch)
+	})
+	center := types.Vector3{f32(pos.x) + 0.5, f32(pos.y) + 0.5, f32(pos.z) + 0.5}
+	tx.play_sound(center, sound.Note{ pitch: pitch })
+	tx.broadcast_swing(s)
+}
+
+fn build_note_block_nbt(x int, y int, z int, pitch int) nbt.RootTag {
+	mut root := nbt.new_compound()
+	root.set('id', nbt.Tag('NoteBlock'))
+	root.set('x', nbt.Tag(i32(x)))
+	root.set('y', nbt.Tag(i32(y)))
+	root.set('z', nbt.Tag(i32(z)))
+	root.set('note', nbt.Tag(i8(pitch)))
+	return nbt.RootTag{
+		name: ''
+		tag:  nbt.Tag(root)
+	}
+}

--- a/server/session/world_place_ops.v
+++ b/server/session/world_place_ops.v
@@ -174,6 +174,14 @@ fn (mut tx WorldTx) interact_block(mut s NetworkSession, pos types.BlockPosition
 			tx.open_chest_container(mut s, pos)
 			return true
 		}
+		if b is block.NoteBlock {
+			tx.play_note(mut s, pos)
+			return true
+		}
+		if b is block.JukeboxBlock {
+			tx.interact_jukebox(mut s, pos)
+			return true
+		}
 	}
 	if isnil(tx.wr.hub.palette) {
 		return false

--- a/server/session/world_place_ops.v
+++ b/server/session/world_place_ops.v
@@ -151,6 +151,34 @@ fn (mut tx WorldTx) create_sign_tile(pos types.BlockPosition, runtime_id int) {
 	})
 }
 
+// create_note_tile initializes a newly placed note block's block entity
+// text to pitch 0, matching create_sign_tile's pattern.
+fn (mut tx WorldTx) create_note_tile(pos types.BlockPosition, runtime_id int) {
+	b := block.get(runtime_id) or { return }
+	if b !is block.NoteBlock {
+		return
+	}
+	tx.wr.world.set_tile_text(pos.x, pos.y, pos.z, '0')
+	tx.wr.broadcast_world(&proto.BlockActorDataPacket{
+		block_position:  proto.block_pos(pos)
+		actor_data_tags: build_note_block_nbt(pos.x, pos.y, pos.z, 0)
+	})
+}
+
+// create_jukebox_tile initializes a newly placed jukebox's block entity
+// text to "no record", matching create_sign_tile's pattern.
+fn (mut tx WorldTx) create_jukebox_tile(pos types.BlockPosition, runtime_id int) {
+	b := block.get(runtime_id) or { return }
+	if b !is block.JukeboxBlock {
+		return
+	}
+	tx.wr.world.set_tile_text(pos.x, pos.y, pos.z, '')
+	tx.wr.broadcast_world(&proto.BlockActorDataPacket{
+		block_position:  proto.block_pos(pos)
+		actor_data_tags: build_jukebox_nbt(pos.x, pos.y, pos.z, '')
+	})
+}
+
 fn (mut tx WorldTx) maybe_open_sign_editor(mut s NetworkSession, pos types.BlockPosition, runtime_id int) {
 	b := block.get(runtime_id) or { return }
 	if b !is block.SignBlock {
@@ -294,6 +322,8 @@ fn (mut tx WorldTx) place_block_form(mut s NetworkSession, pos types.BlockPositi
 	// Tile initialized before the block mutation broadcasts, so an observer
 	// can never see the block exist without its tile.
 	tx.create_sign_tile(pos, runtime_id)
+	tx.create_note_tile(pos, runtime_id)
+	tx.create_jukebox_tile(pos, runtime_id)
 	tx.set_block(pos.x, pos.y, pos.z, runtime_id)
 	tx.broadcast_place_sound(s, pos.x, pos.y, pos.z, runtime_id)
 	tx.broadcast_swing(s)
@@ -318,6 +348,8 @@ fn (mut tx WorldTx) replace_block_form(mut s NetworkSession, pos types.BlockPosi
 		return false
 	}
 	tx.create_sign_tile(pos, runtime_id)
+	tx.create_note_tile(pos, runtime_id)
+	tx.create_jukebox_tile(pos, runtime_id)
 	tx.set_block(pos.x, pos.y, pos.z, runtime_id)
 	tx.broadcast_place_sound(s, pos.x, pos.y, pos.z, runtime_id)
 	tx.broadcast_swing(s)

--- a/server/world/sound/block.v
+++ b/server/world/sound/block.v
@@ -241,3 +241,19 @@ pub fn (s Note) event_name() string {
 pub fn (s Note) data() i32 {
 	return i32(s.pitch)
 }
+
+// Record is played by a jukebox when a music disc is inserted. track is the
+// disc's own name fragment, stripped of its 'minecraft:music_disc_' prefix
+// by the caller.
+pub struct Record {
+pub:
+	track string
+}
+
+pub fn (s Record) event_name() string {
+	return 'record.${s.track}'
+}
+
+pub fn (s Record) data() i32 {
+	return no_data
+}


### PR DESCRIPTION
<!-- Describe what this PR does and why. Keep it focused. -->

## Description

Adds two new interactable blocks, following the existing tile-text block-entity pattern used by signs.
