### PR TITLE
feat(world): add cave carving to the overworld generator

### DIFF
--- a/server/world/generator_normal.v
+++ b/server/world/generator_normal.v
@@ -25,6 +25,17 @@ const normal_terrain_salt = u32(3)
 const normal_temperature_salt = u32(5)
 const normal_rainfall_salt = u32(7)
 
+// cave carving — two overlapping noise fields ("spaghetti") plus a separate
+// wider field ("cheese") cut open cavities of different shapes.
+const normal_cave_spaghetti_salt_a = u32(11)
+const normal_cave_spaghetti_salt_b = u32(13)
+const normal_cave_cheese_salt = u32(17)
+const normal_cave_scale = 48.0
+const normal_cave_cheese_scale = 64.0
+const normal_cave_spaghetti_threshold = 0.03
+const normal_cave_cheese_threshold = 0.72
+const normal_cave_lava_level = 10
+
 struct OreType {
 	material      Block
 	cluster_count int
@@ -348,6 +359,38 @@ fn (g NormalGenerator) column_ids(x int, z int) []int {
 		ids[y] = normal_terrain_id(y, min_sum, max_sum, g.terrain_noise(x, y, z))
 	}
 	apply_ground_cover(mut ids, ids.len, normal_ground_cover(g.biome_at(x, z)))
+	// carve the same way generate() does so single block lookups stay consistent
+	for y := 1; y < normal_terrain_height - 1; y++ {
+		if ids[y] != stone.network_id && ids[y] != dirt.network_id && ids[y] != gravel.network_id {
+			continue
+		}
+		sx := f64(x) / normal_cave_scale
+		sy := f64(y) / normal_cave_scale
+		sz := f64(z) / normal_cave_scale
+		na := fbm3d(sx, sy, sz, normal_cave_spaghetti_salt_a, 3) - 0.5
+		nb := fbm3d(sx, sy, sz, normal_cave_spaghetti_salt_b, 3) - 0.5
+		spaghetti := na * na + nb * nb < normal_cave_spaghetti_threshold
+		cx := f64(x) / normal_cave_cheese_scale
+		cy := f64(y) / normal_cave_cheese_scale
+		cz := f64(z) / normal_cave_cheese_scale
+		cheese := fbm3d(cx, cy, cz, normal_cave_cheese_salt, 2) > normal_cave_cheese_threshold
+		if !spaghetti && !cheese {
+			continue
+		}
+		if y + 1 < normal_terrain_height && (ids[y + 1] == air.network_id || ids[y + 1] == water.network_id) {
+			if y > normal_water_height {
+				continue
+			}
+		}
+		if y <= normal_cave_lava_level {
+			ids[y] = lava.network_id
+		} else if y <= normal_water_height && y + 1 < normal_terrain_height
+			&& ids[y + 1] == water.network_id {
+			ids[y] = water.network_id
+		} else {
+			ids[y] = air.network_id
+		}
+	}
 	return ids
 }
 
@@ -415,8 +458,64 @@ pub fn (g NormalGenerator) generate(chunk_x int, chunk_z int) Chunk {
 		}
 	}
 
+	carve_caves(mut c, chunk_x, chunk_z)
 	g.populate(mut c, chunk_x, chunk_z)
 	return c
+}
+
+// carve_caves punches holes through solid stone using two noise layers. The
+// spaghetti pass intersects two thin bands to create winding tunnels; the
+// cheese pass opens up wide chambers where the noise is high enough. Blocks
+// below the lava level get filled with lava, blocks between the lava level
+// and the water height get filled with water when adjacent to water above.
+fn carve_caves(mut c Chunk, chunk_x int, chunk_z int) {
+	base_x := chunk_x * 16
+	base_z := chunk_z * 16
+	for x in 0 .. 16 {
+		wx := base_x + x
+		for z in 0 .. 16 {
+			wz := base_z + z
+			for y := 1; y < normal_terrain_height - 1; y++ {
+				id := c.block_id(x, y, z)
+				if id != stone.network_id && id != dirt.network_id && id != gravel.network_id {
+					continue
+				}
+				sx := f64(wx) / normal_cave_scale
+				sy := f64(y) / normal_cave_scale
+				sz := f64(wz) / normal_cave_scale
+
+				na := fbm3d(sx, sy, sz, normal_cave_spaghetti_salt_a, 3) - 0.5
+				nb := fbm3d(sx, sy, sz, normal_cave_spaghetti_salt_b, 3) - 0.5
+				spaghetti := na * na + nb * nb < normal_cave_spaghetti_threshold
+
+				cx := f64(wx) / normal_cave_cheese_scale
+				cy := f64(y) / normal_cave_cheese_scale
+				cz := f64(wz) / normal_cave_cheese_scale
+				cheese := fbm3d(cx, cy, cz, normal_cave_cheese_salt, 2) > normal_cave_cheese_threshold
+
+				if !spaghetti && !cheese {
+					continue
+				}
+				// don't carve through the surface — keep solid ground above
+				if y + 1 < normal_terrain_height {
+					above := c.block_id(x, y + 1, z)
+					if above == air.network_id || above == water.network_id {
+						if y > normal_water_height {
+							continue
+						}
+					}
+				}
+				if y <= normal_cave_lava_level {
+					c.set_block(x, y, z, lava)
+				} else if y <= normal_water_height && y + 1 < normal_terrain_height
+					&& c.block_id(x, y + 1, z) == water.network_id {
+					c.set_block(x, y, z, water)
+				} else {
+					c.set_block(x, y, z, air)
+				}
+			}
+		}
+	}
 }
 
 // ---- populators ----

