### PR TITLE
feat(scoreboard): add objectives, display slots and teams

### DIFF
--- a/lang/en.toml
+++ b/lang/en.toml
@@ -133,6 +133,69 @@ other = "§aGave {{.Count}}x {{.Item}} to {{.Name}}§r"
 [cmd.give.received]
 other = "§aYou received {{.Count}}x {{.Item}}§r"
 
+[cmd.scoreboard.usage]
+other = "Usage: /scoreboard <objectives|players|teams> ..."
+
+[cmd.scoreboard.objective_exists]
+other = "An objective already exists by that name"
+
+[cmd.scoreboard.objective_not_found]
+other = "No objective was found by the name '{{.Objective}}'"
+
+[cmd.scoreboard.team_exists]
+other = "A team already exists by that name"
+
+[cmd.scoreboard.team_not_found]
+other = "No team was found by the name '{{.Team}}'"
+
+[cmd.scoreboard.objectives.add]
+other = "Added new objective '{{.Objective}}' successfully"
+
+[cmd.scoreboard.objectives.remove]
+other = "Removed objective '{{.Objective}}' successfully"
+
+[cmd.scoreboard.objectives.list]
+other = "There are {{.Count}} objective(s) on the scoreboard:"
+
+[cmd.scoreboard.objectives.list_empty]
+other = "There are no objectives on the scoreboard"
+
+[cmd.scoreboard.setdisplay.success]
+other = "Set display slot {{.Slot}} to show objective {{.Objective}}"
+
+[cmd.scoreboard.setdisplay.cleared]
+other = "Cleared objective display slot {{.Slot}}"
+
+[cmd.scoreboard.players.set]
+other = "Set score of {{.Objective}} for player {{.Name}} to {{.Score}}"
+
+[cmd.scoreboard.players.add]
+other = "Added {{.Amount}} to {{.Objective}} for player {{.Name}} (now {{.Score}})"
+
+[cmd.scoreboard.players.reset]
+other = "Reset all scores of player {{.Name}}"
+
+[cmd.scoreboard.teams.add]
+other = "Added new team '{{.Team}}' successfully"
+
+[cmd.scoreboard.teams.remove]
+other = "Removed team {{.Team}}"
+
+[cmd.scoreboard.teams.join]
+other = "Added {{.Name}} to team {{.Team}}"
+
+[cmd.scoreboard.teams.leave]
+other = "Removed {{.Name}} from their teams"
+
+[cmd.scoreboard.teams.option]
+other = "Set option {{.Option}} for team {{.Team}} to {{.Value}}"
+
+[cmd.scoreboard.teams.list]
+other = "There are {{.Count}} team(s) on the scoreboard:"
+
+[cmd.scoreboard.teams.list_empty]
+other = "There are no teams on the scoreboard"
+
 [cmd.difficulty.usage]
 other = "§cUsage: /difficulty <peaceful|easy|normal|hard>§r"
 

