### PR TITLE
fix(session): match the armor spelling on the starvation damage source

### DIFF
--- a/server/session/damage_source.v
+++ b/server/session/damage_source.v
@@ -208,7 +208,7 @@ pub fn (s StarvationDamageSource) reduced_by_resistance() bool {
 	return false
 }
 
-pub fn (s StarvationDamageSource) reduced_by_armour() bool {
+pub fn (s StarvationDamageSource) reduced_by_armor() bool {
 	return false
 }
 


### PR DESCRIPTION
## Description

`dev` does not currently compile.

#149 renamed the `DamageSource` method to `reduced_by_armor`, and #150 added `StarvationDamageSource` with `reduced_by_armour`. Each was green on its own branch; together the new source no longer satisfies the interface:

```
server/session/hunger.v:97:42: error: `session.StarvationDamageSource` doesn't implement method `reduced_by_armor` of interface `server.session.DamageSource`
```

One word. Starvation still bypasses armour, which is the behaviour both PRs intended - only the spelling was out of step.

## Related issue

Follow-up to #149 and #150.

## Checklist
- [x] `v -check .` is clean
- [x] `v test server/player` and the session damage-source/hunger/armor/combat tests are green
- [x] Follows the conventions in AGENTS.md (OOP, `pub`/capitalized exports, no import cycles, minimal comments)
- [x] Cross-session gameplay state is only mutated on its owning world's actor thread (via `world_call`/`wr.submit`/`WorldTx`), never through a global Hub actor
- [x] No unrelated changes bundled in
