### PR TITLE
fix: read P-384 SubjectPublicKeyInfo keys on V's default crypto backend

### DIFF
--- a/server/internal/auth/auth_test.v
+++ b/server/internal/auth/auth_test.v
@@ -1,14 +1,7 @@
 module auth
 
-import crypto.ecdsa
 import encoding.base64
-
-const test_private_key_pem = '-----BEGIN PRIVATE KEY-----
-MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDA60Sz/6mR15FtbH8zh
-CcPquhLVbL5RQ3tFb8OBWq1XhK4LiJi0ElIjD1Xu/ghGWD6hZANiAAQxE3lBAsiY
-+8qTmo78MtLgwwNcgpbEE/FRSfgwUwaeO+xXySeaR6tY4OFoeGrnlFg82z0dY/zA
-t0saDAHsX5rVGAhRm7N3C956r/1x/04YodfQB1z1i4TTn6aiSqjiqoM=
------END PRIVATE KEY-----'
+import server.internal.encryption
 
 const test_public_key_spki = 'MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEMRN5QQLImPvKk5qO/DLS4MMDXIKWxBPxUUn4MFMGnjvsV8knmkerWODhaHhq55RYPNs9HWP8wLdLGgwB7F+a1RgIUZuzdwveeq/9cf9OGKHX0Adc9YuE05+mokqo4qqD'
 
@@ -27,44 +20,13 @@ fn test_b64url_decode_without_padding() {
 	assert b64url_decode('aGVsbG8')!.bytestr() == 'hello'
 }
 