--- a/server/cmd/default/command_test.v
+++ b/server/cmd/default/command_test.v
@@ -32,38 +32,45 @@ fn base_ctx() cmd.Context {
 
 struct RecordingSender {
 mut:
-	messages         []string
-	broadcasts       []string
-	gamemode         ?player.Gamemode
-	perm             permission.Permissible
-	peers            map[string]cmd.Sender
-	sender_name      string = 'Steve'
-	killed           bool
-	disconnected     bool
-	disconnect_msg   string
-	pos_x            f32
-	pos_y            f32
-	pos_z            f32
-	cleared          bool
-	given_id         string
-	given_count      int
-	given_ok         bool = true
-	whitelisted      []string
-	whitelist_on     bool
-	difficulty_value int
-	shown_title      string
-	broadcast_titles []string
-	is_player_val    bool = true
-	sent_form        ?form.Form
-	worlds           []string
-	unloaded_worlds  []string
-	created_dim      string
-	created_gen      string
-	tp_world         string
-	bossbar_text     string
-	scoreboard_title string
-	scoreboard_lines []string
-	scoreboard_shown bool
+	messages          []string
+	broadcasts        []string
+	gamemode          ?player.Gamemode
+	perm              permission.Permissible
+	peers             map[string]cmd.Sender
+	sender_name       string = 'Steve'
+	killed            bool
+	disconnected      bool
+	disconnect_msg    string
+	pos_x             f32
+	pos_y             f32
+	pos_z             f32
+	cleared           bool
+	given_id          string
+	objectives        map[string]string
+	scores            map[string]int
+	teams             map[string]string
+	team_members      map[string]string
+	team_options      map[string]string
+	display_slot      string
+	display_objective string
+	given_count       int
+	given_ok          bool = true
+	whitelisted       []string
+	whitelist_on      bool
+	difficulty_value  int
+	shown_title       string
+	broadcast_titles  []string
+	is_player_val     bool = true
+	sent_form         ?form.Form
+	worlds            []string
+	unloaded_worlds   []string
+	created_dim       string
+	created_gen       string
+	tp_world          string
+	bossbar_text      string
+	scoreboard_title  string
+	scoreboard_lines  []string
+	scoreboard_shown  bool
 }
 
 fn (mut s RecordingSender) send_message(message string) ! {
@@ -121,6 +128,119 @@ fn (mut s RecordingSender) teleport(x f32, y f32, z f32) {
 
 fn (mut s RecordingSender) clear_inventory() {
 	s.cleared = true
+}
+
+fn (mut s RecordingSender) scoreboard_objectives() []cmd.ObjectiveInfo {
+	mut out := []cmd.ObjectiveInfo{}
+	for name, display in s.objectives {
+		out << cmd.ObjectiveInfo{
+			name:         name
+			display_name: display
+		}
+	}
+	return out
+}
+
+fn (mut s RecordingSender) scoreboard_add_objective(name string, display_name string) bool {
+	if name in s.objectives {
+		return false
+	}
+	s.objectives[name] = display_name
+	return true
+}
+
+fn (mut s RecordingSender) scoreboard_remove_objective(name string) bool {
+	if name !in s.objectives {
+		return false
+	}
+	s.objectives.delete(name)
+	return true
+}
+
+fn (mut s RecordingSender) scoreboard_set_display(slot string, objective string) bool {
+	if slot !in ['sidebar', 'list', 'belowname'] {
+		return false
+	}
+	s.display_slot = slot
+	s.display_objective = objective
+	return true
+}
+
+fn (mut s RecordingSender) scoreboard_set_score(objective string, entry string, value int) bool {
+	if objective !in s.objectives {
+		return false
+	}
+	s.scores['${objective}/${entry}'] = value
+	return true
+}
+
+fn (mut s RecordingSender) scoreboard_add_score(objective string, entry string, delta int) ?int {
+	if objective !in s.objectives {
+		return none
+	}
+	key := '${objective}/${entry}'
+	updated := (s.scores[key] or { 0 }) + delta
+	s.scores[key] = updated
+	return updated
+}
+
+fn (mut s RecordingSender) scoreboard_reset_score(entry string) {
+	for key, _ in s.scores.clone() {
+		if key.all_after('/') == entry {
+			s.scores.delete(key)
+		}
+	}
+}
+
+fn (mut s RecordingSender) scoreboard_teams() []cmd.TeamInfo {
+	mut out := []cmd.TeamInfo{}
+	for name, display in s.teams {
+		out << cmd.TeamInfo{
+			name:         name
+			display_name: display
+		}
+	}
+	return out
+}
+
+fn (mut s RecordingSender) scoreboard_add_team(name string, display_name string) bool {
+	if name in s.teams {
+		return false
+	}
+	s.teams[name] = display_name
+	return true
+}
+
+fn (mut s RecordingSender) scoreboard_remove_team(name string) bool {
+	if name !in s.teams {
+		return false
+	}
+	s.teams.delete(name)
+	return true
+}
+
+fn (mut s RecordingSender) scoreboard_team_join(team string, entry string) bool {
+	if team !in s.teams {
+		return false
+	}
+	s.team_members[entry] = team
+	return true
+}
+
+fn (mut s RecordingSender) scoreboard_team_leave(entry string) bool {
+	if entry !in s.team_members {
+		return false
+	}
+	s.team_members.delete(entry)
+	return true
+}
+
+fn (mut s RecordingSender) scoreboard_team_option(team string, option string, value string) bool {
+	if team !in s.teams {
+		return false
+	}
+	s.team_options['${team}/${option}'] = value
+	return true
 }
 
 fn (mut s RecordingSender) give_item(id string, count int) bool {
@@ -390,7 +510,7 @@ fn test_available_commands_roundtrip() {
 	mut sender := RecordingSender{}
 	sender.perm.set_op(true)
 	pkt := r.available_commands(sender)
-	assert pkt.commands.len == 14
+	assert pkt.commands.len == 15
 	encoded := protocol.encode_packet_to_bytes(pkt)
 	mut pool := proto.new_packet_pool()
 	mut reader := serializer.new_reader(encoded)
@@ -398,7 +518,7 @@ fn test_available_commands_roundtrip() {
 	assert decoded.name() == 'AvailableCommandsPacket'
 	mut available := proto.AvailableCommandsPacket{}
 	decode_into(pkt, mut available)!
-	assert available.commands.len == 14
+	assert available.commands.len == 15
 	assert available.commands[0].alias_enum == -1
 	assert available.commands[0].overloads.len == 1
 }
@@ -540,4 +660,93 @@ fn decode_into[T](p protocol.Packet, mut out T) ! {
 	mut r := serializer.new_reader(protocol.encode_packet_to_bytes(p))
 	protocol.read_packet_header(mut r)!
 	out.decode_payload(mut r)!
+}
+
+fn test_scoreboard_objectives_are_added_and_listed() {
+	r := full_registry()
+	mut sender := RecordingSender{}
+	sender.perm.set_op(true)
+	r.dispatch('/scoreboard objectives add kills Kills', mut sender, base_ctx())!
+	assert sender.objectives['kills'] == 'Kills'
+	assert sender.messages[0].contains("Added new objective 'kills'")
+
+	r.dispatch('/scoreboard objectives add kills Kills', mut sender, base_ctx())!
+	assert sender.messages[1].contains('already exists')
+
+	r.dispatch('/scoreboard objectives list', mut sender, base_ctx())!
+	assert sender.messages[2].contains('There are 1 objective(s)')
+}
+
+fn test_scoreboard_setdisplay_and_clear() {
+	r := full_registry()
+	mut sender := RecordingSender{}
+	sender.perm.set_op(true)
+	r.dispatch('/scoreboard objectives add kills', mut sender, base_ctx())!
+	r.dispatch('/scoreboard objectives setdisplay sidebar kills', mut sender, base_ctx())!
+	assert sender.display_slot == 'sidebar'
+	assert sender.display_objective == 'kills'
+
+	r.dispatch('/scoreboard objectives setdisplay sidebar', mut sender, base_ctx())!
+	assert sender.display_objective == ''
+	assert sender.messages.last().contains('Cleared objective display slot')
+}
+
+fn test_scoreboard_scores_are_set_and_added() {
+	r := full_registry()
+	mut sender := RecordingSender{}
+	sender.perm.set_op(true)
+	r.dispatch('/scoreboard objectives add kills', mut sender, base_ctx())!
+	r.dispatch('/scoreboard players set Alex kills 3', mut sender, base_ctx())!
+	assert sender.scores['kills/Alex'] == 3
+
+	r.dispatch('/scoreboard players add Alex kills 2', mut sender, base_ctx())!
+	assert sender.scores['kills/Alex'] == 5
+	assert sender.messages.last().contains('now 5')
+
+	r.dispatch('/scoreboard players reset Alex', mut sender, base_ctx())!
+	assert 'kills/Alex' !in sender.scores
+}
+
+fn test_scoreboard_scores_need_an_objective() {
+	r := full_registry()
+	mut sender := RecordingSender{}
+	sender.perm.set_op(true)
+	r.dispatch('/scoreboard players set Alex missing 1', mut sender, base_ctx())!
+	assert sender.messages[0].contains('No objective was found')
+}
+
+fn test_scoreboard_teams_are_managed() {
+	r := full_registry()
+	mut sender := RecordingSender{}
+	sender.perm.set_op(true)
+	r.dispatch('/scoreboard teams add red Red', mut sender, base_ctx())!
+	assert sender.teams['red'] == 'Red'
+
+	r.dispatch('/scoreboard teams join red Alex', mut sender, base_ctx())!
+	assert sender.team_members['Alex'] == 'red'
+
+	r.dispatch('/scoreboard teams option red friendlyFire false', mut sender, base_ctx())!
+	assert sender.team_options['red/friendlyFire'] == 'false'
+
+	r.dispatch('/scoreboard teams leave Alex', mut sender, base_ctx())!
+	assert 'Alex' !in sender.team_members
+
+	r.dispatch('/scoreboard teams remove red', mut sender, base_ctx())!
+	assert 'red' !in sender.teams
+}
+
+fn test_scoreboard_reports_an_unknown_team() {
+	r := full_registry()
+	mut sender := RecordingSender{}
+	sender.perm.set_op(true)
+	r.dispatch('/scoreboard teams join blue Alex', mut sender, base_ctx())!
+	assert sender.messages[0].contains('No team was found')
+}
+
+fn test_scoreboard_denied_without_op() {
+	r := full_registry()
+	mut sender := RecordingSender{}
+	r.dispatch('/scoreboard objectives add kills', mut sender, base_ctx())!
+	assert sender.objectives.len == 0
+	assert sender.messages[0].contains('permission')
 }

--- a/server/cmd/default/register.v
+++ b/server/cmd/default/register.v
@@ -13,6 +13,7 @@ pub fn register_all(mut r cmd.Registry) {
 	r.register(TeleportCommand{})
 	r.register(ClearCommand{})
 	r.register(GiveCommand{})
+	r.register(ScoreboardCommand{})
 	r.register(DifficultyCommand{})
 	r.register(SayCommand{})
 	r.register(TitleCommand{})

--- a/server/cmd/default/scoreboard.v
+++ b/server/cmd/default/scoreboard.v
@@ -1,0 +1,292 @@
+module default
+
+import strconv
+import server.permission
+import server.cmd
+
+pub struct ScoreboardCommand {}
+
+pub fn (c ScoreboardCommand) name() string {
+	return 'scoreboard'
+}
+
+pub fn (c ScoreboardCommand) description() string {
+	return 'Manages objectives, scores and teams'
+}
+
+pub fn (c ScoreboardCommand) aliases() []string {
+	return []
+}
+
+pub fn (c ScoreboardCommand) permission() string {
+	return permission.command_scoreboard
+}
+
+pub fn (c ScoreboardCommand) arguments() []cmd.Argument {
+	return [
+		cmd.StringArgument{
+			arg_name: 'section'
+		},
+		cmd.StringArgument{
+			arg_name:     'action'
+			arg_optional: true
+		},
+		cmd.StringArgument{
+			arg_name:     'a'
+			arg_optional: true
+		},
+		cmd.StringArgument{
+			arg_name:     'b'
+			arg_optional: true
+		},
+		cmd.StringArgument{
+			arg_name:     'c'
+			arg_optional: true
+		},
+	]
+}
+
+pub fn (c ScoreboardCommand) execute(mut sender cmd.Sender, ctx cmd.Context) ! {
+	match ctx.args[0].to_lower() {
+		'objectives' { run_objectives(mut sender, ctx)! }
+		'players' { run_players(mut sender, ctx)! }
+		'teams' { run_teams(mut sender, ctx)! }
+		else { sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))! }
+	}
+}
+
+fn run_objectives(mut sender cmd.Sender, ctx cmd.Context) ! {
+	action := if ctx.args.len > 1 { ctx.args[1].to_lower() } else { '' }
+	match action {
+		'add' {
+			if ctx.args.len < 3 {
+				sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))!
+				return
+			}
+			name := ctx.args[2]
+			display := if ctx.args.len > 3 { ctx.args[3] } else { '' }
+			if !sender.scoreboard_add_objective(name, display) {
+				sender.send_message(ctx.lang.t('cmd.scoreboard.objective_exists'))!
+				return
+			}
+			sender.send_message(ctx.lang.tf('cmd.scoreboard.objectives.add', {
+				'Objective': name
+			}))!
+		}
+		'remove' {
+			if ctx.args.len < 3 {
+				sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))!
+				return
+			}
+			name := ctx.args[2]
+			if !sender.scoreboard_remove_objective(name) {
+				sender.send_message(ctx.lang.tf('cmd.scoreboard.objective_not_found', {
+					'Objective': name
+				}))!
+				return
+			}
+			sender.send_message(ctx.lang.tf('cmd.scoreboard.objectives.remove', {
+				'Objective': name
+			}))!
+		}
+		'list' {
+			objectives := sender.scoreboard_objectives()
+			if objectives.len == 0 {
+				sender.send_message(ctx.lang.t('cmd.scoreboard.objectives.list_empty'))!
+				return
+			}
+			sender.send_message(ctx.lang.tf('cmd.scoreboard.objectives.list', {
+				'Count': objectives.len.str()
+			}))!
+			for objective in objectives {
+				sender.send_message('- ${objective.name}: ${objective.display_name}')!
+			}
+		}
+		'setdisplay' {
+			if ctx.args.len < 3 {
+				sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))!
+				return
+			}
+			slot := ctx.args[2]
+			objective := if ctx.args.len > 3 { ctx.args[3] } else { '' }
+			if !sender.scoreboard_set_display(slot, objective) {
+				sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))!
+				return
+			}
+			if objective == '' {
+				sender.send_message(ctx.lang.tf('cmd.scoreboard.setdisplay.cleared', {
+					'Slot': slot
+				}))!
+				return
+			}
+			sender.send_message(ctx.lang.tf('cmd.scoreboard.setdisplay.success', {
+				'Slot':      slot
+				'Objective': objective
+			}))!
+		}
+		else {
+			sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))!
+		}
+	}
+}
+
+fn run_players(mut sender cmd.Sender, ctx cmd.Context) ! {
+	action := if ctx.args.len > 1 { ctx.args[1].to_lower() } else { '' }
+	if action == 'reset' {
+		if ctx.args.len < 3 {
+			sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))!
+			return
+		}
+		entry := ctx.args[2]
+		sender.scoreboard_reset_score(entry)
+		sender.send_message(ctx.lang.tf('cmd.scoreboard.players.reset', {
+			'Name': entry
+		}))!
+		return
+	}
+	if action != 'set' && action != 'add' {
+		sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))!
+		return
+	}
+	if ctx.args.len < 5 {
+		sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))!
+		return
+	}
+	entry := ctx.args[2]
+	objective := ctx.args[3]
+	amount := strconv.atoi(ctx.args[4]) or {
+		sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))!
+		return
+	}
+	if action == 'set' {
+		if !sender.scoreboard_set_score(objective, entry, amount) {
+			sender.send_message(ctx.lang.tf('cmd.scoreboard.objective_not_found', {
+				'Objective': objective
+			}))!
+			return
+		}
+		sender.send_message(ctx.lang.tf('cmd.scoreboard.players.set', {
+			'Objective': objective
+			'Name':      entry
+			'Score':     amount.str()
+		}))!
+		return
+	}
+	updated := sender.scoreboard_add_score(objective, entry, amount) or {
+		sender.send_message(ctx.lang.tf('cmd.scoreboard.objective_not_found', {
+			'Objective': objective
+		}))!
+		return
+	}
+	sender.send_message(ctx.lang.tf('cmd.scoreboard.players.add', {
+		'Amount':    amount.str()
+		'Objective': objective
+		'Name':      entry
+		'Score':     updated.str()
+	}))!
+}
+
+fn run_teams(mut sender cmd.Sender, ctx cmd.Context) ! {
+	action := if ctx.args.len > 1 { ctx.args[1].to_lower() } else { '' }
+	match action {
+		'add' {
+			if ctx.args.len < 3 {
+				sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))!
+				return
+			}
+			name := ctx.args[2]
+			display := if ctx.args.len > 3 { ctx.args[3] } else { '' }
+			if !sender.scoreboard_add_team(name, display) {
+				sender.send_message(ctx.lang.t('cmd.scoreboard.team_exists'))!
+				return
+			}
+			sender.send_message(ctx.lang.tf('cmd.scoreboard.teams.add', {
+				'Team': name
+			}))!
+		}
+		'remove' {
+			if ctx.args.len < 3 {
+				sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))!
+				return
+			}
+			name := ctx.args[2]
+			if !sender.scoreboard_remove_team(name) {
+				sender.send_message(ctx.lang.tf('cmd.scoreboard.team_not_found', {
+					'Team': name
+				}))!
+				return
+			}
+			sender.send_message(ctx.lang.tf('cmd.scoreboard.teams.remove', {
+				'Team': name
+			}))!
+		}
+		'join' {
+			if ctx.args.len < 4 {
+				sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))!
+				return
+			}
+			team := ctx.args[2]
+			entry := ctx.args[3]
+			if !sender.scoreboard_team_join(team, entry) {
+				sender.send_message(ctx.lang.tf('cmd.scoreboard.team_not_found', {
+					'Team': team
+				}))!
+				return
+			}
+			sender.send_message(ctx.lang.tf('cmd.scoreboard.teams.join', {
+				'Name': entry
+				'Team': team
+			}))!
+		}
+		'leave' {
+			if ctx.args.len < 3 {
+				sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))!
+				return
+			}
+			entry := ctx.args[2]
+			if !sender.scoreboard_team_leave(entry) {
+				sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))!
+				return
+			}
+			sender.send_message(ctx.lang.tf('cmd.scoreboard.teams.leave', {
+				'Name': entry
+			}))!
+		}
+		'option' {
+			if ctx.args.len < 5 {
+				sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))!
+				return
+			}
+			team := ctx.args[2]
+			option := ctx.args[3]
+			value := ctx.args[4]
+			if !sender.scoreboard_team_option(team, option, value) {
+				sender.send_message(ctx.lang.tf('cmd.scoreboard.team_not_found', {
+					'Team': team
+				}))!
+				return
+			}
+			sender.send_message(ctx.lang.tf('cmd.scoreboard.teams.option', {
+				'Option': option
+				'Team':   team
+				'Value':  value
+			}))!
+		}
+		'list' {
+			teams := sender.scoreboard_teams()
+			if teams.len == 0 {
+				sender.send_message(ctx.lang.t('cmd.scoreboard.teams.list_empty'))!
+				return
+			}
+			sender.send_message(ctx.lang.tf('cmd.scoreboard.teams.list', {
+				'Count': teams.len.str()
+			}))!
+			for team in teams {
+				sender.send_message('- ${team.name}: ${team.display_name} (${team.members})')!
+			}
+		}
+		else {
+			sender.send_message(ctx.lang.t('cmd.scoreboard.usage'))!
+		}
+	}
+}

