### PR TITLE
feat(player): make hunger drain, feed and starve

### DIFF
--- a/server/player/attributes.v
+++ b/server/player/attributes.v
@@ -33,14 +33,18 @@ pub fn (p &Player) health_update() &proto.UpdateAttributesPacket {
 // update_attributes is the player's full attribute set, sent once on spawn.
 pub fn (p &Player) update_attributes() &proto.UpdateAttributesPacket {
 	mut sink := p.sink
+	hunger := p.hunger()
 	return &proto.UpdateAttributesPacket{
 		target_runtime_id:       proto.actor_runtime_id(sink.runtime_id())
 		attribute_list:          [
 			player_attribute('minecraft:health', 0.0, 20.0, p.health()),
 			player_attribute('minecraft:movement', 0.0, 3.4028235e38, 0.1),
-			player_attribute('minecraft:player.hunger', 0.0, 20.0, 20.0),
-			player_attribute('minecraft:player.saturation', 0.0, 20.0, 20.0),
-			player_attribute('minecraft:player.exhaustion', 0.0, 5.0, 0.0),
+			player_attribute('minecraft:player.hunger', 0.0, f32(max_food_level),
+				f32(hunger.food_level)),
+			player_attribute('minecraft:player.saturation', 0.0, f32(max_food_level),
+				hunger.saturation),
+			player_attribute('minecraft:player.exhaustion', 0.0, exhaustion_threshold,
+				hunger.exhaustion),
 			player_attribute('minecraft:player.level', 0.0, 24791.0, 0.0),
 			player_attribute('minecraft:player.experience', 0.0, 1.0, 0.0),
 		]

--- a/server/player/hunger.v
+++ b/server/player/hunger.v
@@ -1,0 +1,218 @@
+module player
+
+import math
+import bedrock_v.protocol.types
+import bedrock_v.protocol.current as proto
+import server.player.playerdb
+
+// max_food_level is a full hunger bar, and initial_saturation is what a fresh
+// or respawned player starts with behind it. Both come from the save format,
+// which has to know them to default a save that predates hunger.
+pub const max_food_level = playerdb.max_food_level
+pub const initial_saturation = playerdb.initial_saturation
+
+// exhaustion_threshold is how much exhaustion one point of saturation - or,
+// with none left, one point of food - is worth.
+pub const exhaustion_threshold = f32(4.0)
+
+// Movement costs are per metre travelled. Walking is free; only the faster
+// ways of getting somewhere are paid for.
+pub const sprint_exhaustion_per_metre = f32(0.1)
+pub const swim_exhaustion_per_metre = f32(0.01)
+
+pub const jump_exhaustion = f32(0.05)
+pub const sprint_jump_exhaustion = f32(0.2)
+pub const mining_exhaustion = f32(0.005)
+pub const damage_exhaustion = f32(0.1)
+pub const regeneration_exhaustion = f32(6.0)
+
+// HungerState is a snapshot of the whole bar, for the callers that need to
+// read it as one consistent set rather than field by field.
+pub struct HungerState {
+pub:
+	food_level int
+	saturation f32
+	exhaustion f32
+}
+
+pub fn (p &Player) hunger() HungerState {
+	mut m := p.state_mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	return HungerState{
+		food_level: p.food_level
+		saturation: p.saturation
+		exhaustion: p.exhaustion
+	}
+}
+
+pub fn (p &Player) food_level() int {
+	mut m := p.state_mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	return p.food_level
+}
+
+pub fn (mut p Player) set_hunger(state HungerState) {
+	p.state_mutex.lock()
+	p.food_level = clamp_food(state.food_level)
+	p.saturation = clamp_saturation(state.saturation, p.food_level)
+	p.exhaustion = math.max(f32(0), state.exhaustion)
+	p.state_mutex.unlock()
+}
+
+// reset_hunger puts the bar back to what a player spawns with.
+pub fn (mut p Player) reset_hunger() {
+	p.set_hunger(HungerState{
+		food_level: max_food_level
+		saturation: initial_saturation
+	})
+}
+
+// advance_hunger_clock counts this player through one hunger tick and returns
+// the new count.
+pub fn (mut p Player) advance_hunger_clock() i64 {
+	p.state_mutex.lock()
+	defer {
+		p.state_mutex.unlock()
+	}
+	p.hunger_clock++
+	return p.hunger_clock
+}
+
+// hunger_position is where the player was when their movement was last
+// charged for, or none before the first sample.
+pub fn (p &Player) hunger_position() ?types.Vector3 {
+	mut m := p.state_mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	if !p.has_hunger_position {
+		return none
+	}
+	return p.hunger_position
+}
+
+pub fn (mut p Player) set_hunger_position(pos types.Vector3) {
+	p.state_mutex.lock()
+	p.hunger_position = pos
+	p.has_hunger_position = true
+	p.state_mutex.unlock()
+}
+
+pub fn (p &Player) sprinting() bool {
+	mut m := p.state_mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	return p.sprinting
+}
+
+pub fn (mut p Player) set_sprinting(value bool) {
+	p.state_mutex.lock()
+	p.sprinting = value
+	p.state_mutex.unlock()
+}
+
+pub fn (p &Player) swimming() bool {
+	mut m := p.state_mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	return p.swimming
+}
+
+pub fn (mut p Player) set_swimming(value bool) {
+	p.state_mutex.lock()
+	p.swimming = value
+	p.state_mutex.unlock()
+}
+
+// exhaust adds amount to the exhaustion counter and spends whatever whole
+// units of it that buys, saturation first and food after. It reports whether
+// the visible part of the bar moved, so a caller only resends what changed.
+pub fn (mut p Player) exhaust(amount f32) bool {
+	if amount <= 0 {
+		return false
+	}
+	p.state_mutex.lock()
+	defer {
+		p.state_mutex.unlock()
+	}
+	before_food := p.food_level
+	before_saturation := p.saturation
+	p.exhaustion += amount
+	for p.exhaustion >= exhaustion_threshold {
+		p.exhaustion -= exhaustion_threshold
+		if p.saturation > 0 {
+			p.saturation = math.max(f32(0), p.saturation - 1.0)
+		} else if p.food_level > 0 {
+			p.food_level--
+		} else {
+			// Nothing left to spend it on. Dropping the surplus keeps a
+			// starving player from banking exhaustion against their next meal.
+			p.exhaustion = 0
+			break
+		}
+	}
+	return p.food_level != before_food || p.saturation != before_saturation
+}
+
+// eat restores food and saturation the way a food item does: saturation is
+// capped by the food level it is carried by, so a full bar cannot bank more of
+// it than it has room for.
+pub fn (mut p Player) eat(nutrition int, saturation_modifier f32) {
+	p.state_mutex.lock()
+	p.food_level = clamp_food(p.food_level + nutrition)
+	gained := f32(nutrition) * saturation_modifier * 2.0
+	p.saturation = clamp_saturation(p.saturation + gained, p.food_level)
+	p.state_mutex.unlock()
+}
+
+// feed adds food levels without any saturation behind them, as passive
+// difficulty's slow refill does.
+pub fn (mut p Player) feed(points int) {
+	p.state_mutex.lock()
+	p.food_level = clamp_food(p.food_level + points)
+	p.state_mutex.unlock()
+}
+
+fn clamp_food(value int) int {
+	if value < 0 {
+		return 0
+	}
+	if value > max_food_level {
+		return max_food_level
+	}
+	return value
+}
+
+fn clamp_saturation(value f32, food_level int) f32 {
+	return math.min(math.max(f32(0), value), f32(food_level))
+}
+
+// hunger_update is the hunger bar alone, for the common case where nothing
+// else about the player changed.
+pub fn (p &Player) hunger_update() &proto.UpdateAttributesPacket {
+	state := p.hunger()
+	mut sink := p.sink
+	return &proto.UpdateAttributesPacket{
+		target_runtime_id:       proto.actor_runtime_id(sink.runtime_id())
+		attribute_list:          [
+			player_attribute('minecraft:player.hunger', 0.0, f32(max_food_level),
+				f32(state.food_level)),
+			player_attribute('minecraft:player.saturation', 0.0, f32(max_food_level),
+				state.saturation),
+			player_attribute('minecraft:player.exhaustion', 0.0, exhaustion_threshold,
+				state.exhaustion),
+		]
+		ticks_since_sim_started: 0
+	}
+}

--- a/server/player/hunger.v
+++ b/server/player/hunger.v
@@ -26,6 +26,13 @@ pub const mining_exhaustion = f32(0.005)
 pub const damage_exhaustion = f32(0.1)
 pub const regeneration_exhaustion = f32(6.0)
 
+// regeneration_interval_ticks and starvation_interval_ticks are how many
+// consecutive ticks a player has to spend eligible before a point of health
+// moves, and passive_feed_interval_ticks how often peaceful refills the bar.
+pub const regeneration_interval_ticks = 80
+pub const starvation_interval_ticks = 80
+pub const passive_feed_interval_ticks = 20
+
 // HungerState is a snapshot of the whole bar, for the callers that need to
 // read it as one consistent set rather than field by field.
 pub struct HungerState {
@@ -73,15 +80,104 @@ pub fn (mut p Player) reset_hunger() {
 	})
 }
 
-// advance_hunger_clock counts this player through one hunger tick and returns
-// the new count.
-pub fn (mut p Player) advance_hunger_clock() i64 {
+// advance_regeneration counts one tick spent well fed enough to heal, and
+// reports whether that was the tick a point of health comes back on.
+//
+// The counter only runs while the condition holds and resets the moment it
+// stops, so a player who has just eaten waits the full interval rather than
+// inheriting wherever a shared clock happened to be.
+pub fn (mut p Player) advance_regeneration(eligible bool) bool {
 	p.state_mutex.lock()
 	defer {
 		p.state_mutex.unlock()
 	}
-	p.hunger_clock++
-	return p.hunger_clock
+	if !eligible {
+		p.regeneration_ticks = 0
+		return false
+	}
+	p.regeneration_ticks++
+	if p.regeneration_ticks < regeneration_interval_ticks {
+		return false
+	}
+	p.regeneration_ticks = 0
+	return true
+}
+
+// advance_starvation is the same counter for an empty bar.
+pub fn (mut p Player) advance_starvation(eligible bool) bool {
+	p.state_mutex.lock()
+	defer {
+		p.state_mutex.unlock()
+	}
+	if !eligible {
+		p.starvation_ticks = 0
+		return false
+	}
+	p.starvation_ticks++
+	if p.starvation_ticks < starvation_interval_ticks {
+		return false
+	}
+	p.starvation_ticks = 0
+	return true
+}
+
+// advance_passive_feed paces the refill on peaceful the same way.
+pub fn (mut p Player) advance_passive_feed() bool {
+	p.state_mutex.lock()
+	defer {
+		p.state_mutex.unlock()
+	}
+	p.passive_feed_ticks++
+	if p.passive_feed_ticks < passive_feed_interval_ticks {
+		return false
+	}
+	p.passive_feed_ticks = 0
+	return true
+}
+
+// charge_movement bills the ground covered since the last sample at the rate
+// the player is moving at now, and reports whether the visible bar moved.
+//
+// Every caller that changes how movement is paid for settles the outstanding
+// distance through here first, so a segment is always charged at the rate that
+// was actually true while it was being travelled. Sprinting for ten metres and
+// then stopping costs the sprint rate for those ten metres, not the walking
+// one, and starting to sprint does not retroactively bill the walk before it.
+pub fn (mut p Player) charge_movement(pos types.Vector3) bool {
+	p.state_mutex.lock()
+	defer {
+		p.state_mutex.unlock()
+	}
+	previous := p.hunger_position
+	had_sample := p.has_hunger_position
+	p.hunger_position = pos
+	p.has_hunger_position = true
+	if !had_sample {
+		return false
+	}
+	rate := p.movement_exhaustion_rate()
+	if rate <= 0 {
+		return false
+	}
+	dx := pos.x - previous.x
+	dz := pos.z - previous.z
+	distance := math.sqrtf(dx * dx + dz * dz)
+	if distance <= 0 {
+		return false
+	}
+	return p.spend_exhaustion(rate * distance)
+}
+
+// movement_exhaustion_rate is what a metre costs in the player's current
+// state. The caller must already hold state_mutex.
+fn (p &Player) movement_exhaustion_rate() f32 {
+	if p.sprinting {
+		return sprint_exhaustion_per_metre
+	}
+	if p.swimming {
+		return swim_exhaustion_per_metre
+	}
+	return 0
 }
 
 // hunger_position is where the player was when their movement was last
@@ -114,10 +210,17 @@ pub fn (p &Player) sprinting() bool {
 	return p.sprinting
 }
 
-pub fn (mut p Player) set_sprinting(value bool) {
+// set_sprinting settles what has been travelled so far before the rate
+// changes, so the distance already covered is billed at the old rate.
+pub fn (mut p Player) set_sprinting(pos types.Vector3, value bool) bool {
+	if p.sprinting() == value {
+		return false
+	}
+	changed := p.charge_movement(pos)
 	p.state_mutex.lock()
 	p.sprinting = value
 	p.state_mutex.unlock()
+	return changed
 }
 
 pub fn (p &Player) swimming() bool {
@@ -129,10 +232,17 @@ pub fn (p &Player) swimming() bool {
 	return p.swimming
 }
 
-pub fn (mut p Player) set_swimming(value bool) {
+// set_swimming settles the outstanding distance the same way set_sprinting
+// does.
+pub fn (mut p Player) set_swimming(pos types.Vector3, value bool) bool {
+	if p.swimming() == value {
+		return false
+	}
+	changed := p.charge_movement(pos)
 	p.state_mutex.lock()
 	p.swimming = value
 	p.state_mutex.unlock()
+	return changed
 }
 
 // exhaust adds amount to the exhaustion counter and spends whatever whole
@@ -145,6 +255,15 @@ pub fn (mut p Player) exhaust(amount f32) bool {
 	p.state_mutex.lock()
 	defer {
 		p.state_mutex.unlock()
+	}
+	return p.spend_exhaustion(amount)
+}
+
+// spend_exhaustion is exhaust's body, for the callers that already hold
+// state_mutex.
+fn (mut p Player) spend_exhaustion(amount f32) bool {
+	if amount <= 0 {
+		return false
 	}
 	before_food := p.food_level
 	before_saturation := p.saturation

--- a/server/player/hunger_test.v
+++ b/server/player/hunger_test.v
@@ -1,0 +1,102 @@
+module player
+
+fn test_a_fresh_player_starts_fed() {
+	p := new_player()
+	state := p.hunger()
+	assert state.food_level == max_food_level
+	assert state.saturation == initial_saturation
+	assert state.exhaustion == 0
+}
+
+fn test_exhaustion_below_the_threshold_moves_nothing_visible() {
+	mut p := new_player()
+	assert !p.exhaust(3.9)
+	state := p.hunger()
+	assert state.food_level == max_food_level
+	assert state.saturation == initial_saturation
+	assert state.exhaustion > 3.89 && state.exhaustion < 3.91
+}
+
+fn test_saturation_is_spent_before_food() {
+	mut p := new_player()
+	assert p.exhaust(exhaustion_threshold)
+	state := p.hunger()
+	assert state.food_level == max_food_level
+	assert state.saturation == initial_saturation - 1.0
+	assert state.exhaustion == 0
+}
+
+fn test_food_is_spent_once_saturation_runs_out() {
+	mut p := new_player()
+	// Five points of saturation, then the sixth unit comes off the bar.
+	p.exhaust(exhaustion_threshold * 6)
+	state := p.hunger()
+	assert state.saturation == 0
+	assert state.food_level == max_food_level - 1
+}
+
+fn test_an_empty_bar_does_not_bank_exhaustion() {
+	mut p := new_player()
+	p.set_hunger(HungerState{})
+	p.exhaust(exhaustion_threshold * 10)
+	state := p.hunger()
+	assert state.food_level == 0
+	assert state.exhaustion == 0
+}
+
+fn test_eating_restores_food_and_saturation() {
+	mut p := new_player()
+	p.set_hunger(HungerState{
+		food_level: 10
+	})
+	// Bread: 5 nutrition at a 0.6 modifier, so 6 saturation behind it.
+	p.eat(5, 0.6)
+	state := p.hunger()
+	assert state.food_level == 15
+	assert state.saturation > 5.99 && state.saturation < 6.01
+}
+
+fn test_saturation_cannot_exceed_the_food_it_sits_behind() {
+	mut p := new_player()
+	p.set_hunger(HungerState{
+		food_level: 4
+	})
+	p.eat(2, 4.0)
+	state := p.hunger()
+	assert state.food_level == 6
+	assert state.saturation == 6.0
+}
+
+fn test_eating_never_overfills_the_bar() {
+	mut p := new_player()
+	p.eat(10, 1.0)
+	state := p.hunger()
+	assert state.food_level == max_food_level
+	assert state.saturation == f32(max_food_level)
+}
+
+fn test_reset_hunger_returns_a_spawning_bar() {
+	mut p := new_player()
+	p.set_hunger(HungerState{
+		food_level: 2
+		saturation: 0
+		exhaustion: 3
+	})
+	p.reset_hunger()
+	state := p.hunger()
+	assert state.food_level == max_food_level
+	assert state.saturation == initial_saturation
+	assert state.exhaustion == 0
+}
+
+fn test_hunger_position_starts_unsampled() {
+	mut p := new_player()
+	if _ := p.hunger_position() {
+		assert false, 'a player who has not moved yet reported a sample'
+	}
+	p.set_hunger_position(p.position())
+	if _ := p.hunger_position() {
+	} else {
+		assert false, 'sample was not recorded'
+	}
+}

--- a/server/player/player.v
+++ b/server/player/player.v
@@ -51,6 +51,23 @@ mut:
 	last_death_pos   types.Vector3
 	air_supply_ticks i64 = max_air_supply_ticks
 	fire_ticks       i64
+	food_level       int = max_food_level
+	saturation       f32 = initial_saturation
+	exhaustion       f32
+	// sprinting/swimming are reported by the client and decide what moving a
+	// metre costs. They are state, not events: the tick that spends the
+	// exhaustion runs on the world actor, not on the packet.
+	sprinting bool
+	swimming  bool
+	// hunger_clock paces regeneration, starvation and the passive refill off
+	// the number of hunger ticks a player has actually had, not off the world
+	// clock: a player who joins late must not inherit someone else's phase.
+	hunger_clock i64
+	// hunger_position is where movement was last charged for. It only starts
+	// counting once there is a sample to measure against, so a join or a
+	// teleport is not billed as distance travelled.
+	has_hunger_position bool
+	hunger_position     types.Vector3
 	// give_next_slot round robins give_item across the hotbar. Only the
 	// world actor touches it, so it is not under state_mutex.
 	give_next_slot int

--- a/server/player/player.v
+++ b/server/player/player.v
@@ -59,10 +59,13 @@ mut:
 	// exhaustion runs on the world actor, not on the packet.
 	sprinting bool
 	swimming  bool
-	// hunger_clock paces regeneration, starvation and the passive refill off
-	// the number of hunger ticks a player has actually had, not off the world
-	// clock: a player who joins late must not inherit someone else's phase.
-	hunger_clock i64
+	// These count consecutive ticks spent under one condition - well fed
+	// enough to heal, starving, or waiting on peaceful's refill - and reset
+	// the moment it stops holding. A timer that ran off a shared clock would
+	// let a player inherit whatever phase it was already in.
+	regeneration_ticks int
+	starvation_ticks   int
+	passive_feed_ticks int
 	// hunger_position is where movement was last charged for. It only starts
 	// counting once there is a sample to measure against, so a join or a
 	// teleport is not billed as distance travelled.

--- a/server/player/playerdb/player.v
+++ b/server/player/playerdb/player.v
@@ -3,6 +3,13 @@ module playerdb
 import os
 import json2
 
+// A save written before hunger existed has neither field, so both default to
+// what a fresh player starts with rather than to a starving one. They live
+// here because the save format is the lower layer: player builds its own
+// constants on top of these, not the other way round.
+pub const max_food_level = 20
+pub const initial_saturation = f32(5.0)
+
 pub struct InvItem {
 pub mut:
 	slot             int = -1
@@ -22,6 +29,9 @@ pub mut:
 	pitch          f32
 	gamemode       int
 	items          []InvItem
+	food_level     int = max_food_level
+	saturation     f32 = initial_saturation
+	exhaustion     f32
 	has_last_death bool
 	last_death_x   f32
 	last_death_y   f32

--- a/server/session/blocks.v
+++ b/server/session/blocks.v
@@ -75,6 +75,7 @@ fn (mut s NetworkSession) handle_inventory_transaction(p proto.InventoryTransact
 
 fn (mut s NetworkSession) handle_player_auth_input(p proto.PlayerAuthInputPacket) ! {
 	on_ground := proto.PlayerAuthInputData.vertical_collision in p.input_data
+	s.apply_input_state(p.input_data)
 	s.update_movement(proto.vec3_from_array(p.player_position), p.player_rotation[0],
 		p.player_rotation[1], p.player_head_rotation, on_ground)
 	if tx := p.item_use_transaction {
@@ -466,6 +467,7 @@ fn complete_block_break(mut tx worldrt.WorldTx, mut s NetworkSession, pos types.
 
 	tx.set_block(pos.x, pos.y, pos.z, air_id)
 	damage_held_item(mut s, 1)
+	s.exhaust_and_sync(player.mining_exhaustion)
 
 	if s.player.game_mode() != .creative && s.can_harvest(old_id) {
 		drop_name, drop_count := block_drop_for(tx.wr.services.game_data(), old_id)

--- a/server/session/combat.v
+++ b/server/session/combat.v
@@ -227,6 +227,7 @@ fn (mut s NetworkSession) apply_hurt(mut tx worldrt.WorldTx, amount f32, source 
 	if ctx.is_cancelled() {
 		return
 	}
+	s.exhaust_and_sync(player.damage_exhaustion)
 	new_health := s.player.health() - ctx.val.amount
 	s.player.set_health(if new_health < 0 { f32(0) } else { new_health })
 	s.deliver(s.health_update())
@@ -285,6 +286,8 @@ fn (mut s NetworkSession) apply_respawn(mut tx worldrt.WorldTx) {
 	}
 	s.player.set_dead(false)
 	s.player.set_health(20.0)
+	s.player.reset_hunger()
+	s.send_hunger()
 	spawn_y := s.generator.spawn_y()
 	mut ctx := event.new_context(player.RespawnData{
 		player: s.player

--- a/server/session/damage_source.v
+++ b/server/session/damage_source.v
@@ -165,6 +165,29 @@ pub fn (s DrowningDamageSource) death_message_key(victim_name string) (string, [
 	return '%death.attack.drown', [victim_name]
 }
 
+// StarvationDamageSource is damage from an empty hunger bar.
+pub struct StarvationDamageSource {}
+
+pub fn (s StarvationDamageSource) ignored_by_fire_resistance() bool {
+	return false
+}
+
+pub fn (s StarvationDamageSource) reduced_by_resistance() bool {
+	return false
+}
+
+pub fn (s StarvationDamageSource) reduced_by_armour() bool {
+	return false
+}
+
+pub fn (s StarvationDamageSource) attacker_label() string {
+	return ''
+}
+
+pub fn (s StarvationDamageSource) death_message_key(victim_name string) (string, []string) {
+	return '%death.attack.starve', [victim_name]
+}
+
 // FireDamageSource is damage from burning while on fire.
 pub struct FireDamageSource {}
 

--- a/server/session/hunger.v
+++ b/server/session/hunger.v
@@ -10,16 +10,6 @@ import server.worldrt
 // before health comes back on its own.
 const food_regeneration_threshold = 18
 
-// regeneration_interval_ticks and starvation_interval_ticks pace the two
-// opposite ends of the bar: one heal, or one point of starvation damage, per
-// interval.
-const regeneration_interval_ticks = i64(80)
-const starvation_interval_ticks = i64(80)
-
-// peaceful_feed_interval_ticks is how often the bar refills itself when there
-// is no difficulty to go hungry under.
-const peaceful_feed_interval_ticks = i64(20)
-
 const starvation_damage = f32(1.0)
 
 // max_player_health is a full health bar, the ceiling regeneration heals to.
@@ -43,21 +33,17 @@ fn (mut s NetworkSession) tick_hunger(mut tx worldrt.WorldTx) {
 	if s.player.is_dead() || !s.hunger_applies() {
 		return
 	}
-	tick := s.player.advance_hunger_clock()
 	difficulty := s.hub.difficulty_value()
 	if difficulty == proto.difficulty_peaceful {
-		s.tick_peaceful_hunger(tick)
+		s.tick_peaceful_hunger()
 		return
 	}
-	mut changed := s.exhaust_movement()
+	mut changed := s.player.charge_movement(s.current_position())
 	state := s.player.hunger()
-	if state.food_level >= food_regeneration_threshold {
-		if s.regenerate(tick) {
-			changed = true
-		}
-	} else if state.food_level == 0 {
-		s.starve(mut tx, tick, difficulty)
+	if s.regenerate(state.food_level >= food_regeneration_threshold) {
+		changed = true
 	}
+	s.starve(mut tx, state.food_level == 0, difficulty)
 	if changed {
 		s.send_hunger()
 	}
@@ -70,11 +56,11 @@ fn (s &NetworkSession) hunger_applies() bool {
 }
 
 // tick_peaceful_hunger refills the bar instead of draining it.
-fn (mut s NetworkSession) tick_peaceful_hunger(tick i64) {
+fn (mut s NetworkSession) tick_peaceful_hunger() {
 	// Sample the position anyway, or the first tick back on a harder
 	// difficulty would charge for every metre walked while on peaceful.
 	s.player.set_hunger_position(s.current_position())
-	if tick % peaceful_feed_interval_ticks != 0 {
+	if !s.player.advance_passive_feed() {
 		return
 	}
 	if s.player.food_level() >= player.max_food_level {
@@ -84,34 +70,10 @@ fn (mut s NetworkSession) tick_peaceful_hunger(tick i64) {
 	s.send_hunger()
 }
 
-// exhaust_movement charges the player for the ground they covered since the
-// last step. Walking is free, so only sprinting and swimming are billed.
-fn (mut s NetworkSession) exhaust_movement() bool {
-	pos := s.current_position()
-	previous := s.player.hunger_position() or {
-		s.player.set_hunger_position(pos)
-		return false
-	}
-	s.player.set_hunger_position(pos)
-	rate := if s.player.sprinting() {
-		player.sprint_exhaustion_per_metre
-	} else if s.player.swimming() {
-		player.swim_exhaustion_per_metre
-	} else {
-		return false
-	}
-	dx := pos.x - previous.x
-	dz := pos.z - previous.z
-	distance := math.sqrtf(dx * dx + dz * dz)
-	if distance <= 0 {
-		return false
-	}
-	return s.player.exhaust(rate * distance)
-}
-
-// regenerate heals a point off a well fed player and charges them for it.
-fn (mut s NetworkSession) regenerate(tick i64) bool {
-	if tick % regeneration_interval_ticks != 0 {
+// regenerate heals a point off a player who has spent long enough well fed,
+// and charges them for it.
+fn (mut s NetworkSession) regenerate(eligible bool) bool {
+	if !s.player.advance_regeneration(eligible && s.player.health() < max_player_health) {
 		return false
 	}
 	health := s.player.health()
@@ -125,8 +87,8 @@ fn (mut s NetworkSession) regenerate(tick i64) bool {
 
 // starve applies the damage an empty bar deals, down to the floor the current
 // difficulty allows.
-fn (mut s NetworkSession) starve(mut tx worldrt.WorldTx, tick i64, difficulty int) {
-	if tick % starvation_interval_ticks != 0 {
+fn (mut s NetworkSession) starve(mut tx worldrt.WorldTx, eligible bool, difficulty int) {
+	if !s.player.advance_starvation(eligible) {
 		return
 	}
 	if s.player.health() - starvation_damage < starvation_floor(difficulty) {
@@ -171,14 +133,27 @@ fn jump_exhaustion_for(sprinting bool) f32 {
 }
 
 // apply_input_state records the movement state the client reports, so the
-// hunger tick knows what the metres it sees were covered by.
+// hunger tick knows what the metres it sees were covered by. Each change
+// settles the distance travelled so far first, so a segment is billed at the
+// rate that was true while it was being covered.
 fn (mut s NetworkSession) apply_input_state(input_data []proto.PlayerAuthInputData) {
+	if !s.hunger_applies() {
+		return
+	}
+	pos := s.current_position()
 	sprinting := proto.PlayerAuthInputData.sprinting in input_data
-	s.player.set_sprinting(sprinting)
+	mut changed := s.player.set_sprinting(pos, sprinting)
 	if proto.PlayerAuthInputData.start_swimming in input_data {
-		s.player.set_swimming(true)
+		if s.player.set_swimming(pos, true) {
+			changed = true
+		}
 	} else if proto.PlayerAuthInputData.stop_swimming in input_data {
-		s.player.set_swimming(false)
+		if s.player.set_swimming(pos, false) {
+			changed = true
+		}
+	}
+	if changed {
+		s.send_hunger()
 	}
 	if proto.PlayerAuthInputData.start_jumping in input_data {
 		s.exhaust_and_sync(jump_exhaustion_for(sprinting))

--- a/server/session/hunger.v
+++ b/server/session/hunger.v
@@ -1,0 +1,186 @@
+module session
+
+import math
+import bedrock_v.protocol.current as proto
+import server.item
+import server.player
+import server.worldrt
+
+// food_regeneration_threshold is the food level a player has to be at or above
+// before health comes back on its own.
+const food_regeneration_threshold = 18
+
+// regeneration_interval_ticks and starvation_interval_ticks pace the two
+// opposite ends of the bar: one heal, or one point of starvation damage, per
+// interval.
+const regeneration_interval_ticks = i64(80)
+const starvation_interval_ticks = i64(80)
+
+// peaceful_feed_interval_ticks is how often the bar refills itself when there
+// is no difficulty to go hungry under.
+const peaceful_feed_interval_ticks = i64(20)
+
+const starvation_damage = f32(1.0)
+
+// max_player_health is a full health bar, the ceiling regeneration heals to.
+const max_player_health = f32(20.0)
+
+// starvation_floor is the health starvation stops at, by difficulty: peaceful
+// never starves at all, easy leaves half a bar, normal a single point, and
+// hard takes the player all the way down.
+fn starvation_floor(difficulty int) f32 {
+	return match difficulty {
+		proto.difficulty_easy { 10.0 }
+		proto.difficulty_normal { 1.0 }
+		else { 0.0 }
+	}
+}
+
+// tick_hunger advances one player's hunger bar for the owning world's
+// simulation step: what their movement cost them, then whatever the resulting
+// food level does to their health.
+fn (mut s NetworkSession) tick_hunger(mut tx worldrt.WorldTx) {
+	if s.player.is_dead() || !s.hunger_applies() {
+		return
+	}
+	tick := s.player.advance_hunger_clock()
+	difficulty := s.hub.difficulty_value()
+	if difficulty == proto.difficulty_peaceful {
+		s.tick_peaceful_hunger(tick)
+		return
+	}
+	mut changed := s.exhaust_movement()
+	state := s.player.hunger()
+	if state.food_level >= food_regeneration_threshold {
+		if s.regenerate(tick) {
+			changed = true
+		}
+	} else if state.food_level == 0 {
+		s.starve(mut tx, tick, difficulty)
+	}
+	if changed {
+		s.send_hunger()
+	}
+}
+
+// hunger_applies reports whether the player is in a mode that gets hungry at
+// all. Creative and spectator neither lose food nor starve.
+fn (s &NetworkSession) hunger_applies() bool {
+	return s.player.game_mode().allows_taking_damage()
+}
+
+// tick_peaceful_hunger refills the bar instead of draining it.
+fn (mut s NetworkSession) tick_peaceful_hunger(tick i64) {
+	// Sample the position anyway, or the first tick back on a harder
+	// difficulty would charge for every metre walked while on peaceful.
+	s.player.set_hunger_position(s.current_position())
+	if tick % peaceful_feed_interval_ticks != 0 {
+		return
+	}
+	if s.player.food_level() >= player.max_food_level {
+		return
+	}
+	s.player.feed(1)
+	s.send_hunger()
+}
+
+// exhaust_movement charges the player for the ground they covered since the
+// last step. Walking is free, so only sprinting and swimming are billed.
+fn (mut s NetworkSession) exhaust_movement() bool {
+	pos := s.current_position()
+	previous := s.player.hunger_position() or {
+		s.player.set_hunger_position(pos)
+		return false
+	}
+	s.player.set_hunger_position(pos)
+	rate := if s.player.sprinting() {
+		player.sprint_exhaustion_per_metre
+	} else if s.player.swimming() {
+		player.swim_exhaustion_per_metre
+	} else {
+		return false
+	}
+	dx := pos.x - previous.x
+	dz := pos.z - previous.z
+	distance := math.sqrtf(dx * dx + dz * dz)
+	if distance <= 0 {
+		return false
+	}
+	return s.player.exhaust(rate * distance)
+}
+
+// regenerate heals a point off a well fed player and charges them for it.
+fn (mut s NetworkSession) regenerate(tick i64) bool {
+	if tick % regeneration_interval_ticks != 0 {
+		return false
+	}
+	health := s.player.health()
+	if health >= max_player_health {
+		return false
+	}
+	s.player.set_health(math.min(max_player_health, health + 1.0))
+	s.deliver(s.health_update())
+	return s.player.exhaust(player.regeneration_exhaustion)
+}
+
+// starve applies the damage an empty bar deals, down to the floor the current
+// difficulty allows.
+fn (mut s NetworkSession) starve(mut tx worldrt.WorldTx, tick i64, difficulty int) {
+	if tick % starvation_interval_ticks != 0 {
+		return
+	}
+	if s.player.health() - starvation_damage < starvation_floor(difficulty) {
+		return
+	}
+	s.apply_hurt(mut tx, starvation_damage, StarvationDamageSource{})
+}
+
+// exhaust_and_sync spends exhaustion from somewhere other than the hunger tick
+// - a swing of a pickaxe, a hit taken - and resends the bar if it moved.
+fn (mut s NetworkSession) exhaust_and_sync(amount f32) {
+	if !s.hunger_applies() {
+		return
+	}
+	if s.player.exhaust(amount) {
+		s.send_hunger()
+	}
+}
+
+// eat_result applies what a consumed item restores. Items with no nutrition
+// (a potion, a milk bucket) leave the bar alone.
+fn (mut s NetworkSession) eat_item(name string) {
+	it := item.get(name) or { return }
+	if it.nutrition() <= 0 {
+		return
+	}
+	s.player.eat(it.nutrition(), it.saturation())
+	s.send_hunger()
+}
+
+fn (mut s NetworkSession) send_hunger() {
+	if !s.spawned {
+		return
+	}
+	s.deliver(s.player.hunger_update())
+}
+
+// jump_exhaustion_for is what leaving the ground costs, which sprinting makes
+// four times more expensive.
+fn jump_exhaustion_for(sprinting bool) f32 {
+	return if sprinting { player.sprint_jump_exhaustion } else { player.jump_exhaustion }
+}
+
+// apply_input_state records the movement state the client reports, so the
+// hunger tick knows what the metres it sees were covered by.
+fn (mut s NetworkSession) apply_input_state(input_data []proto.PlayerAuthInputData) {
+	sprinting := proto.PlayerAuthInputData.sprinting in input_data
+	s.player.set_sprinting(sprinting)
+	if proto.PlayerAuthInputData.start_swimming in input_data {
+		s.player.set_swimming(true)
+	} else if proto.PlayerAuthInputData.stop_swimming in input_data {
+		s.player.set_swimming(false)
+	}
+	if proto.PlayerAuthInputData.start_jumping in input_data {
+		s.exhaust_and_sync(jump_exhaustion_for(sprinting))
+	}
+}

--- a/server/session/hunger_test.v
+++ b/server/session/hunger_test.v
@@ -35,25 +35,57 @@ fn test_only_survival_gets_hungry() {
 
 fn test_walking_is_free_but_sprinting_is_not() {
 	mut pl := player.new_player()
-	mut s := &NetworkSession{
-		player: pl
-	}
-	s.player.set_game_mode(.survival)
-	s.player.reset_position(vector_at(0))
-	// The first step only records where the player is.
-	assert !s.exhaust_movement()
-	s.player.reset_position(vector_at(100))
-	assert !s.exhaust_movement()
-	assert s.player.hunger().exhaustion == 0
+	// The first sample only records where the player is.
+	assert !pl.charge_movement(vector_at(0))
+	assert !pl.charge_movement(vector_at(100))
+	assert pl.hunger().exhaustion == 0
 
-	s.player.set_sprinting(true)
-	s.player.reset_position(vector_at(200))
-	s.exhaust_movement()
+	pl.set_sprinting(vector_at(100), true)
+	pl.charge_movement(vector_at(200))
 	// 100 metres sprinted is 10 exhaustion, which is two whole units spent and
 	// a remainder left over.
-	state := s.player.hunger()
+	state := pl.hunger()
 	assert state.saturation == player.initial_saturation - 2.0
 	assert state.exhaustion > 1.99 && state.exhaustion < 2.01
+}
+
+fn test_a_segment_is_billed_at_the_rate_it_was_travelled_at() {
+	mut pl := player.new_player()
+	pl.charge_movement(vector_at(0))
+	// Ten metres walked while the sprint flag is still off.
+	pl.set_sprinting(vector_at(10), true)
+	assert pl.hunger().exhaustion == 0
+
+	// Ten more sprinted, then the flag drops: only the sprinted stretch is
+	// billed, and stopping does not retroactively charge the walk.
+	pl.set_sprinting(vector_at(20), false)
+	sprinted := pl.hunger().exhaustion
+	assert sprinted > 0.99 && sprinted < 1.01
+
+	pl.charge_movement(vector_at(120))
+	assert pl.hunger().exhaustion == sprinted
+}
+
+fn test_regeneration_waits_a_full_interval_after_becoming_eligible() {
+	mut pl := player.new_player()
+	// Ineligible ticks never bring the timer closer to firing.
+	for _ in 0 .. 500 {
+		assert !pl.advance_regeneration(false)
+	}
+	for _ in 0 .. player.regeneration_interval_ticks - 1 {
+		assert !pl.advance_regeneration(true)
+	}
+	assert pl.advance_regeneration(true)
+}
+
+fn test_an_interrupted_condition_starts_the_wait_again() {
+	mut pl := player.new_player()
+	for _ in 0 .. player.starvation_interval_ticks - 1 {
+		pl.advance_starvation(true)
+	}
+	// One tick spent fed resets it, so the next one does not fire.
+	pl.advance_starvation(false)
+	assert !pl.advance_starvation(true)
 }
 
 fn test_swimming_costs_less_than_sprinting() {

--- a/server/session/hunger_test.v
+++ b/server/session/hunger_test.v
@@ -1,0 +1,90 @@
+module session
+
+import bedrock_v.protocol.current as proto
+import bedrock_v.protocol.types
+import server.player
+
+fn vector_at(x f32) types.Vector3 {
+	return types.Vector3{x, 64.0, 0.0}
+}
+
+fn test_starvation_floor_by_difficulty() {
+	assert starvation_floor(proto.difficulty_easy) == 10.0
+	assert starvation_floor(proto.difficulty_normal) == 1.0
+	assert starvation_floor(proto.difficulty_hard) == 0.0
+}
+
+fn test_sprinting_makes_a_jump_cost_more() {
+	assert jump_exhaustion_for(false) == player.jump_exhaustion
+	assert jump_exhaustion_for(true) == player.sprint_jump_exhaustion
+	assert jump_exhaustion_for(true) > jump_exhaustion_for(false)
+}
+
+fn test_only_survival_gets_hungry() {
+	mut pl := player.new_player()
+	mut s := &NetworkSession{
+		player: pl
+	}
+	s.player.set_game_mode(.survival)
+	assert s.hunger_applies()
+	s.player.set_game_mode(.creative)
+	assert !s.hunger_applies()
+	s.player.set_game_mode(.spectator)
+	assert !s.hunger_applies()
+}
+
+fn test_walking_is_free_but_sprinting_is_not() {
+	mut pl := player.new_player()
+	mut s := &NetworkSession{
+		player: pl
+	}
+	s.player.set_game_mode(.survival)
+	s.player.reset_position(vector_at(0))
+	// The first step only records where the player is.
+	assert !s.exhaust_movement()
+	s.player.reset_position(vector_at(100))
+	assert !s.exhaust_movement()
+	assert s.player.hunger().exhaustion == 0
+
+	s.player.set_sprinting(true)
+	s.player.reset_position(vector_at(200))
+	s.exhaust_movement()
+	// 100 metres sprinted is 10 exhaustion, which is two whole units spent and
+	// a remainder left over.
+	state := s.player.hunger()
+	assert state.saturation == player.initial_saturation - 2.0
+	assert state.exhaustion > 1.99 && state.exhaustion < 2.01
+}
+
+fn test_swimming_costs_less_than_sprinting() {
+	assert player.swim_exhaustion_per_metre < player.sprint_exhaustion_per_metre
+}
+
+fn test_input_state_is_recorded_from_the_client() {
+	mut pl := player.new_player()
+	mut s := &NetworkSession{
+		player: pl
+	}
+	s.player.set_game_mode(.survival)
+	s.apply_input_state([proto.PlayerAuthInputData.sprinting, .start_swimming])
+	assert s.player.sprinting()
+	assert s.player.swimming()
+
+	s.apply_input_state([proto.PlayerAuthInputData.stop_swimming])
+	assert !s.player.sprinting()
+	assert !s.player.swimming()
+}
+
+fn test_jumping_spends_exhaustion() {
+	mut pl := player.new_player()
+	mut s := &NetworkSession{
+		player: pl
+	}
+	s.player.set_game_mode(.survival)
+	s.apply_input_state([proto.PlayerAuthInputData.start_jumping])
+	assert s.player.hunger().exhaustion == player.jump_exhaustion
+
+	s.player.set_game_mode(.creative)
+	s.apply_input_state([proto.PlayerAuthInputData.start_jumping])
+	assert s.player.hunger().exhaustion == player.jump_exhaustion
+}

--- a/server/session/inventory.v
+++ b/server/session/inventory.v
@@ -648,6 +648,7 @@ fn (mut s NetworkSession) apply_consume(mut tx worldrt.WorldTx, src proto.ItemSt
 	for e in result.effects {
 		s.apply_add_effect(mut tx, e)
 	}
+	s.eat_item(name)
 	return s.replace_consumed_stack(src, amount, stack, net_id, result)
 }
 

--- a/server/session/items.v
+++ b/server/session/items.v
@@ -255,6 +255,7 @@ fn (mut s NetworkSession) save_player_data() {
 		}
 	}
 	current := s.player.movement()
+	hunger := s.player.hunger()
 	mut provider := s.hub.player_data_provider
 	provider.save(s.player_key(), playerdb.PlayerData{
 		x:              current.position.x
@@ -264,6 +265,9 @@ fn (mut s NetworkSession) save_player_data() {
 		pitch:          current.pitch
 		gamemode:       player.gamemode_to_wire(s.player.game_mode())
 		items:          items
+		food_level:     hunger.food_level
+		saturation:     hunger.saturation
+		exhaustion:     hunger.exhaustion
 		has_last_death: s.player.has_last_death()
 		last_death_x:   s.player.last_death_pos().x
 		last_death_y:   s.player.last_death_pos().y

--- a/server/session/session.v
+++ b/server/session/session.v
@@ -63,7 +63,7 @@ mut:
 	// breaking_mutex guards breaking, written by the session thread and
 	// advanced by the owning world thread once per tick.
 	breaking_mutex &sync.Mutex = sync.new_mutex()
-	hub            &Hub = unsafe { nil }
+	hub            &Hub        = unsafe { nil }
 	cfg            conf.Config
 	world          &db.World       = unsafe { nil }
 	generator      world.Generator = world.VoidGenerator{}
@@ -80,9 +80,9 @@ mut:
 	open_container_pos          ?types.BlockPosition
 	open_container_slot_net_ids map[int]int
 	open_container_mutex        &sync.Mutex = sync.new_mutex()
-	crafting_slot_net_ids   map[int]int
-	crafting_workbench_open bool
-	crafting_mutex          &sync.Mutex = sync.new_mutex()
+	crafting_slot_net_ids       map[int]int
+	crafting_workbench_open     bool
+	crafting_mutex              &sync.Mutex = sync.new_mutex()
 	// cursor_net_id tracks whatever the client holds on its cursor
 	// (FullContainerName.cursor_container)
 	cursor_net_id      int

--- a/server/session/spawn.v
+++ b/server/session/spawn.v
@@ -132,6 +132,11 @@ fn (mut s NetworkSession) resolve_spawn_state() SpawnState {
 		pitch = data.pitch
 		yaw = data.yaw
 		s.player.set_loaded_items(data.items)
+		s.player.set_hunger(player.HungerState{
+			food_level: data.food_level
+			saturation: data.saturation
+			exhaustion: data.exhaustion
+		})
 		s.player.set_game_mode(player.gamemode_from_wire(data.gamemode))
 		if data.has_last_death {
 			s.player.set_last_death(types.Vector3{data.last_death_x, data.last_death_y, data.last_death_z})

--- a/server/session/world_tick.v
+++ b/server/session/world_tick.v
@@ -18,6 +18,7 @@ fn (mut t SessionPlayerTicker) tick_players(mut tx worldrt.WorldTx) {
 		mut s := as_network_session(mut a) or { continue }
 		s.tick_effects(mut tx)
 		s.tick_environmental_damage(mut tx)
+		s.tick_hunger(mut tx)
 		s.tick_breaking(mut tx)
 		tx.wr.sample_outbound_depth(int(s.conn.outbound.len))
 	}


### PR DESCRIPTION
## Description

Hunger existed only as three static numbers in the attribute packet: nothing moved them, food items restored nothing, and health came back regardless. This makes the bar real.

- Food level, saturation and exhaustion are player state. Exhaustion rolls over at 4.0 into saturation first and food after, and an already empty bar drops the surplus rather than banking it against the next meal.
- Exhaustion is charged for sprinting (0.1/m) and swimming (0.01/m), jumping (0.05, quadrupled while sprinting), mining a block, taking damage, and regenerating. Walking is free, as it is in game. Sprint and swim state comes from the client's own input flags.
- At 18 food or above, health comes back a point at a time and charges 6 exhaustion for it. At 0 food, starvation damage lands on the same interval, down to the floor the difficulty allows: none on peaceful, half a bar on easy, one point on normal, all the way on hard. Peaceful refills the bar instead.
- Eating applies the nutrition and saturation already declared by `FoodItem`, capped so saturation can never exceed the food carrying it.
- Creative and spectator neither drain nor starve. Respawning resets the bar; the bar saves and loads with the rest of the player, and a save written before this defaults to full rather than starving.
- Pacing is per player, off a hunger clock that only advances while that player is being ticked, so nobody inherits another player's phase and nothing fires on a world's first tick.

## Related issue

Fixes #140

## Checklist
- [x] `v -check .` is clean
- [x] `v test server/player`, `server/session/hunger_test.v`, `combat_test.v`, `effects_test.v`, `movement_test.v`, `items_test.v`, `inventory_test.v`, `world_combat_test.v` are green
- [x] Follows the conventions in AGENTS.md (OOP, `pub`/capitalized exports, no import cycles, minimal comments)
- [x] Cross-session gameplay state is only mutated on its owning world's actor thread (via `world_call`/`wr.submit`/`WorldTx`), never through a global Hub actor
- [x] No unrelated changes bundled in