-fn der_to_raw(der []u8) []u8 {
-	mut i := 1
-	if der[i] & 0x80 != 0 {
-		i += 1 + int(der[i] & 0x7f)
-	} else {
-		i++
-	}
-	i++
-	r_len := int(der[i])
-	i++
-	r := der[i..i + r_len]
-	i += r_len
-	i++
-	s_len := int(der[i])
-	i++
-	s := der[i..i + s_len]
-	mut out := left_pad(r, 48)
-	out << left_pad(s, 48)
-	return out
-}
-
-fn left_pad(value []u8, size int) []u8 {
-	mut v := value.clone()
-	for v.len > size && v[0] == 0 {
-		v = v[1..]
-	}
-	mut out := []u8{len: size - v.len, init: u8(0)}
-	out << v
-	return out
-}
-
-fn make_token(header_json string, payload_json string, priv ecdsa.PrivateKey) !string {
+// make_token signs a login token with keys, the way a client does: ES384 with a
+// raw R||S signature.
+fn make_token(header_json string, payload_json string, keys &encryption.ServerKeyPair) !string {
 	h := base64.url_encode(header_json.bytes()).trim_right('=')
 	p := base64.url_encode(payload_json.bytes()).trim_right('=')
 	signing_input := '${h}.${p}'
-	der := priv.sign(signing_input.bytes(), ecdsa.SignerOpts{})!
-	raw := der_to_raw(der)
-	sig := base64.url_encode(raw).trim_right('=')
+	sig := base64.url_encode(keys.sign_es384(signing_input.bytes())!).trim_right('=')
 	return '${signing_input}.${sig}'
 }
 
@@ -76,24 +38,32 @@ fn unsigned_token(header_json string, payload_json string) string {
 
 fn test_offline_chain_roundtrip() {
 	mut verifier := new_oidc_verifier()
-	priv := ecdsa.privkey_from_string(test_private_key_pem)!
-	header := '{"alg":"ES384","x5u":"${test_public_key_spki}"}'
-	payload := '{"extraData":{"displayName":"Steve","identity":"00000000-0000-0000-0000-000000000001","XUID":""},"identityPublicKey":"${test_public_key_spki}"}'
-	token := make_token(header, payload, priv)!
+	mut keys := encryption.new_server_key_pair()!
+	defer {
+		keys.free()
+	}
+	spki := base64.encode(keys.public_key_der()!)
+	header := '{"alg":"ES384","x5u":"${spki}"}'
+	payload := '{"extraData":{"displayName":"Steve","identity":"00000000-0000-0000-0000-000000000001","XUID":""},"identityPublicKey":"${spki}"}'
+	token := make_token(header, payload, keys)!
 	chain_json := '{"chain":["${token}"]}'
 	identity := parse_login_chain(chain_json, false, mut verifier)!
 	assert identity.display_name == 'Steve'
 	assert identity.uuid == '00000000-0000-0000-0000-000000000001'
 	assert identity.xbox_authenticated == false
-	assert identity.client_public_key == test_public_key_spki
+	assert identity.client_public_key == spki
 }
 
 fn test_require_xbox_rejects_offline() {
 	mut verifier := new_oidc_verifier()
-	priv := ecdsa.privkey_from_string(test_private_key_pem)!
-	header := '{"alg":"ES384","x5u":"${test_public_key_spki}"}'
-	payload := '{"extraData":{"displayName":"Steve","identity":"00000000-0000-0000-0000-000000000001"},"identityPublicKey":"${test_public_key_spki}"}'
-	token := make_token(header, payload, priv)!
+	mut keys := encryption.new_server_key_pair()!
+	defer {
+		keys.free()
+	}
+	spki := base64.encode(keys.public_key_der()!)
+	header := '{"alg":"ES384","x5u":"${spki}"}'
+	payload := '{"extraData":{"displayName":"Steve","identity":"00000000-0000-0000-0000-000000000001"},"identityPublicKey":"${spki}"}'
+	token := make_token(header, payload, keys)!
 	chain_json := '{"chain":["${token}"]}'
 	if _ := parse_login_chain(chain_json, true, mut verifier) {
 		assert false
@@ -107,10 +77,14 @@ fn test_require_xbox_rejects_offline() {
 // observable outcome this test asserts.
 fn test_unsigned_identity_token_is_offline() {
 	mut verifier := new_oidc_verifier()
-	priv := ecdsa.privkey_from_string(test_private_key_pem)!
-	header := '{"alg":"ES384","x5u":"${test_public_key_spki}"}'
-	payload := '{"xid":"2535412345678901","xname":"Alex","identity":"00000000-0000-0000-0000-0000000000aa","cpk":"${test_public_key_spki}"}'
-	token := make_token(header, payload, priv)!
+	mut keys := encryption.new_server_key_pair()!
+	defer {
+		keys.free()
+	}
+	spki := base64.encode(keys.public_key_der()!)
+	header := '{"alg":"ES384","x5u":"${spki}"}'
+	payload := '{"xid":"2535412345678901","xname":"Alex","identity":"00000000-0000-0000-0000-0000000000aa","cpk":"${spki}"}'
+	token := make_token(header, payload, keys)!
 	auth_json := '{"AuthenticationType":2,"Token":"${token}","Certificate":""}'
 	if _ := parse_login_chain(auth_json, true, mut verifier) {
 		assert false
@@ -123,10 +97,14 @@ fn test_unsigned_identity_token_is_offline() {
 
 fn test_identity_token_offline_rejected_when_xbox_required() {
 	mut verifier := new_oidc_verifier()
-	priv := ecdsa.privkey_from_string(test_private_key_pem)!
-	header := '{"alg":"ES384","x5u":"${test_public_key_spki}"}'
-	payload := '{"xid":"","xname":"Steve","identity":"00000000-0000-0000-0000-0000000000bb","cpk":"${test_public_key_spki}"}'
-	token := make_token(header, payload, priv)!
+	mut keys := encryption.new_server_key_pair()!
+	defer {
+		keys.free()
+	}
+	spki := base64.encode(keys.public_key_der()!)
+	header := '{"alg":"ES384","x5u":"${spki}"}'
+	payload := '{"xid":"","xname":"Steve","identity":"00000000-0000-0000-0000-0000000000bb","cpk":"${spki}"}'
+	token := make_token(header, payload, keys)!
 	auth_json := '{"AuthenticationType":2,"Token":"${token}"}'
 	if _ := parse_login_chain(auth_json, true, mut verifier) {
 		assert false
@@ -156,10 +134,14 @@ fn test_spoofed_xid_is_not_xbox_authenticated() {
 // false even if the payload claims to be Mojang's.
 fn test_self_signed_chain_not_authenticated() {
 	mut verifier := new_oidc_verifier()
-	priv := ecdsa.privkey_from_string(test_private_key_pem)!
-	header := '{"alg":"ES384","x5u":"${test_public_key_spki}"}'
+	mut keys := encryption.new_server_key_pair()!
+	defer {
+		keys.free()
+	}
+	spki := base64.encode(keys.public_key_der()!)
+	header := '{"alg":"ES384","x5u":"${spki}"}'
 	payload := '{"extraData":{"displayName":"Notch","identity":"00000000-0000-0000-0000-0000000000ff","XUID":"2535400000000000"},"identityPublicKey":"${mojang_public_key}"}'
-	token := make_token(header, payload, priv)!
+	token := make_token(header, payload, keys)!
 	chain_json := '{"chain":["${token}"]}'
 	identity := parse_login_chain(chain_json, false, mut verifier)!
 	assert identity.display_name == 'Notch'
@@ -181,12 +163,16 @@ fn test_trust_anchor_is_verifying_key() {
 // hands off - must fail verification, not silently continue.
 fn test_broken_chain_returns_error() {
 	mut verifier := new_oidc_verifier()
-	priv := ecdsa.privkey_from_string(test_private_key_pem)!
-	header := '{"alg":"ES384","x5u":"${test_public_key_spki}"}'
+	mut keys := encryption.new_server_key_pair()!
+	defer {
+		keys.free()
+	}
+	spki := base64.encode(keys.public_key_der()!)
+	header := '{"alg":"ES384","x5u":"${spki}"}'
 	first_payload := '{"identityPublicKey":"${mojang_public_key}"}'
-	first := make_token(header, first_payload, priv)!
-	second_payload := '{"extraData":{"displayName":"Steve","XUID":"1"},"identityPublicKey":"${test_public_key_spki}"}'
-	second := make_token(header, second_payload, priv)!
+	first := make_token(header, first_payload, keys)!
+	second_payload := '{"extraData":{"displayName":"Steve","XUID":"1"},"identityPublicKey":"${spki}"}'
+	second := make_token(header, second_payload, keys)!
 	chain_json := '{"chain":["${first}","${second}"]}'
 	if _ := parse_login_chain(chain_json, false, mut verifier) {
 		assert false
@@ -195,10 +181,14 @@ fn test_broken_chain_returns_error() {
 
 fn test_tampered_signature_fails() {
 	mut verifier := new_oidc_verifier()
-	priv := ecdsa.privkey_from_string(test_private_key_pem)!
-	header := '{"alg":"ES384","x5u":"${test_public_key_spki}"}'
-	payload := '{"extraData":{"displayName":"Steve","identity":"00000000-0000-0000-0000-000000000001"},"identityPublicKey":"${test_public_key_spki}"}'
-	mut token := make_token(header, payload, priv)!
+	mut keys := encryption.new_server_key_pair()!
+	defer {
+		keys.free()
+	}
+	spki := base64.encode(keys.public_key_der()!)
+	header := '{"alg":"ES384","x5u":"${spki}"}'
+	payload := '{"extraData":{"displayName":"Steve","identity":"00000000-0000-0000-0000-000000000001"},"identityPublicKey":"${spki}"}'
+	mut token := make_token(header, payload, keys)!
 	token = token[..token.len - 2] + 'AA'
 	chain_json := '{"chain":["${token}"]}'
 	if _ := parse_login_chain(chain_json, false, mut verifier) {

--- a/server/internal/auth/jwt.v
+++ b/server/internal/auth/jwt.v
@@ -3,6 +3,7 @@ module auth
 import crypto.ecdsa
 import encoding.base64
 import x.json2
+import server.internal.encryption
 
 pub struct Jwt {
 pub:
@@ -31,7 +32,10 @@ pub fn verify_jwt(token string, public_key_b64 string) !bool {
 	signing_input := '${parts[0]}.${parts[1]}'
 	raw_signature := b64url_decode(parts[2])!
 	der_signature := ecdsa_signature_to_der(raw_signature)!
-	public_key := ecdsa.pubkey_from_string(pem_from_spki(public_key_b64))!
+	public_key := encryption.p384_public_key_from_spki(base64.decode(public_key_b64))!
+	defer {
+		public_key.free()
+	}
 	return public_key.verify(signing_input.bytes(), der_signature, ecdsa.SignerOpts{})!
 }
 
@@ -44,17 +48,6 @@ fn b64url_decode(data string) ![]u8 {
 		padded += '='
 	}
 	return base64.url_decode(padded)
-}
-
-fn pem_from_spki(public_key_b64 string) string {
-	mut body := ''
-	mut i := 0
-	for i < public_key_b64.len {
-		end := if i + 64 < public_key_b64.len { i + 64 } else { public_key_b64.len }
-		body += public_key_b64[i..end] + '\n'
-		i += 64
-	}
-	return '-----BEGIN PUBLIC KEY-----\n${body}-----END PUBLIC KEY-----\n'
 }
 
 fn ecdsa_signature_to_der(raw []u8) ![]u8 {

--- a/server/internal/encryption/keys.v
+++ b/server/internal/encryption/keys.v
@@ -6,9 +6,9 @@ import encoding.base64
 // The Bedrock encryption handshake needs a P-384 keypair, an ECDH derive
 // against the client key and an ES384 signature. crypto.ecdsa does all three;
 // this file only bridges the key format. Bedrock carries public keys as base64
-// SubjectPublicKeyInfo DER while crypto.ecdsa emits a raw EC point and reads
-// PEM. Both are the same bytes in different wrappers, so no OpenSSL binding
-// of our own is involved.
+// SubjectPublicKeyInfo DER while crypto.ecdsa, on its default backend, reads
+// and writes only the raw EC point. For P-384 an SPKI is that point behind a
+// fixed header, so the conversion is done here in both directions.
 
 // p384_spki_prefix is the SubjectPublicKeyInfo header for a secp384r1 key: the
 // SEQUENCE, the id-ecPublicKey/secp384r1 AlgorithmIdentifier and the BIT
@@ -23,8 +23,8 @@ const p384_point_size = 97
 const p384_component_size = 48
 
 // ServerKeyPair holds the ephemeral P-384 ECDH/signing keypair the server
-// generates once per session for the encryption handshake. It owns two OpenSSL
-// key handles and must be freed when the handshake is done.
+// generates once per session for the encryption handshake. It owns two
+// crypto.ecdsa key handles and must be freed when the handshake is done.
 pub struct ServerKeyPair {
 mut:
 	private_key ecdsa.PrivateKey
@@ -69,17 +69,17 @@ fn spki_from_p384_point(point []u8) ![]u8 {
 	return out
 }
 
-// pem_from_spki_der puts DER into the PEM armor crypto.ecdsa's parser reads.
-// PEM is base64 DER wrapped at 64 columns, so this adds no key material.
-fn pem_from_spki_der(der []u8) string {
-	body := base64.encode(der)
-	mut out := '-----BEGIN PUBLIC KEY-----\n'
-	for i := 0; i < body.len; i += 64 {
-		end := if i + 64 < body.len { i + 64 } else { body.len }
-		out += body[i..end] + '\n'
+// p384_public_key_from_spki reads a P-384 SubjectPublicKeyInfo, the form
+// Bedrock carries every public key in: the client's handshake key and each key
+// in the login chain. A key on any other curve is refused.
+pub fn p384_public_key_from_spki(der []u8) !ecdsa.PublicKey {
+	if der.len != p384_spki_prefix.len + p384_point_size {
+		return error('expected a ${p384_spki_prefix.len + p384_point_size}-byte P-384 SubjectPublicKeyInfo, got ${der.len} bytes')
 	}
-	out += '-----END PUBLIC KEY-----\n'
-	return out
+	if der[..p384_spki_prefix.len] != p384_spki_prefix {
+		return error('not a P-384 SubjectPublicKeyInfo')
+	}
+	return ecdsa.PublicKey.from_uncompressed_bytes(der[p384_spki_prefix.len..], nid: .secp384r1)!
 }
 
 // derive_shared_secret runs ECDH against the client public key (a base64 SPKI
@@ -90,7 +90,7 @@ pub fn (k &ServerKeyPair) derive_shared_secret(client_public_key_b64 string) ![]
 	if der.len == 0 {
 		return error('client public key is empty or not valid base64')
 	}
-	peer := ecdsa.pubkey_from_string(pem_from_spki_der(der)) or {
+	peer := p384_public_key_from_spki(der) or {
 		return error('failed to parse client public key DER: ${err}')
 	}
 	defer {

--- a/server/internal/encryption/keys_test.v
+++ b/server/internal/encryption/keys_test.v
@@ -1,7 +1,5 @@
 module encryption
 
-import crypto.ecdsa
-
 const openssl_p384_spki_hex = '3076301006072a8648ce3d020106052b81040022036200047603ab9946d88aea4b191aa5414277b541b1f76ea1c2d287df301322113de9b569c65e55448ea5535e40fecda5c4989013cd40588563f88b91e4b4d3f09f328f83c2e07a62a2a262a66841dd5d36e630bc24961031947c4cc6472a633ee88121'
 
 fn spki_vector() []u8 {
@@ -39,8 +37,8 @@ fn test_spki_from_point_rejects_a_bad_point() {
 	}
 }
 
-// test_generated_spki_parses_back proves the SPKI we hand the client is valid
-// DER: OpenSSL's own parser reads it back to the same point.
+// test_generated_spki_parses_back proves the SPKI we hand the client reads
+// back to the same point.
 fn test_generated_spki_parses_back() {
 	mut keys := new_server_key_pair()!
 	defer {
@@ -48,7 +46,7 @@ fn test_generated_spki_parses_back() {
 	}
 	der := keys.public_key_der()!
 	assert der.len == p384_spki_prefix.len + p384_point_size
-	parsed := ecdsa_pubkey_for_test(der)!
+	parsed := p384_public_key_from_spki(der)!
 	defer {
 		parsed.free()
 	}
@@ -63,7 +61,25 @@ fn test_free_is_idempotent() {
 	keys.free()
 }
 
-// ecdsa_pubkey_for_test parses SPKI DER the same way derive_shared_secret does.
-fn ecdsa_pubkey_for_test(der []u8) !ecdsa.PublicKey {
-	return ecdsa.pubkey_from_string(pem_from_spki_der(der))!
+// test_openssl_spki_reads_to_its_point reads a key as OpenSSL encodes it, which
+// is how a client's key arrives.
+fn test_openssl_spki_reads_to_its_point() {
+	vector := spki_vector()
+	key := p384_public_key_from_spki(vector)!
+	defer {
+		key.free()
+	}
+	assert key.bytes()! == vector[p384_spki_prefix.len..]
+}
+
+fn test_spki_that_is_not_p384_is_rejected() {
+	mut other_curve := spki_vector()
+	other_curve[19] = 0x23
+	if _ := p384_public_key_from_spki(other_curve) {
+		assert false, 'expected an error for a key on another curve'
+	}
+	short := spki_vector()[..p384_spki_prefix.len + p384_point_size - 1]
+	if _ := p384_public_key_from_spki(short) {
+		assert false, 'expected an error for a truncated key'
+	}
 }


### PR DESCRIPTION
crypto.ecdsa's default mbedTLS backend (V 414d5eb) cannot load PEM or DER keys, so derive_shared_secret and verify_jwt failed for every player unless the server was built with -d use_openssl.

A P-384 SubjectPublicKeyInfo is a fixed header followed by the uncompressed point. p384_public_key_from_spki checks the header and hands the point to PublicKey.from_uncompressed_bytes, both backends implement. The encryption handshake and login chain verification both use it. Keys on other curves are refused (the chain is ES384) and verify_jwt now frees the key it parsed.