--- a/server/world/generator_test.v
+++ b/server/world/generator_test.v
@@ -199,3 +199,84 @@ fn test_density_column_matches_full_grid_sampling() {
 		}
 	}
 }
+
+
+fn test_normal_generator_carves_caves_below_surface() {
+	g := NormalGenerator{}
+	// sample several chunks to find carved air below terrain
+	mut carved_air := 0
+	mut carved_lava := 0
+	for cx in -2 .. 3 {
+		for cz in -2 .. 3 {
+			chunk := g.generate(cx, cz)
+			for x in 0 .. 16 {
+				for z in 0 .. 16 {
+					mut found_surface := false
+					for y := 127; y > 0; y-- {
+						id := chunk.block_id(x, y, z)
+						if !found_surface && id != air.network_id && id != water.network_id {
+							found_surface = true
+							continue
+						}
+						if found_surface && id == air.network_id {
+							carved_air++
+						}
+						if found_surface && id == lava.network_id && y <= normal_cave_lava_level {
+							carved_lava++
+						}
+					}
+				}
+			}
+		}
+	}
+	assert carved_air > 100, 'expected caves to carve air pockets below terrain'
+	assert carved_lava > 0, 'expected lava in caves below y=${normal_cave_lava_level}'
+}
+
+fn test_normal_generator_caves_preserve_bedrock() {
+	g := NormalGenerator{}
+	for cx in -1 .. 2 {
+		for cz in -1 .. 2 {
+			chunk := g.generate(cx, cz)
+			for x in 0 .. 16 {
+				for z in 0 .. 16 {
+					assert chunk.block_id(x, 0, z) == bedrock.network_id, 'cave carving broke bedrock floor at chunk ${cx},${cz} column ${x},${z}'
+				}
+			}
+		}
+	}
+}
+
+fn test_normal_generator_caves_dont_break_surface() {
+	g := NormalGenerator{}
+	chunk := g.generate(0, 0)
+	for x in 0 .. 16 {
+		for z in 0 .. 16 {
+			// find topmost solid block
+			mut top := 0
+			for y := 127; y > 0; y-- {
+				id := chunk.block_id(x, y, z)
+				if id != air.network_id && id != water.network_id {
+					top = y
+					break
+				}
+			}
+			assert top > 0, 'column ${x},${z} has no terrain after carving'
+		}
+	}
+}
+
+fn test_normal_generator_block_at_has_caves() {
+	g := NormalGenerator{}
+	mut carved := 0
+	for x in 0 .. 64 {
+		for z in 0 .. 64 {
+			for y := 1; y < 60; y++ {
+				if g.block_at(x, y, z) == air.network_id {
+					carved++
+				}
+			}
+		}
+	}
+	assert carved > 0, 'expected block_at to reflect cave carving'
+}


### PR DESCRIPTION
## Description

Adds underground caves to the NormalGenerator using two 3D noise layers — spaghetti (winding tunnels) and cheese (wide chambers). Lava fills caves below y=10, water fills caves under sea level. Bedrock floor and surface are preserved.

Includes 4 tests covering air carving, lava placement, bedrock preservation and surface integrity.

## Related issue

Closes #111

## Checklist
- [x] `v -check .` is clean
- [x] `v test server` is fully green
- [x] Follows the conventions in AGENTS.md (OOP, `pub`/capitalized exports, no import cycles, minimal comments)
- [x] Cross-session gameplay state is only mutated on its owning world's actor thread (via `world_call`/`wr.submit`/`WorldTx`), never through a global Hub actor
- [x] No unrelated changes bundled in