### PR TITLE
feat(enchant): make enchantments on a held item do something

### DIFF
--- a/lang/en.toml
+++ b/lang/en.toml
@@ -133,6 +133,21 @@ other = "§aGave {{.Count}}x {{.Item}} to {{.Name}}§r"
 [cmd.give.received]
 other = "§aYou received {{.Count}}x {{.Item}}§r"
 
+[cmd.enchant.usage]
+other = "Usage: /enchant <player: target> <enchantmentName: EnchantmentName> [level: int]"
+
+[cmd.enchant.no_item]
+other = "The target doesn't hold an item"
+
+[cmd.enchant.not_found]
+other = "There is no such enchantment with ID {{.Enchantment}}"
+
+[cmd.enchant.cant_combine]
+other = "{{.Enchantment}} can't be combined with {{.Item}}"
+
+[cmd.enchant.success]
+other = "Enchanting succeeded"
+
 [cmd.difficulty.usage]
 other = "§cUsage: /difficulty <peaceful|easy|normal|hard>§r"
 

--- a/server/cmd/default/command_test.v
+++ b/server/cmd/default/command_test.v
@@ -46,6 +46,10 @@ mut:
 	pos_z            f32
 	cleared          bool
 	given_id         string
+	enchanted_name   string
+	enchanted_level  int
+	enchant_ok       bool   = true
+	held_item        string = 'minecraft:diamond_sword'
 	given_count      int
 	given_ok         bool = true
 	whitelisted      []string