--- a/server/cmd/sender.v
+++ b/server/cmd/sender.v
@@ -22,6 +22,25 @@ mut:
 	whitelist_remove(name string)
 	whitelist_set_enabled(value bool)
 	set_difficulty(value int)
+	// Scoreboard state is the server's, not any one player's, so it lives
+	// here rather than on player.View.
+	scoreboard_objectives() []ObjectiveInfo
+	scoreboard_add_objective(name string, display_name string) bool
+	scoreboard_remove_objective(name string) bool
+	// scoreboard_set_display shows an objective in a slot; an empty objective
+	// name clears the slot. It reports false for an unknown slot or objective.
+	scoreboard_set_display(slot string, objective string) bool
+	scoreboard_set_score(objective string, entry string, value int) bool
+	scoreboard_add_score(objective string, entry string, delta int) ?int
+	scoreboard_reset_score(entry string)
+	scoreboard_teams() []TeamInfo
+	scoreboard_add_team(name string, display_name string) bool
+	scoreboard_remove_team(name string) bool
+	scoreboard_team_join(team string, entry string) bool
+	scoreboard_team_leave(entry string) bool
+	// scoreboard_team_option sets one of a team's settings by name, reporting
+	// false for an unknown team, option or value.
+	scoreboard_team_option(team string, option string, value string) bool
 	broadcast_message(text string)
 	// show_title sends a title/subtitle/actionbar to this sender only.
 	show_title(kind int, text string)