@@ -121,6 +125,19 @@ fn (mut s RecordingSender) teleport(x f32, y f32, z f32) {
 
 fn (mut s RecordingSender) clear_inventory() {
 	s.cleared = true
+}
+
+fn (s RecordingSender) held_item_name() string {
+	return s.held_item
+}
+
+fn (mut s RecordingSender) enchant_held_item(name string, level int) player.EnchantResult {
+	if !s.enchant_ok {
+		return .cannot_combine
+	}
+	s.enchanted_name = name
+	s.enchanted_level = level
+	return .applied
 }
 
 fn (mut s RecordingSender) give_item(id string, count int) bool {
@@ -390,7 +407,7 @@ fn test_available_commands_roundtrip() {
 	mut sender := RecordingSender{}
 	sender.perm.set_op(true)
 	pkt := r.available_commands(sender)
-	assert pkt.commands.len == 14
+	assert pkt.commands.len == 15
 	encoded := protocol.encode_packet_to_bytes(pkt)
 	mut pool := proto.new_packet_pool()
 	mut reader := serializer.new_reader(encoded)
@@ -398,7 +415,7 @@ fn test_available_commands_roundtrip() {
 	assert decoded.name() == 'AvailableCommandsPacket'
 	mut available := proto.AvailableCommandsPacket{}
 	decode_into(pkt, mut available)!
-	assert available.commands.len == 14
+	assert available.commands.len == 15
 	assert available.commands[0].alias_enum == -1
 	assert available.commands[0].overloads.len == 1
 }
@@ -540,4 +557,67 @@ fn decode_into[T](p protocol.Packet, mut out T) ! {
 	mut r := serializer.new_reader(protocol.encode_packet_to_bytes(p))
 	protocol.read_packet_header(mut r)!
 	out.decode_payload(mut r)!
+}
+
+fn test_enchant_command_applies_to_the_target() {
+	r := full_registry()
+	mut target := RecordingSender{
+		sender_name: 'Alex'
+	}
+	mut sender := RecordingSender{
+		peers: {
+			'alex': cmd.Sender(&target)
+		}
+	}
+	sender.perm.set_op(true)
+	r.dispatch('/enchant Alex sharpness 3', mut sender, base_ctx())!
+	assert target.enchanted_name == 'sharpness'
+	assert target.enchanted_level == 3
+}
+
+fn test_enchant_command_defaults_to_level_one() {
+	r := full_registry()
+	mut target := RecordingSender{
+		sender_name: 'Alex'
+	}
+	mut sender := RecordingSender{
+		peers: {
+			'alex': cmd.Sender(&target)
+		}
+	}
+	sender.perm.set_op(true)
+	r.dispatch('/enchant Alex unbreaking', mut sender, base_ctx())!
+	assert target.enchanted_level == 1
+}
+
+fn test_enchant_command_reports_a_refusal() {
+	r := full_registry()
+	mut target := RecordingSender{
+		sender_name: 'Alex'
+		enchant_ok:  false
+	}
+	mut sender := RecordingSender{
+		peers: {
+			'alex': cmd.Sender(&target)
+		}
+	}
+	sender.perm.set_op(true)
+	r.dispatch('/enchant Alex sharpness 3', mut sender, base_ctx())!
+	assert target.enchanted_name == ''
+	assert sender.messages[0].contains("can't be combined")
+}
+
+fn test_enchant_command_denied_without_op() {
+	r := full_registry()
+	mut target := RecordingSender{
+		sender_name: 'Alex'
+	}
+	mut sender := RecordingSender{
+		peers: {
+			'alex': cmd.Sender(&target)
+		}
+	}
+	r.dispatch('/enchant Alex sharpness', mut sender, base_ctx())!
+	assert target.enchanted_name == ''
+	assert sender.messages[0].contains('permission')
 }

--- a/server/cmd/default/enchant.v
+++ b/server/cmd/default/enchant.v
@@ -1,0 +1,76 @@
+module default
+
+import strconv
+import server.permission
+import server.cmd
+import server.player
+
+pub struct EnchantCommand {}
+
+pub fn (c EnchantCommand) name() string {
+	return 'enchant'
+}
+
+pub fn (c EnchantCommand) description() string {
+	return 'Enchants the item a player is holding'
+}
+
+pub fn (c EnchantCommand) aliases() []string {
+	return []
+}
+
+pub fn (c EnchantCommand) permission() string {
+	return permission.command_enchant
+}
+
+pub fn (c EnchantCommand) arguments() []cmd.Argument {
+	return [
+		cmd.StringArgument{
+			arg_name: 'player'
+		},
+		cmd.StringArgument{
+			arg_name: 'enchantment'
+		},
+		cmd.IntArgument{
+			arg_name:     'level'
+			arg_optional: true
+		},
+	]
+}
+
+pub fn (c EnchantCommand) execute(mut sender cmd.Sender, ctx cmd.Context) ! {
+	target_name := ctx.args[0]
+	mut target := sender.find_player(target_name) or {
+		sender.send_message(ctx.lang.tf('cmd.player_not_found', {
+			'Name': target_name
+		}))!
+		return
+	}
+	name := ctx.args[1].all_after('minecraft:')
+	mut level := 1
+	if ctx.args.len > 2 {
+		level = strconv.atoi(ctx.args[2]) or {
+			sender.send_message(ctx.lang.t('cmd.enchant.usage'))!
+			return
+		}
+	}
+	match target.enchant_held_item(name, level) {
+		.applied {
+			sender.send_message(ctx.lang.t('cmd.enchant.success'))!
+		}
+		.no_item {
+			sender.send_message(ctx.lang.t('cmd.enchant.no_item'))!
+		}
+		.not_found {
+			sender.send_message(ctx.lang.tf('cmd.enchant.not_found', {
+				'Enchantment': name
+			}))!
+		}
+		.cannot_combine {
+			sender.send_message(ctx.lang.tf('cmd.enchant.cant_combine', {
+				'Enchantment': name
+				'Item':        target.held_item_name()
+			}))!
+		}
+	}
+}

--- a/server/cmd/default/register.v
+++ b/server/cmd/default/register.v
@@ -13,6 +13,7 @@ pub fn register_all(mut r cmd.Registry) {
 	r.register(TeleportCommand{})
 	r.register(ClearCommand{})
 	r.register(GiveCommand{})
+	r.register(EnchantCommand{})
 	r.register(DifficultyCommand{})
 	r.register(SayCommand{})
 	r.register(TitleCommand{})

--- a/server/item/enchantments.v
+++ b/server/item/enchantments.v
@@ -1,0 +1,134 @@
+module item
+
+import server.enchant
+
+const ench_key = 'ench'
+const ench_id_key = 'id'
+const ench_level_key = 'lvl'
+
+// max_stack_enchantments bounds how many entries are read out of one item's
+// enchantment list, so a malformed or hostile stack cannot size an allocation.
+const max_stack_enchantments = 64
+
+// enchantments_from_nbt reads the enchantments on an item stack's extra data.
+// A stack with none, or with data that does not parse, has none.
+pub fn enchantments_from_nbt(raw []u8) []enchant.Applied {
+	if raw.len == 0 {
+		return []enchant.Applied{}
+	}
+	mut r := LeNbtReader{
+		data: raw
+	}
+	return parse_item_enchantments(mut r) or { []enchant.Applied{} }
+}
+
+// enchantment_level is the level of one enchantment on a stack, or 0 when it
+// does not carry it. Callers scale an effect by this directly.
+pub fn enchantment_level(raw []u8, name string) int {
+	target := enchant.get_by_name(name) or { return 0 }
+	for applied in enchantments_from_nbt(raw) {
+		if applied.eid == target.id() {
+			return applied.level
+		}
+	}
+	return 0
+}
+
+// enchanted_nbt returns item extra data carrying entries, keeping nothing else
+// the stack had. It is enough for putting enchantments on an item; a stack
+// that also carries book pages or a custom name is not merged with it.
+pub fn enchanted_nbt(entries []enchant.Applied) []u8 {
+	if entries.len == 0 {
+		return []u8{}
+	}
+	mut w := LeNbtWriter{}
+	start_item_extra_data(mut w)
+	w.u8(nbt_tag_compound)
+	w.le_u16(0)
+	write_enchantments_field(mut w, entries)
+	w.u8(nbt_tag_end)
+	end_item_extra_data(mut w)
+	return w.data
+}
+
+fn write_enchantments_field(mut w LeNbtWriter, entries []enchant.Applied) {
+	w.key(nbt_tag_list, ench_key)
+	w.u8(nbt_tag_compound)
+	w.le_u32(u32(entries.len))
+	for entry in entries {
+		w.key(nbt_tag_short, ench_id_key)
+		w.le_u16(u16(entry.eid))
+		w.key(nbt_tag_short, ench_level_key)
+		w.le_u16(u16(entry.level))
+		w.u8(nbt_tag_end)
+	}
+}
+
+fn (mut r LeNbtReader) read_enchantment_list() ![]enchant.Applied {
+	element_id := r.u8()!
+	count := int(r.le_u32()!)
+	if count < 0 || count > max_stack_enchantments {
+		return error('item nbt: enchantment list length ${count} out of range')
+	}
+	mut out := []enchant.Applied{cap: count}
+	for _ in 0 .. count {
+		if element_id != nbt_tag_compound {
+			return error('item nbt: unexpected enchantment element type ${element_id}')
+		}
+		mut eid := 0
+		mut level := 0
+		for {
+			field_id := r.u8()!
+			if field_id == nbt_tag_end {
+				break
+			}
+			field_key := r.string()!
+			if field_id == nbt_tag_short && field_key == ench_id_key {
+				eid = int(r.le_u16()!)
+			} else if field_id == nbt_tag_short && field_key == ench_level_key {
+				level = int(r.le_u16()!)
+			} else {
+				r.skip_payload(field_id)!
+			}
+		}
+		if level > 0 {
+			out << enchant.Applied{
+				eid:   eid
+				level: level
+			}
+		}
+	}
+	return out
+}
+
+fn parse_enchantments(mut r LeNbtReader) ![]enchant.Applied {
+	root_id := r.u8()!
+	if root_id != nbt_tag_compound {
+		return error('item nbt: root is not a compound')
+	}
+	r.string()!
+	for {
+		child_id := r.u8()!
+		if child_id == nbt_tag_end {
+			break
+		}
+		key := r.string()!
+		if child_id == nbt_tag_list && key == ench_key {
+			return r.read_enchantment_list()!
+		}
+		r.skip_payload(child_id)!
+	}
+	return []enchant.Applied{}
+}
+
+fn parse_item_enchantments(mut r LeNbtReader) ![]enchant.Applied {
+	flag := r.le_u16()!
+	if flag != 0xffff {
+		return []enchant.Applied{}
+	}
+	version := r.u8()!
+	if version != 1 {
+		return error('item nbt: unexpected item extra data version ${version}')
+	}
+	return parse_enchantments(mut r)!
+}

--- a/server/item/enchantments_test.v
+++ b/server/item/enchantments_test.v
@@ -1,0 +1,67 @@
+module item
+
+import server.enchant
+
+fn sharpness_id() int {
+	e := enchant.get_by_name('sharpness') or { panic('sharpness is not registered') }
+	return e.id()
+}
+
+fn test_an_item_without_nbt_carries_nothing() {
+	assert enchantments_from_nbt([]u8{}).len == 0
+	assert enchantment_level([]u8{}, 'sharpness') == 0
+}
+
+fn test_enchantments_survive_a_write_and_read() {
+	raw := enchanted_nbt([
+		enchant.Applied{
+			eid:   sharpness_id()
+			level: 3
+		},
+	])
+	assert raw.len > 0
+	entries := enchantments_from_nbt(raw)
+	assert entries.len == 1
+	assert entries[0].eid == sharpness_id()
+	assert entries[0].level == 3
+	assert enchantment_level(raw, 'sharpness') == 3
+	assert enchantment_level(raw, 'unbreaking') == 0
+}
+
+fn test_several_enchantments_round_trip() {
+	unbreaking := enchant.get_by_name('unbreaking') or { panic('unbreaking is not registered') }
+	raw := enchanted_nbt([
+		enchant.Applied{
+			eid:   sharpness_id()
+			level: 5
+		},
+		enchant.Applied{
+			eid:   unbreaking.id()
+			level: 2
+		},
+	])
+	assert enchantments_from_nbt(raw).len == 2
+	assert enchantment_level(raw, 'sharpness') == 5
+	assert enchantment_level(raw, 'unbreaking') == 2
+}
+
+fn test_an_empty_list_writes_no_nbt() {
+	assert enchanted_nbt([]enchant.Applied{}).len == 0
+}
+
+fn test_malformed_nbt_is_read_as_nothing() {
+	assert enchantments_from_nbt([u8(1), 2, 3]).len == 0
+	assert enchantment_level([u8(0xff), 0xff, 9, 9], 'sharpness') == 0
+}
+
+fn test_a_book_and_an_enchantment_do_not_read_as_each_other() {
+	book := writable_book_nbt(['a page'])
+	assert enchantments_from_nbt(book).len == 0
+	raw := enchanted_nbt([
+		enchant.Applied{
+			eid:   sharpness_id()
+			level: 1
+		},
+	])
+	assert book_pages_from_nbt(raw).len == 0
+}

--- a/server/permission/permission.v
+++ b/server/permission/permission.v
@@ -37,6 +37,7 @@ pub const command_teleport_other = 'vedrock.cmd.teleport.other'
 pub const command_clear_self = 'vedrock.cmd.clear.self'
 pub const command_clear_other = 'vedrock.cmd.clear.other'
 pub const command_give = 'vedrock.cmd.give'
+pub const command_enchant = 'vedrock.cmd.enchant'
 pub const command_difficulty = 'vedrock.cmd.difficulty'
 pub const command_say = 'vedrock.cmd.say'
 pub const command_title = 'vedrock.cmd.title'
@@ -118,6 +119,11 @@ fn new_registry() &Registry {
 	r.register(Permission{
 		name:        command_give
 		description: 'Allows giving items to players'
+		default:     .op
+	})
+	r.register(Permission{
+		name:        command_enchant
+		description: 'Allows enchanting the item a player is holding'
 		default:     .op
 	})
 	r.register(Permission{

--- a/server/player/view.v
+++ b/server/player/view.v
@@ -25,10 +25,27 @@ mut:
 	teleport(x f32, y f32, z f32)
 	clear_inventory()
 	give_item(id string, count int) bool
+	// held_item_name is the id of whatever the player is holding, empty for an
+	// empty hand.
+	held_item_name() string
+	// enchant_held_item puts an enchantment on whatever the player is holding
+	// and reports what happened, so a caller can say which of the ways it
+	// failed applies.
+	enchant_held_item(name string, level int) EnchantResult
 	send_form(f form.Form) !
 	send_scoreboard(board &scoreboard.Scoreboard)
 	remove_scoreboard()
 	send_title(t title.Title)
 	send_bossbar(bar bossbar.BossBar)
 	remove_bossbar()
+}
+
+// EnchantResult is the outcome of trying to enchant what a player holds.
+pub enum EnchantResult {
+	applied
+	// no_item is an empty hand, and cannot_combine an enchantment the held
+	// item will not take, or a level it does not go up to.
+	no_item
+	cannot_combine
+	not_found
 }

--- a/server/session/blocks.v
+++ b/server/session/blocks.v
@@ -202,6 +202,9 @@ fn (mut s NetworkSession) damage_held_item(amount int) {
 	if net == 0 {
 		return
 	}
+	if survives_unbreaking(item.enchantment_level(stack.raw_extra_data, 'unbreaking')) {
+		return
+	}
 	it := item.get(s.hub.data.item_name(stack.id)) or { return }
 	result := item.damage_item(it, stack.meta, amount)
 	if result.broken {
@@ -468,10 +471,9 @@ fn complete_block_break(mut tx worldrt.WorldTx, mut s NetworkSession, pos types.
 	damage_held_item(mut s, 1)
 
 	if s.player.game_mode() != .creative && s.can_harvest(old_id) {
-		drop_name, drop_count := block_drop_for(tx.wr.services.game_data(), old_id)
+		drop_name, drop_count := s.harvested_drop(tx.wr.services.game_data(), old_id)
 		if drop_name != '' {
-			center := types.Vector3{f32(pos.x) + 0.5, f32(pos.y) + 0.5, f32(pos.z) + 0.5}
-			spawn_dropped_item_stack(mut tx, drop_name, drop_count, center)
+			spawn_dropped_item_stack(mut tx, drop_name, drop_count, block_center(pos))
 		}
 	}
 

--- a/server/session/breaking.v
+++ b/server/session/breaking.v
@@ -301,8 +301,8 @@ fn (s &NetworkSession) can_harvest(runtime_id int) bool {
 
 // break_progress_per_tick is the fraction of the block broken each tick. The
 // base time comes from the block's hardness and the held tool, then the
-// player's own state scales it, mirroring vanilla. Efficiency and aqua
-// affinity enchantments are not modelled yet.
+// player's own state scales it, mirroring vanilla. Aqua Affinity is not
+// modelled yet.
 fn (s &NetworkSession) break_progress_per_tick(runtime_id int) f32 {
 	info := block.break_info(runtime_id)
 	if !info.breakable() {
@@ -347,7 +347,7 @@ fn mining_fatigue_multiplier(level int) f32 {
 fn (s &NetworkSession) held_mining_stats() (int, int, f32) {
 	_, name := s.held_stack_and_name()
 	held := item.get(name) or { return block.tool_type_none, block.harvest_level_none, f32(1.0) }
-	efficiency := held.mining_speed()
+	efficiency := held.mining_speed() + efficiency_bonus(s.held_enchantment_level('efficiency'))
 	if held is item.MiningTool {
 		return held.block_tool_type(), held.harvest_level(), efficiency
 	}

--- a/server/session/combat.v
+++ b/server/session/combat.v
@@ -26,7 +26,10 @@ struct PlayerAttackTask {
 	damage              f32
 	knockback_force     f32 = knockback_horizontal
 	knockback_height    f32 = knockback_vertical
-	critical            bool
+	// fire_ticks is how long the attacker's Fire Aspect sets the victim
+	// burning for, 0 when the weapon does not carry it.
+	fire_ticks i64
+	critical   bool
 }
 
 fn (t PlayerAttackTask) name() string {
@@ -66,6 +69,9 @@ fn (t PlayerAttackTask) run(mut tx worldrt.WorldTx) {
 		return
 	}
 	damage_held_item(mut attacker, 1)
+	if mut victim_session := as_network_session(mut victim_actor) {
+		ignite_victim(mut victim_session, t.fire_ticks)
+	}
 	damage_actor(mut tx, t.victim_runtime_id, ctx.val.damage, AttackDamageSource{
 		attacker_name: attacker.player.identity.display_name
 	}, t.attacker_runtime_id, own, ctx.val.knockback_force, ctx.val.knockback_height)
@@ -91,7 +97,7 @@ fn (mut s NetworkSession) handle_attack(target_runtime_id u64) ! {
 	// client-supplied held item - otherwise a client could claim a weapon it
 	// does not own to inflate damage.
 	_, weapon_name := s.held_stack_and_name()
-	mut damage := s.weapon_damage(weapon_name)
+	mut damage := s.enchanted_attack_damage(s.weapon_damage(weapon_name))
 	critical := s.is_critical()
 	if critical {
 		damage *= critical_multiplier
@@ -106,6 +112,8 @@ fn (mut s NetworkSession) handle_attack(target_runtime_id u64) ! {
 		attacker_epoch:      s.world_binding().epoch
 		victim_runtime_id:   target_runtime_id
 		damage:              damage
+		knockback_force:     s.enchanted_knockback(knockback_horizontal)
+		fire_ticks:          s.fire_aspect_ticks()
 		critical:            critical
 	})
 }

--- a/server/session/console.v
+++ b/server/session/console.v
@@ -84,6 +84,14 @@ fn (mut c ConsoleSender) give_item(_ string, _ int) bool {
 	return false
 }
 
+fn (c ConsoleSender) held_item_name() string {
+	return ''
+}
+
+fn (mut c ConsoleSender) enchant_held_item(_ string, _ int) player.EnchantResult {
+	return .no_item
+}
+
 fn (mut c ConsoleSender) send_form(_ form.Form) ! {
 	return error('the console cannot display forms')
 }

--- a/server/session/enchantments.v
+++ b/server/session/enchantments.v
@@ -1,0 +1,195 @@
+module session
+
+import rand
+import bedrock_v.protocol.types
+import server.enchant
+import server.internal.gamedata
+import server.item
+import server.player
+import server.worldrt
+
+// fire_aspect_ticks_per_level is how long a hit sets its victim burning for
+// each level of Fire Aspect.
+const fire_aspect_ticks_per_level = i64(4 * 20)
+
+// knockback_per_level is the extra horizontal push each level of Knockback
+// adds to a hit.
+const knockback_per_level = f32(0.5)
+
+// held_enchantments is what the player's held item carries.
+fn (s &NetworkSession) held_enchantments() []enchant.Applied {
+	stack, _ := s.held_stack_and_name()
+	return item.enchantments_from_nbt(stack.raw_extra_data)
+}
+
+// held_enchantment_level is the level of one enchantment on the held item, 0
+// when it is not there.
+fn (s &NetworkSession) held_enchantment_level(name string) int {
+	stack, _ := s.held_stack_and_name()
+	return item.enchantment_level(stack.raw_extra_data, name)
+}
+
+// enchanted_attack_damage is what the held weapon hits for once its
+// enchantments are counted.
+fn (s &NetworkSession) enchanted_attack_damage(base f32) f32 {
+	return base + enchant.attack_bonus(s.held_enchantments())
+}
+
+// enchanted_knockback is the horizontal push a hit lands with.
+fn (s &NetworkSession) enchanted_knockback(base f32) f32 {
+	return base + knockback_per_level * f32(s.held_enchantment_level('knockback'))
+}
+
+// fire_aspect_ticks is how long the held weapon sets a victim burning for.
+fn (s &NetworkSession) fire_aspect_ticks() i64 {
+	return fire_aspect_ticks_per_level * i64(s.held_enchantment_level('fire_aspect'))
+}
+
+// efficiency_bonus is the mining speed Efficiency adds, which is level squared
+// plus one on top of whatever the tool was already worth.
+fn efficiency_bonus(level int) f32 {
+	if level <= 0 {
+		return 0
+	}
+	return f32(level * level + 1)
+}
+
+// survives_unbreaking rolls whether a point of durability damage is skipped.
+// Each level of Unbreaking makes an item last proportionally longer.
+fn survives_unbreaking(level int) bool {
+	if level <= 0 {
+		return false
+	}
+	return rand.intn(level + 1) or { 0 } != 0
+}
+
+// silk_touch_drop is the block itself rather than what breaking it normally
+// leaves, when the held tool has Silk Touch and the block has a form to drop.
+fn (s &NetworkSession) silk_touch_drop(block_id int) ?string {
+	if s.held_enchantment_level('silk_touch') <= 0 {
+		return none
+	}
+	item_id := s.hub.data.item_for_block(block_id)
+	if item_id == 0 {
+		return none
+	}
+	return s.hub.data.item_name(item_id)
+}
+
+// fortune_count multiplies a drop the way Fortune does: usually nothing, and
+// at best one extra drop per level. Drops that are the block itself - stone,
+// ores that drop their own block - are not multiplied.
+fn fortune_count(base int, level int) int {
+	if level <= 0 || base <= 0 {
+		return base
+	}
+	bonus := rand.intn(level + 1) or { 0 }
+	return base + bonus
+}
+
+// ignite_victim sets a victim burning for as long as the attacker's Fire
+// Aspect says.
+fn ignite_victim(mut victim NetworkSession, ticks i64) {
+	if ticks <= 0 || victim.player.fire_ticks() >= ticks {
+		return
+	}
+	victim.player.set_fire_ticks(ticks)
+}
+
+// block_center is where a block's drops appear.
+fn block_center(pos types.BlockPosition) types.Vector3 {
+	return types.Vector3{f32(pos.x) + 0.5, f32(pos.y) + 0.5, f32(pos.z) + 0.5}
+}
+
+// harvested_drop is what breaking a block leaves for this player: the block
+// itself when the held tool has Silk Touch, and otherwise the block's normal
+// drop, multiplied by Fortune where that applies.
+fn (s &NetworkSession) harvested_drop(data &gamedata.GameData, block_id int) (string, int) {
+	if silk := s.silk_touch_drop(block_id) {
+		return silk, 1
+	}
+	drop_name, drop_count := block_drop_for(data, block_id)
+	if drop_name == '' {
+		return '', 0
+	}
+	// Fortune only multiplies a drop that is not the block itself - an ore
+	// dropping its own block gains nothing from it, exactly as in game.
+	block_item := s.hub.data.item_for_block(block_id)
+	if block_item != 0 && s.hub.data.item_name(block_item) == drop_name {
+		return drop_name, drop_count
+	}
+	return drop_name, fortune_count(drop_count, s.held_enchantment_level('fortune'))
+}
+
+// PlayerEnchantTask puts an enchantment on a player's held item, on that
+// player's own world runtime.
+struct PlayerEnchantTask {
+	runtime_id u64
+	epoch      i64
+	eid        int
+	level      int
+}
+
+fn (t PlayerEnchantTask) name() string {
+	return 'PlayerEnchantTask'
+}
+
+fn (t PlayerEnchantTask) run(mut tx worldrt.WorldTx) {
+	mut target := player_for_epoch(mut tx, t.runtime_id, t.epoch) or { return }
+	target.apply_held_enchantment(t.eid, t.level)
+}
+
+// apply_held_enchantment rewrites the held item's enchantments to include this
+// one at this level, replacing whatever level it was at before.
+fn (mut s NetworkSession) apply_held_enchantment(eid int, level int) {
+	slot := s.player.held_slot()
+	stack, net := s.inventory_stack_at(slot)
+	if net == 0 || stack.count <= 0 {
+		return
+	}
+	mut entries := item.enchantments_from_nbt(stack.raw_extra_data).filter(it.eid != eid)
+	if level > 0 {
+		entries << enchant.Applied{
+			eid:   eid
+			level: level
+		}
+	}
+	mut updated := stack
+	updated.raw_extra_data = item.enchanted_nbt(entries)
+	s.player.put_stack(net, updated)
+	wrapped := wrap_stack_id(updated, net)
+	s.player.set_held(slot, wrapped)
+	s.send_slot_update(slot, wrapped)
+}
+
+// enchant_held_item is the View entry point: it says what the named
+// enchantment would do to what the player is holding, and applies it on that
+// player's own world runtime when it can go there.
+pub fn (mut s NetworkSession) enchant_held_item(name string, level int) player.EnchantResult {
+	e := enchant.get_by_name(name) or { return .not_found }
+	stack, held_name := s.held_stack_and_name()
+	if held_name == '' || stack.count <= 0 {
+		return .no_item
+	}
+	if !e.can_enchant(held_name) || level < e.min_level() || level > e.max_level() {
+		return .cannot_combine
+	}
+	mut wr := s.current_world_runtime()
+	if isnil(wr) {
+		return .no_item
+	}
+	wr.submit(PlayerEnchantTask{
+		runtime_id: s.runtime_id
+		epoch:      s.world_binding().epoch
+		eid:        e.id()
+		level:      level
+	})
+	return .applied
+}
+
+// held_item_name is the id of what the player is holding, for the callers that
+// only need to name it.
+pub fn (s &NetworkSession) held_item_name() string {
+	_, name := s.held_stack_and_name()
+	return name
+}

--- a/server/session/enchantments_test.v
+++ b/server/session/enchantments_test.v
@@ -1,0 +1,35 @@
+module session
+
+fn test_efficiency_adds_level_squared_plus_one() {
+	assert efficiency_bonus(0) == 0
+	assert efficiency_bonus(1) == 2
+	assert efficiency_bonus(3) == 10
+	assert efficiency_bonus(5) == 26
+}
+
+fn test_unbreaking_only_ever_skips_damage() {
+	// Without the enchantment every point of damage lands.
+	for _ in 0 .. 100 {
+		assert !survives_unbreaking(0)
+	}
+	// With it, some do not - over this many rolls at level 3 a run of all
+	// hits would be a one in four billion coincidence.
+	mut skipped := 0
+	for _ in 0 .. 200 {
+		if survives_unbreaking(3) {
+			skipped++
+		}
+	}
+	assert skipped > 0
+	assert skipped < 200
+}
+
+fn test_fortune_never_reduces_a_drop() {
+	for _ in 0 .. 100 {
+		count := fortune_count(1, 3)
+		assert count >= 1
+		assert count <= 4
+	}
+	assert fortune_count(2, 0) == 2
+	assert fortune_count(0, 3) == 0
+}


### PR DESCRIPTION
## Description

The `enchant` package defined the whole vanilla set and a registry, and nothing read it: an enchanted sword hit exactly as hard as a plain one. Nothing put an enchantment on an item either, so there was no way to find that out in game.

- Enchantments are read from and written to an item stack's own NBT, using the little-endian reader and writer the book code already had. Malformed data reads as no enchantments rather than failing a hit.
- What now applies from a held item: sharpness, smite and bane of arthropods add their damage; knockback pushes further; fire aspect sets the victim burning; efficiency speeds up mining by level squared plus one; unbreaking rolls to skip a point of durability; silk touch drops the block itself; fortune multiplies a drop, though never one that is the block itself.
- `/enchant <player> <enchantment> [level]` puts one on whatever the player is holding, refusing an enchantment the item cannot take or a level outside its range. Without it the effects would exist but be unreachable, since there is no enchanting table yet.

## Related issue

Part of #128

Not in this PR:

- The enchanting table itself. It costs levels and lapis, which needs the experience system in #139 (PR #151).
- The protection line, thorns, feather falling, respiration and depth strider. All of them read worn armour, which #141 (PR #149) is what makes readable.
- Looting: mob drops are decided in the entity package, which is not told who did the killing.

`enchanted_nbt` writes only the enchantment list, so putting one on an item drops any other NBT it carried. Nothing today holds both - a written book takes no enchantment - but merging is the honest fix once something does.

## Checklist
- [x] `v -check .` is clean
- [x] `v test server/item/enchantments_test.v`, `server/session/enchantments_test.v`, `server/enchant`, `server/cmd/default`, and the session combat/blocks/items/break tests are green
- [x] Follows the conventions in AGENTS.md (OOP, `pub`/capitalized exports, no import cycles, minimal comments)
- [x] Cross-session gameplay state is only mutated on its owning world's actor thread (via `world_call`/`wr.submit`/`WorldTx`), never through a global Hub actor
- [x] No unrelated changes bundled in