@@ -95,4 +114,20 @@ pub:
 	chunk_requests_total           i64
 	chunk_dedup_hits_total         i64
 	actor_running                  bool
+}
+
+// ObjectiveInfo is a read-only view of one scoreboard objective, so the cmd
+// layer never depends on the scoreboard types directly.
+pub struct ObjectiveInfo {
+pub:
+	name         string
+	display_name string
+}
+
+// TeamInfo is the same for a team, with how many entries are in it.
+pub struct TeamInfo {
+pub:
+	name         string
+	display_name string
+	members      int
 }

--- a/server/permission/permission.v
+++ b/server/permission/permission.v
@@ -37,6 +37,7 @@ pub const command_teleport_other = 'vedrock.cmd.teleport.other'
 pub const command_clear_self = 'vedrock.cmd.clear.self'
 pub const command_clear_other = 'vedrock.cmd.clear.other'
 pub const command_give = 'vedrock.cmd.give'
+pub const command_scoreboard = 'vedrock.cmd.scoreboard'
 pub const command_difficulty = 'vedrock.cmd.difficulty'
 pub const command_say = 'vedrock.cmd.say'
 pub const command_title = 'vedrock.cmd.title'
@@ -118,6 +119,11 @@ fn new_registry() &Registry {
 	r.register(Permission{
 		name:        command_give
 		description: 'Allows giving items to players'
+		default:     .op
+	})
+	r.register(Permission{
+		name:        command_scoreboard
+		description: 'Allows managing objectives, scores and teams'
 		default:     .op
 	})
 	r.register(Permission{

--- a/server/player/scoreboard/objective.v
+++ b/server/player/scoreboard/objective.v
@@ -1,0 +1,45 @@
+module scoreboard
+
+// DisplaySlot is where a scoreboard objective is drawn.
+pub enum DisplaySlot {
+	sidebar
+	list
+	belowname
+}
+
+// wire_name is the name the client knows a slot by.
+pub fn (slot DisplaySlot) wire_name() string {
+	return match slot {
+		.sidebar { 'sidebar' }
+		.list { 'list' }
+		.belowname { 'belowname' }
+	}
+}
+
+// display_slot_from_name resolves a slot from what a command was given.
+pub fn display_slot_from_name(name string) ?DisplaySlot {
+	return match name.to_lower() {
+		'sidebar' { DisplaySlot.sidebar }
+		'list' { DisplaySlot.list }
+		'belowname' { DisplaySlot.belowname }
+		else { none }
+	}
+}
+
+// Objective is something scores are counted under. Criteria are not modelled:
+// every objective is a dummy one whose scores are set by the server, which is
+// what every criterion other than the vanilla automatic ones amounts to.
+pub struct Objective {
+pub:
+	name         string
+	display_name string
+	descending   bool
+}
+
+// display_title is what the client draws above the scores.
+pub fn (o Objective) display_title() string {
+	if o.display_name == '' {
+		return o.name
+	}
+	return o.display_name
+}

--- a/server/player/scoreboard/registry.v
+++ b/server/player/scoreboard/registry.v
@@ -1,0 +1,296 @@
+module scoreboard
+
+import sync
+
+// Registry holds the objectives, scores and teams of one server. It is shared
+// across sessions, so every read and write goes through its own lock.
+@[heap]
+pub struct Registry {
+mut:
+	mutex      &sync.Mutex = sync.new_mutex()
+	objectives map[string]Objective
+	// scores is per objective name, then per entry name. An entry is a player
+	// name or any other label an objective counts.
+	scores   map[string]map[string]int
+	displays map[string]string
+	teams    map[string]Team
+	// membership maps an entry name to the team it is in, so the common
+	// lookup does not have to scan every team.
+	membership map[string]string
+}
+
+pub fn new_registry() &Registry {
+	return &Registry{}
+}
+
+// add_objective registers an objective, reporting false when one already goes
+// by that name.
+pub fn (mut r Registry) add_objective(objective Objective) bool {
+	r.mutex.lock()
+	defer {
+		r.mutex.unlock()
+	}
+	if objective.name in r.objectives {
+		return false
+	}
+	r.objectives[objective.name] = objective
+	return true
+}
+
+// remove_objective drops an objective, its scores and any slot showing it.
+pub fn (mut r Registry) remove_objective(name string) bool {
+	r.mutex.lock()
+	defer {
+		r.mutex.unlock()
+	}
+	if name !in r.objectives {
+		return false
+	}
+	r.objectives.delete(name)
+	r.scores.delete(name)
+	for slot, shown in r.displays.clone() {
+		if shown == name {
+			r.displays.delete(slot)
+		}
+	}
+	return true
+}
+
+pub fn (r &Registry) objective(name string) ?Objective {
+	mut m := r.mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	return r.objectives[name] or { return none }
+}
+
+pub fn (r &Registry) objectives() []Objective {
+	mut m := r.mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	mut out := []Objective{cap: r.objectives.len}
+	for _, objective in r.objectives {
+		out << objective
+	}
+	return out
+}
+
+// set_display shows an objective in a slot. An unknown objective clears the
+// slot instead, which is what an empty name means.
+pub fn (mut r Registry) set_display(slot DisplaySlot, objective_name string) bool {
+	r.mutex.lock()
+	defer {
+		r.mutex.unlock()
+	}
+	key := slot.wire_name()
+	if objective_name == '' {
+		r.displays.delete(key)
+		return true
+	}
+	if objective_name !in r.objectives {
+		return false
+	}
+	r.displays[key] = objective_name
+	return true
+}
+
+pub fn (r &Registry) display(slot DisplaySlot) ?string {
+	mut m := r.mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	return r.displays[slot.wire_name()] or { return none }
+}
+
+// set_score records an entry's score under an objective, reporting false when
+// the objective does not exist.
+pub fn (mut r Registry) set_score(objective_name string, entry string, value int) bool {
+	r.mutex.lock()
+	defer {
+		r.mutex.unlock()
+	}
+	if objective_name !in r.objectives {
+		return false
+	}
+	r.scores[objective_name][entry] = value
+	return true
+}
+
+// add_score moves an entry's score by delta and returns where it ended up.
+pub fn (mut r Registry) add_score(objective_name string, entry string, delta int) ?int {
+	r.mutex.lock()
+	defer {
+		r.mutex.unlock()
+	}
+	if objective_name !in r.objectives {
+		return none
+	}
+	current := r.scores[objective_name][entry] or { 0 }
+	updated := current + delta
+	r.scores[objective_name][entry] = updated
+	return updated
+}
+
+// reset_score drops an entry from one objective, or from all of them when the
+// objective name is empty.
+pub fn (mut r Registry) reset_score(objective_name string, entry string) {
+	r.mutex.lock()
+	defer {
+		r.mutex.unlock()
+	}
+	if objective_name == '' {
+		for name, _ in r.scores {
+			r.scores[name].delete(entry)
+		}
+		return
+	}
+	r.scores[objective_name].delete(entry)
+}
+
+pub fn (r &Registry) scores(objective_name string) map[string]int {
+	mut m := r.mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	return (r.scores[objective_name] or {
+		map[string]int{}
+	}).clone()
+}
+
+// add_team registers a team, reporting false when one already goes by that
+// name.
+pub fn (mut r Registry) add_team(team Team) bool {
+	r.mutex.lock()
+	defer {
+		r.mutex.unlock()
+	}
+	if team.name in r.teams {
+		return false
+	}
+	r.teams[team.name] = team
+	return true
+}
+
+// remove_team drops a team and empties it.
+pub fn (mut r Registry) remove_team(name string) bool {
+	r.mutex.lock()
+	defer {
+		r.mutex.unlock()
+	}
+	if name !in r.teams {
+		return false
+	}
+	r.teams.delete(name)
+	for entry, team in r.membership.clone() {
+		if team == name {
+			r.membership.delete(entry)
+		}
+	}
+	return true
+}
+
+// update_team replaces a team's settings, keeping its members.
+pub fn (mut r Registry) update_team(team Team) bool {
+	r.mutex.lock()
+	defer {
+		r.mutex.unlock()
+	}
+	if team.name !in r.teams {
+		return false
+	}
+	r.teams[team.name] = team
+	return true
+}
+
+pub fn (r &Registry) team(name string) ?Team {
+	mut m := r.mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	return r.teams[name] or { return none }
+}
+
+pub fn (r &Registry) teams() []Team {
+	mut m := r.mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	mut out := []Team{cap: r.teams.len}
+	for _, team in r.teams {
+		out << team
+	}
+	return out
+}
+
+// join_team moves an entry into a team, leaving whichever it was in.
+pub fn (mut r Registry) join_team(team_name string, entry string) bool {
+	r.mutex.lock()
+	defer {
+		r.mutex.unlock()
+	}
+	if team_name !in r.teams {
+		return false
+	}
+	r.membership[entry] = team_name
+	return true
+}
+
+// leave_team takes an entry out of whatever team it is in.
+pub fn (mut r Registry) leave_team(entry string) bool {
+	r.mutex.lock()
+	defer {
+		r.mutex.unlock()
+	}
+	if entry !in r.membership {
+		return false
+	}
+	r.membership.delete(entry)
+	return true
+}
+
+// team_of returns the team an entry belongs to.
+pub fn (r &Registry) team_of(entry string) ?Team {
+	mut m := r.mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	name := r.membership[entry] or { return none }
+	return r.teams[name] or { return none }
+}
+
+// members lists who is in a team.
+pub fn (r &Registry) members(team_name string) []string {
+	mut m := r.mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	mut out := []string{}
+	for entry, name in r.membership {
+		if name == team_name {
+			out << entry
+		}
+	}
+	return out
+}
+
+// same_team reports whether two entries share a team. Two entries in no team
+// are not on the same team.
+pub fn (r &Registry) same_team(a string, b string) bool {
+	mut m := r.mutex
+	m.lock()
+	defer {
+		m.unlock()
+	}
+	first := r.membership[a] or { return false }
+	second := r.membership[b] or { return false }
+	return first == second
+}

--- a/server/player/scoreboard/registry_test.v
+++ b/server/player/scoreboard/registry_test.v
@@ -1,0 +1,127 @@
+module scoreboard
+
+fn test_an_objective_is_registered_once() {
+	mut r := new_registry()
+	assert r.add_objective(Objective{ name: 'kills' })
+	assert !r.add_objective(Objective{ name: 'kills' })
+	assert r.objectives().len == 1
+	if _ := r.objective('kills') {
+	} else {
+		assert false, 'objective was not stored'
+	}
+}
+
+fn test_removing_an_objective_takes_its_scores_and_display_with_it() {
+	mut r := new_registry()
+	r.add_objective(Objective{ name: 'kills' })
+	r.set_score('kills', 'Alex', 4)
+	r.set_display(.sidebar, 'kills')
+
+	assert r.remove_objective('kills')
+	assert r.scores('kills').len == 0
+	if _ := r.display(.sidebar) {
+		assert false, 'the slot still shows a removed objective'
+	}
+	assert !r.remove_objective('kills')
+}
+
+fn test_scores_only_exist_under_a_known_objective() {
+	mut r := new_registry()
+	assert !r.set_score('missing', 'Alex', 1)
+	if _ := r.add_score('missing', 'Alex', 1) {
+		assert false, 'scored against an objective that does not exist'
+	}
+	r.add_objective(Objective{ name: 'kills' })
+	assert r.set_score('kills', 'Alex', 2)
+	assert r.add_score('kills', 'Alex', 3)? == 5
+	assert r.scores('kills')['Alex'] == 5
+}
+
+fn test_resetting_a_score_clears_every_objective() {
+	mut r := new_registry()
+	r.add_objective(Objective{ name: 'kills' })
+	r.add_objective(Objective{ name: 'deaths' })
+	r.set_score('kills', 'Alex', 1)
+	r.set_score('deaths', 'Alex', 2)
+	r.set_score('kills', 'Steve', 3)
+
+	r.reset_score('', 'Alex')
+	assert 'Alex' !in r.scores('kills')
+	assert 'Alex' !in r.scores('deaths')
+	assert r.scores('kills')['Steve'] == 3
+}
+
+fn test_a_slot_only_shows_a_known_objective() {
+	mut r := new_registry()
+	assert !r.set_display(.sidebar, 'missing')
+	r.add_objective(Objective{ name: 'kills' })
+	assert r.set_display(.sidebar, 'kills')
+	assert r.display(.sidebar)? == 'kills'
+	// An empty name clears the slot.
+	assert r.set_display(.sidebar, '')
+	if _ := r.display(.sidebar) {
+		assert false, 'the slot was not cleared'
+	}
+}
+
+fn test_membership_moves_between_teams() {
+	mut r := new_registry()
+	r.add_team(Team{ name: 'red' })
+	r.add_team(Team{ name: 'blue' })
+	assert r.join_team('red', 'Alex')
+	assert r.team_of('Alex')?.name == 'red'
+
+	assert r.join_team('blue', 'Alex')
+	assert r.team_of('Alex')?.name == 'blue'
+	assert r.members('red').len == 0
+	assert r.members('blue') == ['Alex']
+
+	assert r.leave_team('Alex')
+	assert !r.leave_team('Alex')
+	if _ := r.team_of('Alex') {
+		assert false, 'Alex is still on a team'
+	}
+}
+
+fn test_removing_a_team_empties_it() {
+	mut r := new_registry()
+	r.add_team(Team{ name: 'red' })
+	r.join_team('red', 'Alex')
+	assert r.remove_team('red')
+	if _ := r.team_of('Alex') {
+		assert false, 'Alex kept a team that no longer exists'
+	}
+	assert !r.remove_team('red')
+}
+
+fn test_same_team_needs_both_to_be_on_one() {
+	mut r := new_registry()
+	r.add_team(Team{ name: 'red' })
+	r.join_team('red', 'Alex')
+	assert !r.same_team('Alex', 'Steve')
+	r.join_team('red', 'Steve')
+	assert r.same_team('Alex', 'Steve')
+	// Two players in no team are not teammates.
+	assert !r.same_team('Nobody', 'Nobody else')
+}
+
+fn test_a_team_decorates_its_members_names() {
+	team := Team{
+		name:   'red'
+		colour: 'c'
+		prefix: '[R] '
+	}
+	assert team.decorate('Alex') == '§c[R] Alex§r'
+	plain := Team{
+		name: 'plain'
+	}
+	assert plain.decorate('Alex') == 'Alex'
+}
+
+fn test_display_slots_map_to_their_wire_names() {
+	assert DisplaySlot.sidebar.wire_name() == 'sidebar'
+	assert display_slot_from_name('BelowName')? == .belowname
+	if _ := display_slot_from_name('nowhere') {
+		assert false, 'an unknown slot resolved'
+	}
+}

--- a/server/player/scoreboard/team.v
+++ b/server/player/scoreboard/team.v
@@ -1,0 +1,50 @@
+module scoreboard
+
+// NameTagVisibility decides who sees a team member's name above their head.
+pub enum NameTagVisibility {
+	always
+	never
+	hide_for_other_teams
+}
+
+pub fn name_tag_visibility_from_name(name string) ?NameTagVisibility {
+	return match name.to_lower() {
+		'always' { NameTagVisibility.always }
+		'never' { NameTagVisibility.never }
+		'hideforotherteams' { NameTagVisibility.hide_for_other_teams }
+		else { none }
+	}
+}
+
+// Team is a named group of players. Bedrock has no team packet of its own, so
+// everything a team does is done by the server: it decorates the name it sends
+// for its members and decides whether their hits land on each other.
+pub struct Team {
+pub:
+	name         string
+	display_name string
+	// colour is the formatting code applied to a member's name, without the
+	// section sign. Empty leaves the name uncoloured.
+	colour           string
+	prefix           string
+	suffix           string
+	friendly_fire    bool              = true
+	name_tag_visible NameTagVisibility = .always
+}
+
+// decorate returns a member's name as it should be shown.
+pub fn (t Team) decorate(name string) string {
+	mut out := t.prefix + name + t.suffix
+	if t.colour != '' {
+		out = '§${t.colour}${out}§r'
+	}
+	return out
+}
+
+// display_title is what the team is called on screen.
+pub fn (t Team) display_title() string {
+	if t.display_name == '' {
+		return t.name
+	}
+	return t.display_name
+}

--- a/server/session/combat.v
+++ b/server/session/combat.v
@@ -52,6 +52,10 @@ fn (t PlayerAttackTask) run(mut tx worldrt.WorldTx) {
 		if !victim_actor.spawned || !victim_actor.player.game_mode().allows_taking_damage() {
 			return
 		}
+		if !attacker.hub.friendly_fire_allowed(attacker.player.identity.display_name,
+			victim_actor.player.identity.display_name) {
+			return
+		}
 	}
 	mut ctx := event.new_context(player.AttackData{
 		player:            attacker.player

--- a/server/session/console.v
+++ b/server/session/console.v
@@ -110,3 +110,58 @@ fn strip_formatting(message string) string {
 	}
 	return out.string()
 }
+
+// The console shares the server's scoreboard: these are the same registry the
+// player sessions reach, since none of it belongs to any one player.
+
+fn (mut c ConsoleSender) scoreboard_objectives() []cmd.ObjectiveInfo {
+	return c.hub.objective_infos()
+}
+
+fn (mut c ConsoleSender) scoreboard_add_objective(name string, display_name string) bool {
+	return c.hub.add_objective(name, display_name)
+}
+
+fn (mut c ConsoleSender) scoreboard_remove_objective(name string) bool {
+	return c.hub.remove_objective(name)
+}
+
+fn (mut c ConsoleSender) scoreboard_set_display(slot string, objective string) bool {
+	return c.hub.set_display(slot, objective)
+}
+
+fn (mut c ConsoleSender) scoreboard_set_score(objective string, entry string, value int) bool {
+	return c.hub.set_score(objective, entry, value)
+}
+
+fn (mut c ConsoleSender) scoreboard_add_score(objective string, entry string, delta int) ?int {
+	return c.hub.add_score(objective, entry, delta)
+}
+
+fn (mut c ConsoleSender) scoreboard_reset_score(entry string) {
+	c.hub.reset_score(entry)
+}
+
+fn (mut c ConsoleSender) scoreboard_teams() []cmd.TeamInfo {
+	return c.hub.team_infos()
+}
+
+fn (mut c ConsoleSender) scoreboard_add_team(name string, display_name string) bool {
+	return c.hub.add_team(name, display_name)
+}
+
+fn (mut c ConsoleSender) scoreboard_remove_team(name string) bool {
+	return c.hub.remove_team(name)
+}
+
+fn (mut c ConsoleSender) scoreboard_team_join(team string, entry string) bool {
+	return c.hub.team_join(team, entry)
+}
+
+fn (mut c ConsoleSender) scoreboard_team_leave(entry string) bool {
+	return c.hub.team_leave(entry)
+}
+
+fn (mut c ConsoleSender) scoreboard_team_option(team string, option string, value string) bool {
+	return c.hub.team_option(team, option, value)
+}

--- a/server/session/hub.v
+++ b/server/session/hub.v
@@ -24,6 +24,7 @@ import server.player.playerdb
 import bedrock_v.protocol.current as proto
 import server.worldrt
 import server.player
+import server.player.scoreboard
 
 // Hub holds the server's internal, directly synchronized state (sessions,
 // world registry, config, shared registries) rather than its public API. It
@@ -62,11 +63,13 @@ mut:
 	// session_wg tracks sessions from registration until leave completes.
 	// wait_for_sessions_to_leave blocks until every session has finished
 	// leaving including saving player data and removing itself.
-	session_wg         &sync.WaitGroup = sync.new_waitgroup()
-	oidc_verifier      auth.Verifier
-	data               gamedata.GameData
-	lang               &language.Lang               = unsafe { nil }
-	commands           cmd.Registry                 = cmd.new_registry()
+	session_wg    &sync.WaitGroup = sync.new_waitgroup()
+	oidc_verifier auth.Verifier
+	data          gamedata.GameData
+	lang          &language.Lang = unsafe { nil }
+	commands      cmd.Registry   = cmd.new_registry()
+	// scoreboards holds this server's objectives, scores and teams.
+	scoreboards &scoreboard.Registry = scoreboard.new_registry()
 	// Defaults handed to every player and world this Hub creates. One handler
 	// each, not a list: ordering between several listeners is the caller's to
 	// arrange, in a handler that calls them in the order it wants.
@@ -270,11 +273,11 @@ pub fn (h &Hub) uptime_seconds() i64 {
 // unless one is already set.
 fn (mut h Hub) add_world(loaded_world &db.World) {
 	mut wr := worldrt.new_world_runtime(
-		world:      loaded_world
-		services:   h
-		generators: h
-		handler:    h.world_handler
-		players:    SessionPlayerTicker{}
+		world:       loaded_world
+		services:    h
+		generators:  h
+		handler:     h.world_handler
+		players:     SessionPlayerTicker{}
 		entity_host: new_world_entity_host
 	)
 	h.restore_world_entities(mut wr)

--- a/server/session/metadata.v
+++ b/server/session/metadata.v
@@ -72,7 +72,7 @@ fn visible_name_metadata(name string) []proto.DataItem {
 fn (s &NetworkSession) set_actor_data() &proto.SetActorDataPacket {
 	return &proto.SetActorDataPacket{
 		target_runtime_id: proto.actor_runtime_id(s.runtime_id)
-		actor_data:        visible_name_metadata(s.player.identity.display_name)
+		actor_data:        visible_name_metadata(s.shown_name())
 		synced_properties: proto.PropertySyncData{}
 		tick:              0
 	}

--- a/server/session/player_view.v
+++ b/server/session/player_view.v
@@ -154,7 +154,7 @@ fn (s &NetworkSession) add_player_packet() &proto.AddPlayerPacket {
 		y_head_rotation:   current.head_yaw
 		carried_item:      proto.item_descriptor(s.player.held_item().item_stack)
 		player_game_type:  proto.game_type(player.gamemode_to_wire(s.player.game_mode()))
-		entity_data:       visible_name_metadata(s.player.identity.display_name)
+		entity_data:       visible_name_metadata(s.shown_name())
 		synced_properties: proto.PropertySyncData{}
 		abilities_data:    s.build_abilities()
 		actor_links:       []proto.ActorLink{}

--- a/server/session/scoreboard_admin.v
+++ b/server/session/scoreboard_admin.v
@@ -1,0 +1,232 @@
+module session
+
+import server.cmd
+import server.player.scoreboard
+
+// The Sender side of the scoreboard: every one of these reads or writes the
+// server-wide registry on the Hub and redraws whatever slot the change was
+// visible in.
+
+fn (mut s NetworkSession) scoreboard_objectives() []cmd.ObjectiveInfo {
+	return s.hub.objective_infos()
+}
+
+fn (mut s NetworkSession) scoreboard_add_objective(name string, display_name string) bool {
+	return s.hub.add_objective(name, display_name)
+}
+
+fn (mut s NetworkSession) scoreboard_remove_objective(name string) bool {
+	return s.hub.remove_objective(name)
+}
+
+fn (mut s NetworkSession) scoreboard_set_display(slot string, objective string) bool {
+	return s.hub.set_display(slot, objective)
+}
+
+fn (mut s NetworkSession) scoreboard_set_score(objective string, entry string, value int) bool {
+	return s.hub.set_score(objective, entry, value)
+}
+
+fn (mut s NetworkSession) scoreboard_add_score(objective string, entry string, delta int) ?int {
+	return s.hub.add_score(objective, entry, delta)
+}
+
+fn (mut s NetworkSession) scoreboard_reset_score(entry string) {
+	s.hub.reset_score(entry)
+}
+
+fn (mut s NetworkSession) scoreboard_teams() []cmd.TeamInfo {
+	return s.hub.team_infos()
+}
+
+fn (mut s NetworkSession) scoreboard_add_team(name string, display_name string) bool {
+	return s.hub.add_team(name, display_name)
+}
+
+fn (mut s NetworkSession) scoreboard_remove_team(name string) bool {
+	return s.hub.remove_team(name)
+}
+
+fn (mut s NetworkSession) scoreboard_team_join(team string, entry string) bool {
+	return s.hub.team_join(team, entry)
+}
+
+fn (mut s NetworkSession) scoreboard_team_leave(entry string) bool {
+	return s.hub.team_leave(entry)
+}
+
+fn (mut s NetworkSession) scoreboard_team_option(team string, option string, value string) bool {
+	return s.hub.team_option(team, option, value)
+}
+
+// Hub owns the registry; the session methods above are only the route in.
+
+pub fn (h &Hub) objective_infos() []cmd.ObjectiveInfo {
+	mut out := []cmd.ObjectiveInfo{}
+	for objective in h.scoreboards.objectives() {
+		out << cmd.ObjectiveInfo{
+			name:         objective.name
+			display_name: objective.display_title()
+		}
+	}
+	return out
+}
+
+pub fn (mut h Hub) add_objective(name string, display_name string) bool {
+	if name == '' {
+		return false
+	}
+	return h.scoreboards.add_objective(scoreboard.Objective{
+		name:         name
+		display_name: display_name
+	})
+}
+
+pub fn (mut h Hub) remove_objective(name string) bool {
+	if !h.scoreboards.remove_objective(name) {
+		return false
+	}
+	h.refresh_displays()
+	return true
+}
+
+pub fn (mut h Hub) set_display(slot_name string, objective string) bool {
+	slot := scoreboard.display_slot_from_name(slot_name) or { return false }
+	if !h.scoreboards.set_display(slot, objective) {
+		return false
+	}
+	h.broadcast_display(slot)
+	return true
+}
+
+pub fn (mut h Hub) set_score(objective string, entry string, value int) bool {
+	if !h.scoreboards.set_score(objective, entry, value) {
+		return false
+	}
+	h.refresh_displays()
+	return true
+}
+
+pub fn (mut h Hub) add_score(objective string, entry string, delta int) ?int {
+	updated := h.scoreboards.add_score(objective, entry, delta) or { return none }
+	h.refresh_displays()
+	return updated
+}
+
+pub fn (mut h Hub) reset_score(entry string) {
+	h.scoreboards.reset_score('', entry)
+	h.refresh_displays()
+}
+
+pub fn (h &Hub) team_infos() []cmd.TeamInfo {
+	mut out := []cmd.TeamInfo{}
+	for team in h.scoreboards.teams() {
+		out << cmd.TeamInfo{
+			name:         team.name
+			display_name: team.display_title()
+			members:      h.scoreboards.members(team.name).len
+		}
+	}
+	return out
+}
+
+pub fn (mut h Hub) add_team(name string, display_name string) bool {
+	if name == '' {
+		return false
+	}
+	return h.scoreboards.add_team(scoreboard.Team{
+		name:         name
+		display_name: display_name
+	})
+}
+
+pub fn (mut h Hub) remove_team(name string) bool {
+	members := h.scoreboards.members(name)
+	if !h.scoreboards.remove_team(name) {
+		return false
+	}
+	h.refresh_name_tags(members)
+	return true
+}
+
+pub fn (mut h Hub) team_join(team string, entry string) bool {
+	if !h.scoreboards.join_team(team, entry) {
+		return false
+	}
+	h.refresh_name_tags([entry])
+	return true
+}
+
+pub fn (mut h Hub) team_leave(entry string) bool {
+	if !h.scoreboards.leave_team(entry) {
+		return false
+	}
+	h.refresh_name_tags([entry])
+	return true
+}
+
+// team_option sets one of a team's settings from the names the command uses.
+pub fn (mut h Hub) team_option(name string, option string, value string) bool {
+	team := h.scoreboards.team(name) or { return false }
+	updated := apply_team_option(team, option, value) or { return false }
+	if !h.scoreboards.update_team(updated) {
+		return false
+	}
+	h.refresh_name_tags(h.scoreboards.members(name))
+	return true
+}
+
+fn apply_team_option(team scoreboard.Team, option string, value string) ?scoreboard.Team {
+	return match option.to_lower() {
+		'color', 'colour' {
+			scoreboard.Team{
+				...team
+				colour: value
+			}
+		}
+		'prefix' {
+			scoreboard.Team{
+				...team
+				prefix: value
+			}
+		}
+		'suffix' {
+			scoreboard.Team{
+				...team
+				suffix: value
+			}
+		}
+		'friendlyfire' {
+			scoreboard.Team{
+				...team
+				friendly_fire: parse_option_flag(value)?
+			}
+		}
+		'nametagvisibility' {
+			scoreboard.Team{
+				...team
+				name_tag_visible: scoreboard.name_tag_visibility_from_name(value)?
+			}
+		}
+		else {
+			none
+		}
+	}
+}
+
+fn parse_option_flag(value string) ?bool {
+	return match value.to_lower() {
+		'true' { true }
+		'false' { false }
+		else { none }
+	}
+}
+
+// refresh_name_tags resends the name of every listed player, so a team's
+// colour and prefix appear without them having to reconnect.
+fn (mut h Hub) refresh_name_tags(names []string) {
+	for name in names {
+		mut target := h.session_by_name(name) or { continue }
+		h.broadcast(target.set_actor_data())
+	}
+}

--- a/server/session/scoreboard_display.v
+++ b/server/session/scoreboard_display.v
@@ -1,0 +1,103 @@
+module session
+
+import bedrock_v.protocol
+import bedrock_v.protocol.current as proto
+import server.player.scoreboard
+
+// broadcast_display sends whatever a slot is showing to everyone, or clears it
+// when the slot shows nothing. It is the one place a display slot is drawn, so
+// sidebar, list and belowname all render the same way.
+fn (mut h Hub) broadcast_display(slot scoreboard.DisplaySlot) {
+	objective_name := h.scoreboards.display(slot) or {
+		h.broadcast(&proto.RemoveObjectivePacket{
+			objective_name: slot_objective_name(slot)
+		})
+		return
+	}
+	objective := h.scoreboards.objective(objective_name) or { return }
+	for p in h.display_packets(slot, objective) {
+		h.broadcast(p)
+	}
+}
+
+// display_packets is the packet sequence that draws one objective in one slot.
+// Built as its own function so the wiring can be tested without a connection.
+fn (h &Hub) display_packets(slot scoreboard.DisplaySlot, objective scoreboard.Objective) []protocol.Packet {
+	scores := h.scoreboards.scores(objective.name)
+	name := slot_objective_name(slot)
+	mut packets := []protocol.Packet{cap: scores.len + 2}
+	packets << &proto.RemoveObjectivePacket{
+		objective_name: name
+	}
+	packets << &proto.SetDisplayObjectivePacket{
+		display_slot_name:      slot.wire_name()
+		objective_name:         name
+		objective_display_name: objective.display_title()
+		criteria_name:          'dummy'
+		sort_order:             if objective.descending {
+			proto.ObjectiveSortOrder.descending
+		} else {
+			proto.ObjectiveSortOrder.ascending
+		}
+	}
+	mut entries := proto.ScorePacketEntries{}
+	mut id := i64(1)
+	for entry, value in scores {
+		entries << proto.ScoreEntryChangeFakePlayer{
+			scoreboard_id:    proto.ScoreboardId{
+				id: id
+			}
+			objective_name:   name
+			score_value:      i32(value)
+			fake_player_name: entry
+		}
+		id++
+	}
+	packets << &proto.SetScorePacket{
+		score_info: entries
+	}
+	return packets
+}
+
+// slot_objective_name is the objective name the client is given for a slot.
+// Each slot gets its own so showing one does not disturb another.
+fn slot_objective_name(slot scoreboard.DisplaySlot) string {
+	return 'vedrock.${slot.wire_name()}'
+}
+
+// refresh_displays redraws every slot that is showing something, which is what
+// a score change or a new objective needs.
+fn (mut h Hub) refresh_displays() {
+	for slot in [scoreboard.DisplaySlot.sidebar, .list, .belowname] {
+		h.broadcast_display(slot)
+	}
+}
+
+// team_display_name is a player's name as their team says it should be shown,
+// or their plain name when they are in no team.
+fn (h &Hub) team_display_name(name string) string {
+	team := h.scoreboards.team_of(name) or { return name }
+	return team.decorate(name)
+}
+
+// friendly_fire_allowed reports whether one player's hit lands on another. Two
+// players on a team that has friendly fire turned off cannot hurt each other.
+fn (h &Hub) friendly_fire_allowed(attacker string, victim string) bool {
+	if attacker == victim {
+		return true
+	}
+	team := h.scoreboards.team_of(attacker) or { return true }
+	if !h.scoreboards.same_team(attacker, victim) {
+		return true
+	}
+	return team.friendly_fire
+}
+
+// shown_name is the name other players see for this session: decorated by the
+// player's team when there is a server to ask, and the plain name otherwise.
+fn (s &NetworkSession) shown_name() string {
+	if isnil(s.hub) {
+		return s.player.identity.display_name
+	}
+	return s.hub.team_display_name(s.player.identity.display_name)
+}


### PR DESCRIPTION
## Description

The scoreboard was a per-player sidebar of fake-player lines and nothing else: no objective anyone else could see, no other display slot, and no concept of a team.

- Objectives, scores and teams live in one server-wide registry. Objectives are dummy ones whose scores the server sets, which is what every criterion other than the vanilla automatic ones amounts to.
- All three display slots work - sidebar, list and belowname - each with its own objective, so showing one does not disturb another. A score change redraws whatever slot is showing it.
- Teams carry a colour, prefix, suffix, friendly fire and name tag visibility. Bedrock has no team packet of its own, so a team does its work through the server: a member's name tag is decorated when it is sent, and two players on a team with friendly fire off cannot hurt each other.
- `/scoreboard objectives|players|teams` covers add, remove, list, setdisplay, set, add, reset, join, leave and option. Its messages are the vanilla ones.

## Related issue

Part of #143

Name tag visibility is stored and settable but not yet enforced per viewer: hiding a name from other teams means sending different metadata to different players, which the broadcast path does not do today.

## Checklist
- [x] `v -check .` is clean
- [x] `v test server/player`, `server/cmd/default`, and the session combat/scoreboard/broadcast/entity-view/login tests are green
- [x] Follows the conventions in AGENTS.md (OOP, `pub`/capitalized exports, no import cycles, minimal comments)
- [x] Cross-session gameplay state is only mutated on its owning world's actor thread (via `world_call`/`wr.submit`/`WorldTx`), never through a global Hub actor
- [x] No unrelated changes bundled in
