### PR TITLE
feat: per world seed

### DIFF
--- a/lang/de.toml
+++ b/lang/de.toml
@@ -142,8 +142,11 @@ other = "§cVerwendung: /say <Nachricht>§r"
 [cmd.title.usage]
 other = "§cVerwendung: /title <Spieler|@a> <title|subtitle|actionbar> <Text>§r"
 
+[cmd.seed.body]
+other = "§aStartwert: [{{.Seed}}]§r"
+
 [cmd.world.usage]
-other = "§cVerwendung: /world <list|info|metrics|create|load|delete|tp> [Name] [Dimension] [Generator]§r"
+other = "§cVerwendung: /world <list|info|metrics|create|load|delete|tp> [Name] [Dimension] [Generator] [Startwert]§r"
 
 [cmd.world.none]
 other = "§eKeine Welten wurden geladen§r"

--- a/lang/en.toml
+++ b/lang/en.toml
@@ -154,8 +154,11 @@ other = "§cUsage: /say <message>§r"
 [cmd.title.usage]
 other = "§cUsage: /title <player|@a> <title|subtitle|actionbar> <text>§r"
 
+[cmd.seed.body]
+other = "§aSeed: [{{.Seed}}]§r"
+
 [cmd.world.usage]
-other = "§cUsage: /world <list|info|metrics|create|load|delete|tp> [name] [dimension] [generator]§r"
+other = "§cUsage: /world <list|info|metrics|create|load|delete|tp> [name] [dimension] [generator] [seed]§r"
 
 [cmd.world.none]
 other = "§eNo worlds are loaded§r"

--- a/lang/es.toml
+++ b/lang/es.toml
@@ -141,8 +141,11 @@ other = "§cUso: /say <mensaje>§r"
 [cmd.title.usage]
 other = "§cUso: /title <jugador|@a> <title|subtitle|actionbar> <texto>§r"
 
+[cmd.seed.body]
+other = "§aSemilla: [{{.Seed}}]§r"
+
 [cmd.world.usage]
-other = "§cUso: /world <list|info|metrics|create|load|delete|tp> [nombre] [dimensión] [generador]§r"
+other = "§cUso: /world <list|info|metrics|create|load|delete|tp> [nombre] [dimensión] [generador] [semilla]§r"
 
 [cmd.world.none]
 other = "§eNo hay mundos cargados§r"

--- a/lang/fr.toml
+++ b/lang/fr.toml
@@ -142,8 +142,11 @@ other = "§cUtilisation : /say <message>§r"
 [cmd.title.usage]
 other = "§cUtilisation : /title <joueur|@a> <title|subtitle|actionbar> <texte>§r"
 
+[cmd.seed.body]
+other = "§aGraine : [{{.Seed}}]§r"
+
 [cmd.world.usage]
-other = "§cUtilisation : /world <list|info|metrics|create|load|delete|tp> [nom] [dimension] [générateur]§r"
+other = "§cUtilisation : /world <list|info|metrics|create|load|delete|tp> [nom] [dimension] [générateur] [graine]§r"
 
 [cmd.world.none]
 other = "§eAucun monde chargé§r"

--- a/lang/ru.toml
+++ b/lang/ru.toml
@@ -141,8 +141,11 @@ other = "§cИспользование: /say <сообщение>§r"
 [cmd.title.usage]
 other = "§cИспользование: /title <игрок|@a> <title|subtitle|actionbar> <текст>§r"
 
+[cmd.seed.body]
+other = "§aКлюч генератора: [{{.Seed}}]§r"
+
 [cmd.world.usage]
-other = "§cИспользование: /world <list|info|create|load|delete|tp> [имя] [измерение] [генератор]§r"
+other = "§cИспользование: /world <list|info|create|load|delete|tp> [имя] [измерение] [генератор] [ключ генератора]§r"
 
 [cmd.world.none]
 other = "§eНи один мир не загружен§r"

--- a/lang/tr.toml
+++ b/lang/tr.toml
@@ -142,8 +142,11 @@ other = "§cKullanım: /say <mesaj>§r"
 [cmd.title.usage]
 other = "§cKullanım: /title <oyuncu|@a> <title|subtitle|actionbar> <metin>§r"
 
+[cmd.seed.body]
+other = "§aTohum: [{{.Seed}}]§r"
+
 [cmd.world.usage]
-other = "§cKullanım: /world <list|info|metrics|create|load|delete|tp> [isim] [boyut] [üretici]§r"
+other = "§cKullanım: /world <list|info|metrics|create|load|delete|tp> [isim] [boyut] [üretici] [tohum]§r"
 
 [cmd.world.none]
 other = "§eHiç dünya yüklü değil§r"

--- a/server/cmd/default/command_test.v
+++ b/server/cmd/default/command_test.v
@@ -233,10 +233,14 @@ fn (mut s RecordingSender) world_metrics(name string) ?cmd.WorldMetricsSummary {
 	}
 }
 
-fn (mut s RecordingSender) world_create(name string, dimension string, generator string) ! {
+fn (mut s RecordingSender) world_create(name string, dimension string, generator string, seed ?i64) ! {
 	s.worlds << name
 	s.created_dim = dimension
 	s.created_gen = generator
+}
+
+fn (mut s RecordingSender) current_world_name() string {
+	return ''
 }
 
 fn (mut s RecordingSender) world_load(name string) ! {
@@ -406,7 +410,7 @@ fn test_available_commands_roundtrip() {
 	mut sender := RecordingSender{}
 	sender.perm.set_op(true)
 	pkt := r.available_commands(sender)
-	assert pkt.commands.len == 15
+	assert pkt.commands.len == 16
 	encoded := protocol.encode_packet_to_bytes(pkt)
 	mut pool := proto.new_packet_pool()
 	mut reader := serializer.new_reader(encoded)
@@ -414,7 +418,7 @@ fn test_available_commands_roundtrip() {
 	assert decoded.name() == 'AvailableCommandsPacket'
 	mut available := proto.AvailableCommandsPacket{}
 	decode_into(pkt, mut available)!
-	assert available.commands.len == 15
+	assert available.commands.len == 16
 	assert available.commands[0].alias_enum == -1
 	assert available.commands[0].overloads.len == 1
 }

--- a/server/cmd/default/register.v
+++ b/server/cmd/default/register.v
@@ -18,4 +18,5 @@ pub fn register_all(mut r cmd.Registry) {
 	r.register(SayCommand{})
 	r.register(TitleCommand{})
 	r.register(WorldCommand{})
+	r.register(SeedCommand{})
 }

--- a/server/cmd/default/seed.v
+++ b/server/cmd/default/seed.v
@@ -1,0 +1,36 @@
+module default
+
+import server.permission
+import server.cmd
+
+pub struct SeedCommand {}
+
+pub fn (c SeedCommand) name() string {
+	return 'seed'
+}
+
+pub fn (c SeedCommand) description() string {
+	return 'Shows the seed of the world you are in'
+}
+
+pub fn (c SeedCommand) aliases() []string {
+	return []
+}
+
+pub fn (c SeedCommand) permission() string {
+	return permission.command_seed
+}
+
+pub fn (c SeedCommand) arguments() []cmd.Argument {
+	return []
+}
+
+pub fn (c SeedCommand) execute(mut sender cmd.Sender, ctx cmd.Context) ! {
+	info := sender.world_info(sender.current_world_name()) or {
+		sender.send_message(ctx.lang.t('cmd.world.none'))!
+		return
+	}
+	sender.send_message(ctx.lang.tf('cmd.seed.body', {
+		'Seed': info.seed.str()
+	}))!
+}

--- a/server/cmd/default/world.v
+++ b/server/cmd/default/world.v
@@ -1,5 +1,6 @@
 module default
 
+import strconv
 import server.permission
 import server.cmd
 
@@ -38,6 +39,12 @@ pub fn (c WorldCommand) arguments() []cmd.Argument {
 		},
 		cmd.StringArgument{
 			arg_name:     'generator'
+			arg_optional: true
+		},
+		// A seed is 64 bits wide and the client's integer argument is 32, so it
+		// travels as a string and is parsed here.
+		cmd.StringArgument{
+			arg_name:     'seed'
 			arg_optional: true
 		},
 	]
@@ -176,7 +183,17 @@ fn (c WorldCommand) create(mut sender cmd.Sender, ctx cmd.Context) ! {
 		'overworld'
 	}
 	generator := if ctx.args.len >= 4 { ctx.args[3] } else { '' }
-	sender.world_create(name, dimension, generator) or {
+	mut seed := ?i64(none)
+	if ctx.args.len >= 5 {
+		seed = strconv.parse_int(ctx.args[4], 10, 64) or {
+			sender.send_message(ctx.lang.tf('cmd.world.create_failed', {
+				'Name':   name
+				'Reason': 'the seed has to be a whole number'
+			}))!
+			return
+		}
+	}
+	sender.world_create(name, dimension, generator, seed) or {
 		sender.send_message(ctx.lang.tf('cmd.world.create_failed', {
 			'Name':   name
 			'Reason': err.msg()

--- a/server/cmd/sender.v
+++ b/server/cmd/sender.v
@@ -66,11 +66,15 @@ mut:
 	world_metrics(name string) ?WorldMetricsSummary
 	// world_create's dimension and generator are names rather than the
 	// world.Dimension/world.Generator types themselves, so the cmd layer never
-	// depends on the world package directly.
-	world_create(name string, dimension string, generator string) !
+	// depends on the world package directly. Without a seed the new world is
+	// given a random one.
+	world_create(name string, dimension string, generator string, seed ?i64) !
 	world_load(name string) !
 	world_delete(name string) !
 	world_teleport(name string) !
+	// current_world_name names the world the sender is in. The console's is the
+	// default world.
+	current_world_name() string
 }
 
 // WorldSummary is a read-only snapshot of a loaded world, built for command
@@ -80,6 +84,7 @@ pub:
 	name       string
 	generator  string
 	dimension  string
+	seed       i64
 	overrides  int
 	is_default bool
 	players    int

--- a/server/permission/permission.v
+++ b/server/permission/permission.v
@@ -42,6 +42,7 @@ pub const command_difficulty = 'vedrock.cmd.difficulty'
 pub const command_say = 'vedrock.cmd.say'
 pub const command_title = 'vedrock.cmd.title'
 pub const command_world = 'vedrock.cmd.world'
+pub const command_seed = 'vedrock.cmd.seed'
 
 // Registry is a mutable set of known permissions. The shared `registry`
 // below is the one every Permissible checks against; register() may be
@@ -144,6 +145,11 @@ fn new_registry() &Registry {
 	r.register(Permission{
 		name:        command_world
 		description: 'Allows managing worlds (list/info/create/delete/tp)'
+		default:     .op
+	})
+	r.register(Permission{
+		name:        command_seed
+		description: 'Allows viewing the seed of the current world'
 		default:     .op
 	})
 	return r

--- a/server/server.v
+++ b/server/server.v
@@ -671,6 +671,9 @@ pub:
 	name           string
 	dimension      world.Dimension = world.overworld
 	generator_name string
+	// seed is used only when the world is created: none gives it a random
+	// one and a world that already exists keeps the seed it was made with.
+	seed ?i64
 }
 
 // load_world returns the loaded world, loading it from storage or creating
@@ -682,7 +685,7 @@ pub fn (mut s Server) load_world(config WorldConfig) !session.World {
 	if handle := s.hub.world_handle(config.name) {
 		return handle
 	}
-	s.hub.load_or_create_world(config.name, config.dimension, config.generator_name)!
+	s.hub.load_or_create_world(config.name, config.dimension, config.generator_name, config.seed)!
 	return s.hub.world_handle(config.name) or {
 		error('world "${config.name}" failed to register after loading')
 	}
@@ -716,7 +719,7 @@ pub fn (mut s Server) unload_world(name string) ! {
 // register_generator makes a custom world generator available under name,
 // so load_world/WorldConfig can select it by that name for a new world.
 // Register before loading any world that uses it.
-pub fn (mut s Server) register_generator(name string, factory fn (dim world.Dimension) world.Generator) {
+pub fn (mut s Server) register_generator(name string, factory world.GeneratorFactory) {
 	s.hub.register_generator(name, factory)
 }
 

--- a/server/session/combat_test.v
+++ b/server/session/combat_test.v
@@ -353,7 +353,7 @@ fn test_apply_respawn_resets_health_and_position() {
 	assert !victim.player.is_dead()
 	assert victim.player.health() == 20.0
 	assert victim.player.movement().vy == 0.0
-	assert victim.player.movement().position.y == f32(world.VoidGenerator{}.spawn_y()) +
+	assert victim.player.movement().position.y == f32(world.VoidGenerator{}.spawn_point().y) +
 		player_eye_height
 }
 

--- a/server/session/hub.v
+++ b/server/session/hub.v
@@ -443,6 +443,7 @@ pub:
 	name       string
 	generator  string
 	dimension  string
+	seed       i64
 	// overrides counts the block overrides in the world's resident columns,
 	// not everything it has ever stored.
 	overrides  int
@@ -461,6 +462,7 @@ fn (mut h Hub) world_info(name string) ?WorldInfo {
 		name:       loaded_world.name
 		generator:  loaded_world.generator_name
 		dimension:  loaded_world.dimension.name()
+		seed:       loaded_world.seed
 		overrides:  loaded_world.resident_block_count()
 		is_default: is_default
 		players:    h.players_in_world(name)
@@ -489,7 +491,7 @@ fn (mut h Hub) players_in_world(name string) int {
 
 // register_generator adds or overrides a named world generator, reachable
 // through Server.register_generator.
-pub fn (mut h Hub) register_generator(name string, factory fn (dim blockworld.Dimension) blockworld.Generator) {
+pub fn (mut h Hub) register_generator(name string, factory blockworld.GeneratorFactory) {
 	h.generators.register(name, factory)
 }
 
@@ -502,8 +504,12 @@ fn (mut h Hub) generator_type_names() []string {
 // build_generator resolves a world's own generator by name and dimension
 // through the registry.
 pub fn (h &Hub) build_generator(w &db.World) blockworld.Generator {
-	return h.generators.create(w.generator_name, w.dimension) or {
-		h.generators.create(w.dimension.default_generator, w.dimension) or {
+	opts := blockworld.GeneratorOptions{
+		dim:  w.dimension
+		seed: w.seed
+	}
+	return h.generators.create(w.generator_name, opts) or {
+		h.generators.create(w.dimension.default_generator, opts) or {
 			blockworld.new_generator(w.generator_name)
 		}
 	}
@@ -512,8 +518,8 @@ pub fn (h &Hub) build_generator(w &db.World) blockworld.Generator {
 // create_world creates a fresh empty world on disk and registers it as loaded.
 // Refuses to clobber an already-loaded or already-on-disk world. Safe to call
 // off the actor thread - it only adds to the worlds map, never mutates a
-// player's active world.
-pub fn (mut h Hub) create_world(name string, dim blockworld.Dimension, generator string) !string {
+// player's active world. Without a seed the world gets a new random one.
+pub fn (mut h Hub) create_world(name string, dim blockworld.Dimension, generator string, seed ?i64) !string {
 	if _ := h.world(name) {
 		return error('world "${name}" is already loaded')
 	}
@@ -530,10 +536,12 @@ pub fn (mut h Hub) create_world(name string, dim blockworld.Dimension, generator
 	}
 	h.mutex.unlock()
 	resolved_generator := if generator.trim_space() == '' { default_generator } else { generator }
-	provider := factory.create(name, dim, resolved_generator) or {
+	resolved_seed := seed or { blockworld.new_world_seed() }
+	provider := factory.create(name, dim, resolved_generator, resolved_seed) or {
 		return error('failed to create world "${name}": ${err}')
 	}
-	loaded_world := db.new_world(name, provider, resolved_generator, dim)
+	mut loaded_world := db.new_world(name, provider, resolved_generator, dim)
+	loaded_world.seed = resolved_seed
 	h.add_world(loaded_world)
 	return name
 }
@@ -562,7 +570,7 @@ pub fn (mut h Hub) load_world(name string) !string {
 
 // load_or_create_world loads name from storage when it already exists there
 // or creates it fresh otherwise.
-pub fn (mut h Hub) load_or_create_world(name string, dim blockworld.Dimension, generator string) !string {
+pub fn (mut h Hub) load_or_create_world(name string, dim blockworld.Dimension, generator string, seed ?i64) !string {
 	h.mutex.lock()
 	factory := h.world_factory or {
 		h.mutex.unlock()
@@ -573,7 +581,7 @@ pub fn (mut h Hub) load_or_create_world(name string, dim blockworld.Dimension, g
 	if factory.exists(name) {
 		return h.load_world(name)
 	}
-	return h.create_world(name, dim, generator)
+	return h.create_world(name, dim, generator, seed)
 }
 
 // unload_world flushes and releases a loaded world without deleting its

--- a/server/session/hub.v
+++ b/server/session/hub.v
@@ -80,6 +80,9 @@ mut:
 	// fallback generator name for freshly created worlds. Both are set at boot.
 	worlds_dir      string = 'worlds'
 	world_generator string = 'flat'
+	// creating names the worlds being created right now. A second create of
+	// the same name is refused rather than racing the first for its folder.
+	creating map[string]bool
 	// world_factory creates/opens/lists/deletes named world backends.
 	// Defaults to db.LevelDBFactory the first time set_world_config runs,
 	// unless HubOptions already supplied one at construction time.
@@ -528,6 +531,10 @@ pub fn (mut h Hub) create_world(name string, dim blockworld.Dimension, generator
 		return error('world "${name}" is already loaded')
 	}
 	h.mutex.lock()
+	if name in h.creating {
+		h.mutex.unlock()
+		return error('world "${name}" is already being created')
+	}
 	mut factory := h.world_factory or {
 		h.mutex.unlock()
 		return error('world factory not configured')
@@ -538,7 +545,13 @@ pub fn (mut h Hub) create_world(name string, dim blockworld.Dimension, generator
 	} else {
 		dim.default_generator
 	}
+	h.creating[name] = true
 	h.mutex.unlock()
+	defer {
+		h.mutex.lock()
+		h.creating.delete(name)
+		h.mutex.unlock()
+	}
 	resolved_generator := if generator.trim_space() == '' { default_generator } else { generator }
 	resolved_seed := seed or { blockworld.new_world_seed() }
 	spawn_point := h.generator_for(resolved_generator, dim, resolved_seed).spawn_point()

--- a/server/session/hub.v
+++ b/server/session/hub.v
@@ -504,14 +504,18 @@ fn (mut h Hub) generator_type_names() []string {
 // build_generator resolves a world's own generator by name and dimension
 // through the registry.
 pub fn (h &Hub) build_generator(w &db.World) blockworld.Generator {
+	return h.generator_for(w.generator_name, w.dimension, w.seed)
+}
+
+// generator_for resolves a generator by name for dim and seed, falling back to
+// the dimension's own default and then to the built-in of that name.
+fn (h &Hub) generator_for(name string, dim blockworld.Dimension, seed i64) blockworld.Generator {
 	opts := blockworld.GeneratorOptions{
-		dim:  w.dimension
-		seed: w.seed
+		dim:  dim
+		seed: seed
 	}
-	return h.generators.create(w.generator_name, opts) or {
-		h.generators.create(w.dimension.default_generator, opts) or {
-			blockworld.new_generator(w.generator_name)
-		}
+	return h.generators.create(name, opts) or {
+		h.generators.create(dim.default_generator, opts) or { blockworld.new_generator(name) }
 	}
 }
 
@@ -537,11 +541,13 @@ pub fn (mut h Hub) create_world(name string, dim blockworld.Dimension, generator
 	h.mutex.unlock()
 	resolved_generator := if generator.trim_space() == '' { default_generator } else { generator }
 	resolved_seed := seed or { blockworld.new_world_seed() }
-	provider := factory.create(name, dim, resolved_generator, resolved_seed) or {
+	spawn_point := h.generator_for(resolved_generator, dim, resolved_seed).spawn_point()
+	provider := factory.create(name, dim, resolved_generator, resolved_seed, spawn_point) or {
 		return error('failed to create world "${name}": ${err}')
 	}
 	mut loaded_world := db.new_world(name, provider, resolved_generator, dim)
 	loaded_world.seed = resolved_seed
+	loaded_world.spawn_point = spawn_point
 	h.add_world(loaded_world)
 	return name
 }

--- a/server/session/player_world_test.v
+++ b/server/session/player_world_test.v
@@ -54,7 +54,7 @@ fn standing_position(mut hub Hub) types.Vector3 {
 	mut wr := hub.default_world_runtime() or { panic('expected a default world') }
 	target := wr.world
 	gen := target.make_generator(hub.build_generator(target))
-	return types.Vector3{18.5, f32(gen.spawn_y()) + player_eye_height, -6.5}
+	return types.Vector3{18.5, f32(gen.spawn_point().y) + player_eye_height, -6.5}
 }
 
 fn resume_dir(tag string) string {

--- a/server/session/session.v
+++ b/server/session/session.v
@@ -272,7 +272,8 @@ pub fn new(mut transport network.Transport, mut hub Hub, cfg conf.Config, log &l
 	}
 	mut p := player.new_player()
 	p.handle(hub.player_handler)
-	p.reset_position(types.Vector3{0.0, f32(generator.spawn_y()) + player_eye_height, 0.0})
+	spawn_point := generator.spawn_point()
+	p.reset_position(types.Vector3{f32(spawn_point.x), f32(spawn_point.y) + player_eye_height, f32(spawn_point.z)})
 	mut s := &NetworkSession{
 		player:             p
 		conn:               &Conn{

--- a/server/session/spawn.v
+++ b/server/session/spawn.v
@@ -123,7 +123,7 @@ struct SpawnState {
 	yaw            f32
 	dimension_id   int
 	generator_type proto.GeneratorType
-	spawn_y        int
+	spawn_point    world.SpawnPoint
 }
 
 // resolve_spawn_state picks player's spawn position. A generator provided
@@ -148,7 +148,7 @@ fn (mut s NetworkSession) resolve_spawn_state() !SpawnState {
 	if data := saved {
 		saved_position_stands = s.resume_saved_world(data.world)
 	}
-	spawn_y := s.generator.spawn_y()
+	spawn_point := s.generator.spawn_point()
 	dimension_id := if isnil(s.world) { world.overworld.id } else { s.world.dimension.id }
 	generator_type := if dimension_id == world.nether.id {
 		proto.GeneratorType.nether
@@ -157,7 +157,7 @@ fn (mut s NetworkSession) resolve_spawn_state() !SpawnState {
 	} else {
 		proto.GeneratorType.overworld
 	}
-	mut pos := types.Vector3{0.0, f32(spawn_y) + player_eye_height, 0.0}
+	mut pos := types.Vector3{f32(spawn_point.x), f32(spawn_point.y) + player_eye_height, f32(spawn_point.z)}
 	mut pitch := f32(0.0)
 	mut yaw := f32(0.0)
 	if data := saved {
@@ -190,7 +190,7 @@ fn (mut s NetworkSession) resolve_spawn_state() !SpawnState {
 		yaw:            yaw
 		dimension_id:   dimension_id
 		generator_type: generator_type
-		spawn_y:        spawn_y
+		spawn_point:    spawn_point
 	}
 }
 
@@ -220,9 +220,9 @@ fn (mut s NetworkSession) build_start_game_packet(spawn_state SpawnState) &proto
 			is_hardcore_enabled:                          false
 			game_difficulty:                              unsafe { proto.Difficulty(s.hub.difficulty_value()) }
 			default_spawn_block_position:                 proto.NetworkBlockPosition{
-				x: 0
-				y: i32(spawn_state.spawn_y)
-				z: 0
+				x: i32(spawn_state.spawn_point.x)
+				y: i32(spawn_state.spawn_point.y)
+				z: i32(spawn_state.spawn_point.z)
 			}
 			achievements_disabled:                        false
 			editor_world_type:                            proto.EditorWorldType.non_editor

--- a/server/session/start_game_test.v
+++ b/server/session/start_game_test.v
@@ -207,12 +207,12 @@ fn test_accepts_saved_pos_supported_by_world_overr() {
 
 fn test_saved_player_position_must_be_standable() {
 	flat := world.FlatGenerator{}
-	flat_spawn := types.Vector3{0.0, f32(flat.spawn_y()) + player_eye_height, 0.0}
+	flat_spawn := types.Vector3{0.0, f32(flat.spawn_point().y) + player_eye_height, 0.0}
 	assert safe_player_position(flat, flat_spawn)
 	assert !safe_player_position(flat, types.Vector3{0.0, f32(world.overworld.min_y + 2), 0.0})
 
 	nether := world.NetherGenerator{}
-	nether_spawn := types.Vector3{0.0, f32(nether.spawn_y()) + player_eye_height, 0.0}
+	nether_spawn := types.Vector3{0.0, f32(nether.spawn_point().y) + player_eye_height, 0.0}
 	assert safe_player_position(nether, nether_spawn)
 	assert !safe_player_position(nether, types.Vector3{0.0, 4.0 + player_eye_height, 0.0})
 }
@@ -223,7 +223,7 @@ fn test_world_spawn_position_uses_target_world_generator() {
 	pos := world_spawn_position(target, gen)
 	assert pos.x == 0.0
 	assert pos.z == 0.0
-	assert pos.y == f32(gen.spawn_y()) + player_eye_height
+	assert pos.y == f32(gen.spawn_point().y) + player_eye_height
 	assert pos.y != 64.0
 }
 
@@ -264,8 +264,10 @@ mut:
 	mutex &sync.Mutex = sync.new_mutex()
 }
 
-fn (g CountingGenerator) spawn_y() int {
-	return 64
+fn (g CountingGenerator) spawn_point() world.SpawnPoint {
+	return world.SpawnPoint{
+		y: 64
+	}
 }
 
 fn (g CountingGenerator) uses_blocks() bool {
@@ -337,8 +339,10 @@ struct BlockingCountingGenerator {
 	release chan bool
 }
 
-fn (g BlockingCountingGenerator) spawn_y() int {
-	return 64
+fn (g BlockingCountingGenerator) spawn_point() world.SpawnPoint {
+	return world.SpawnPoint{
+		y: 64
+	}
 }
 
 fn (g BlockingCountingGenerator) uses_blocks() bool {

--- a/server/session/world_admin.v
+++ b/server/session/world_admin.v
@@ -17,6 +17,10 @@ fn (mut s NetworkSession) world_names() []string {
 	return s.hub.list_worlds()
 }
 
+fn (mut s NetworkSession) current_world_name() string {
+	return s.world_name()
+}
+
 fn (mut s NetworkSession) world_info(name string) ?cmd.WorldSummary {
 	info := s.hub.world_info(name)?
 	return to_world_summary(info)
@@ -27,11 +31,11 @@ fn (mut s NetworkSession) world_metrics(name string) ?cmd.WorldMetricsSummary {
 	return to_world_metrics_summary(m)
 }
 
-fn (mut s NetworkSession) world_create(name string, dimension string, generator string) ! {
+fn (mut s NetworkSession) world_create(name string, dimension string, generator string, seed ?i64) ! {
 	dim := world.dimension_by_name(dimension) or {
 		return error('unknown dimension "${dimension}"')
 	}
-	s.hub.create_world(name, dim, generator)!
+	s.hub.create_world(name, dim, generator, seed)!
 	mut load_ctx := event.new_context(player.WorldLoadData{
 		name:   name
 		sender: s
@@ -71,6 +75,11 @@ fn (mut c ConsoleSender) world_names() []string {
 	return c.hub.list_worlds()
 }
 
+fn (mut c ConsoleSender) current_world_name() string {
+	default_world := c.hub.default_world() or { return '' }
+	return default_world.name
+}
+
 fn (mut c ConsoleSender) world_info(name string) ?cmd.WorldSummary {
 	info := c.hub.world_info(name)?
 	return to_world_summary(info)
@@ -81,11 +90,11 @@ fn (mut c ConsoleSender) world_metrics(name string) ?cmd.WorldMetricsSummary {
 	return to_world_metrics_summary(m)
 }
 
-fn (mut c ConsoleSender) world_create(name string, dimension string, generator string) ! {
+fn (mut c ConsoleSender) world_create(name string, dimension string, generator string, seed ?i64) ! {
 	dim := world.dimension_by_name(dimension) or {
 		return error('unknown dimension "${dimension}"')
 	}
-	c.hub.create_world(name, dim, generator)!
+	c.hub.create_world(name, dim, generator, seed)!
 	mut load_ctx := event.new_context(player.WorldLoadData{
 		name:   name
 		sender: c
@@ -123,6 +132,7 @@ fn to_world_summary(info WorldInfo) cmd.WorldSummary {
 		name:       info.name
 		generator:  info.generator
 		dimension:  info.dimension
+		seed:       info.seed
 		overrides:  info.overrides
 		is_default: info.is_default
 		players:    info.players
@@ -173,7 +183,8 @@ fn to_world_metrics_summary(m worldrt.WorldMetrics) cmd.WorldMetricsSummary {
 }
 
 fn world_spawn_position(target &db.World, gen world.Generator) types.Vector3 {
-	mut y := gen.spawn_y()
+	spawn_point := gen.spawn_point()
+	mut y := spawn_point.y
 	if y < target.dimension.min_y + 1 {
 		y = target.dimension.min_y + 1
 	}
@@ -181,5 +192,5 @@ fn world_spawn_position(target &db.World, gen world.Generator) types.Vector3 {
 	if y > max_y {
 		y = max_y
 	}
-	return types.Vector3{0.0, f32(y) + player_eye_height, 0.0}
+	return types.Vector3{f32(spawn_point.x), f32(y) + player_eye_height, f32(spawn_point.z)}
 }

--- a/server/session/world_boot.v
+++ b/server/session/world_boot.v
@@ -29,6 +29,18 @@ pub fn (mut h Hub) load_configured_worlds(worlds_dir string, default_world strin
 		log.info(lang.tf('server.world_loading', {
 			'Name': name
 		}))
+		if !factory.exists(name) {
+			// Made the way /world create makes a world, so it records its
+			// generator and seed like any other.
+			h.create_world(name, blockworld.overworld, generator, none) or {
+				log.warn('Failed to create world "${name}": ${err}')
+				continue
+			}
+			log.info(lang.tf('server.world_loaded', {
+				'Name': name
+			}))
+			continue
+		}
 		if w := factory.open(name, generator, blockworld.overworld) {
 			h.add_world(w)
 			log.info(lang.tf('server.world_loaded', {

--- a/server/session/world_chunk_streaming_test.v
+++ b/server/session/world_chunk_streaming_test.v
@@ -28,8 +28,8 @@ fn new_blocking_generator(started chan bool, release chan bool) BlockingGenerato
 	}
 }
 
-fn (g BlockingGenerator) spawn_y() int {
-	return g.inner.spawn_y()
+fn (g BlockingGenerator) spawn_point() world.SpawnPoint {
+	return g.inner.spawn_point()
 }
 
 fn (g BlockingGenerator) uses_blocks() bool {
@@ -63,7 +63,7 @@ fn (g BlockingGenerator) generate(chunk_x int, chunk_z int) world.Chunk {
 }
 
 fn register_blocking_generator(mut hub Hub, name string, gen BlockingGenerator) {
-	hub.register_generator(name, fn [gen] (dim world.Dimension) world.Generator {
+	hub.register_generator(name, fn [gen] (_ world.GeneratorOptions) world.Generator {
 		return gen
 	})
 }
@@ -228,8 +228,8 @@ struct ConcurrentBlockingGenerator {
 	inner   world.Generator = world.VoidGenerator{}
 }
 
-fn (g ConcurrentBlockingGenerator) spawn_y() int {
-	return g.inner.spawn_y()
+fn (g ConcurrentBlockingGenerator) spawn_point() world.SpawnPoint {
+	return g.inner.spawn_point()
 }
 
 fn (g ConcurrentBlockingGenerator) uses_blocks() bool {
@@ -262,7 +262,7 @@ fn test_req_chunk_chans_keeps_worker_pool_busy_concurrently() {
 		tracker: tracker
 		release: release
 	}
-	hub.register_generator('concurrent-blocking-stream', fn [gen] (dim world.Dimension) world.Generator {
+	hub.register_generator('concurrent-blocking-stream', fn [gen] (_ world.GeneratorOptions) world.Generator {
 		return gen
 	})
 	w := db.new_world('chunk-concurrency', none, 'concurrent-blocking-stream', world.overworld)

--- a/server/session/world_factory_test.v
+++ b/server/session/world_factory_test.v
@@ -1,6 +1,9 @@
 module session
 
+import os
 import server.internal.gamedata
+import server.internal.language
+import server.internal.logger
 import server.world
 import server.world.db
 
@@ -40,14 +43,16 @@ fn (mut p FakeProvider) close() ! {}
 struct FakeFactory {
 mut:
 	created []string
+	seeds   []i64
 }
 
 fn (f &FakeFactory) exists(name string) bool {
 	return false
 }
 
-fn (mut f FakeFactory) create(name string, dim world.Dimension, generator string) !db.Provider {
+fn (mut f FakeFactory) create(name string, dim world.Dimension, generator string, seed i64) !db.Provider {
 	f.created << name
+	f.seeds << seed
 	return &FakeProvider{}
 }
 
@@ -66,11 +71,58 @@ fn test_hub_creates_world_through_custom_factory() {
 	mut hub := new_hub(gamedata.GameData{}, world_factory: db.Factory(factory))
 	hub.set_world_config('unused-worlds-dir', 'flat')
 
-	hub.create_world('custom', world.overworld, 'flat') or {
+	hub.create_world('custom', world.overworld, 'flat', none) or {
 		panic('expected create_world to succeed: ${err}')
 	}
 
 	assert factory.created == ['custom']
+	assert factory.seeds.len == 1 && factory.seeds[0] != 0
+	created := hub.world('custom') or { panic('expected the created world to be loaded') }
+	assert created.seed == factory.seeds[0]
 	info := hub.world_info('custom') or { panic('expected world_info to find it') }
 	assert info.name == 'custom'
+}
+
+fn test_a_default_world_created_at_boot_records_its_seed() {
+	dir := os.join_path(os.vtmp_dir(), 'vedrock_boot_seed_${os.getpid()}')
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	mut hub := new_hub(gamedata.GameData{},
+		world_factory: db.Factory(db.LevelDBFactory{
+			worlds_dir: dir
+		})
+	)
+	defer {
+		hub.close_worlds()
+	}
+	lang := language.load('en') or { panic(err) }
+
+	hub.load_configured_worlds(dir, 'world', false, 'normal', logger.new(.info), lang)
+
+	created := hub.world('world') or { panic('the default world was not created') }
+	assert created.seed != 0
+	meta := os.read_file(os.join_path(dir, 'world', 'meta.txt')) or {
+		panic('the default world has no meta.txt')
+	}
+	assert meta.contains('seed: ${created.seed}')
+}
+
+fn test_a_world_s_seed_reaches_the_generator_built_for_it() {
+	mut hub := new_hub(gamedata.GameData{})
+	mut seeded := db.new_world('seeded', none, 'normal', world.overworld)
+	seeded.seed = 42
+	legacy := db.new_world('legacy', none, 'normal', world.overworld)
+
+	assert sample_block_ids(hub.build_generator(seeded)) != sample_block_ids(hub.build_generator(legacy))
+}
+
+fn sample_block_ids(g world.Generator) []int {
+	mut ids := []int{}
+	for pos in [[0, 0], [300, -120]] {
+		for y in 0 .. 128 {
+			ids << g.block_at(pos[0], y, pos[1])
+		}
+	}
+	return ids
 }

--- a/server/session/world_factory_test.v
+++ b/server/session/world_factory_test.v
@@ -44,15 +44,17 @@ struct FakeFactory {
 mut:
 	created []string
 	seeds   []i64
+	spawns  []world.SpawnPoint
 }
 
 fn (f &FakeFactory) exists(name string) bool {
 	return false
 }
 
-fn (mut f FakeFactory) create(name string, dim world.Dimension, generator string, seed i64) !db.Provider {
+fn (mut f FakeFactory) create(name string, dim world.Dimension, generator string, seed i64, spawn_point world.SpawnPoint) !db.Provider {
 	f.created << name
 	f.seeds << seed
+	f.spawns << spawn_point
 	return &FakeProvider{}
 }
 
@@ -79,6 +81,9 @@ fn test_hub_creates_world_through_custom_factory() {
 	assert factory.seeds.len == 1 && factory.seeds[0] != 0
 	created := hub.world('custom') or { panic('expected the created world to be loaded') }
 	assert created.seed == factory.seeds[0]
+	stored := created.spawn_point or { panic('the created world has no spawn') }
+	assert factory.spawns == [stored]
+	assert stored == world.FlatGenerator{}.spawn_point()
 	info := hub.world_info('custom') or { panic('expected world_info to find it') }
 	assert info.name == 'custom'
 }
@@ -106,6 +111,7 @@ fn test_a_default_world_created_at_boot_records_its_seed() {
 		panic('the default world has no meta.txt')
 	}
 	assert meta.contains('seed: ${created.seed}')
+	assert meta.contains('spawn: ')
 }
 
 fn test_a_world_s_seed_reaches_the_generator_built_for_it() {

--- a/server/session/world_handle.v
+++ b/server/session/world_handle.v
@@ -52,12 +52,18 @@ pub fn (w World) block_at(x int, y int, z int) world.Block {
 	return world.block_from_id(gen.block_at(x, y, z))
 }
 
-// spawn_y returns the configured generator's spawn height for this world.
-// The generator can be resolved from thread safe world and registry state,
-// so no world actor call is required.
-pub fn (w World) spawn_y() int {
+// spawn_point returns where a player new to this world arrives as its
+// generator chooses. The generator can be resolved from thread safe world and
+// registry state, so no world actor call is required.
+pub fn (w World) spawn_point() world.SpawnPoint {
 	gen := w.runtime.world.make_generator(w.runtime.generators.build_generator(w.runtime.world))
-	return gen.spawn_y()
+	return gen.spawn_point()
+}
+
+// seed returns the seed this world's generator is built with. 0 is a world
+// made before seeds existed.
+pub fn (w World) seed() i64 {
+	return w.runtime.world.seed
 }
 
 // set_block applies an authoritative block change through the owning world

--- a/server/world/db/factory.v
+++ b/server/world/db/factory.v
@@ -10,7 +10,9 @@ pub interface Factory {
 	exists(name string) bool
 	discover() []string
 mut:
-	create(name string, dim world.Dimension, generator string) !Provider
+	// create records generator and seed with the world, so it is generated
+	// the same way every time it is opened.
+	create(name string, dim world.Dimension, generator string, seed i64) !Provider
 	// open loads a persisted world, resolving its own generator/dimension
 	// from whatever metadata the backend keeps (falling back to
 	// fallback_generator/fallback_dim if it can't). Returns a fully loaded
@@ -32,8 +34,8 @@ pub fn (f LevelDBFactory) exists(name string) bool {
 	return world_exists(f.worlds_dir, name)
 }
 
-pub fn (f LevelDBFactory) create(name string, dim world.Dimension, generator string) !Provider {
-	return create_world_store(f.worlds_dir, name, dim, generator)!
+pub fn (f LevelDBFactory) create(name string, dim world.Dimension, generator string, seed i64) !Provider {
+	return create_world_store(f.worlds_dir, name, dim, generator, seed)!
 }
 
 pub fn (f LevelDBFactory) open(name string, fallback_generator string, fallback_dim world.Dimension) !&World {

--- a/server/world/db/factory.v
+++ b/server/world/db/factory.v
@@ -12,7 +12,7 @@ pub interface Factory {
 mut:
 	// create records generator and seed with the world, so it is generated
 	// the same way every time it is opened.
-	create(name string, dim world.Dimension, generator string, seed i64) !Provider
+	create(name string, dim world.Dimension, generator string, seed i64, spawn_point world.SpawnPoint) !Provider
 	// open loads a persisted world, resolving its own generator/dimension
 	// from whatever metadata the backend keeps (falling back to
 	// fallback_generator/fallback_dim if it can't). Returns a fully loaded
@@ -34,8 +34,8 @@ pub fn (f LevelDBFactory) exists(name string) bool {
 	return world_exists(f.worlds_dir, name)
 }
 
-pub fn (f LevelDBFactory) create(name string, dim world.Dimension, generator string, seed i64) !Provider {
-	return create_world_store(f.worlds_dir, name, dim, generator, seed)!
+pub fn (f LevelDBFactory) create(name string, dim world.Dimension, generator string, seed i64, spawn_point world.SpawnPoint) !Provider {
+	return create_world_store(f.worlds_dir, name, dim, generator, seed, spawn_point)!
 }
 
 pub fn (f LevelDBFactory) open(name string, fallback_generator string, fallback_dim world.Dimension) !&World {

--- a/server/world/db/manage.v
+++ b/server/world/db/manage.v
@@ -50,13 +50,13 @@ pub fn delete_world_files(worlds_dir string, name string) ! {
 
 // create_world_store creates a fresh, empty world on disk under worlds_dir and
 // returns its opened store. Errors if a world by that name already exists.
-pub fn create_world_store(worlds_dir string, name string, dim world.Dimension, generator string, seed i64) !&WorldStore {
+pub fn create_world_store(worlds_dir string, name string, dim world.Dimension, generator string, seed i64, spawn_point world.SpawnPoint) !&WorldStore {
 	full := safe_world_dir(worlds_dir, name)!
 	if world_exists(worlds_dir, name) {
 		return error('world "${name}" already exists')
 	}
 	os.mkdir_all(full)!
-	write_world_meta(full, generator, dim, seed)!
+	write_world_meta(full, generator, dim, seed, spawn_point)!
 	path := os.join_path(full, 'db')
 	return open_world(path, dim)!
 }

--- a/server/world/db/manage.v
+++ b/server/world/db/manage.v
@@ -52,6 +52,10 @@ pub fn delete_world_files(worlds_dir string, name string) ! {
 // returns its opened store. Errors if a world by that name already exists.
 pub fn create_world_store(worlds_dir string, name string, dim world.Dimension, generator string, seed i64, spawn_point world.SpawnPoint) !&WorldStore {
 	full := safe_world_dir(worlds_dir, name)!
+	// A symlink would carry the writes below outside worlds_dir.
+	if os.is_link(full) {
+		return error('world "${name}" is a symlink; not creating through it')
+	}
 	if world_exists(worlds_dir, name) {
 		return error('world "${name}" already exists')
 	}

--- a/server/world/db/manage.v
+++ b/server/world/db/manage.v
@@ -50,13 +50,13 @@ pub fn delete_world_files(worlds_dir string, name string) ! {
 
 // create_world_store creates a fresh, empty world on disk under worlds_dir and
 // returns its opened store. Errors if a world by that name already exists.
-pub fn create_world_store(worlds_dir string, name string, dim world.Dimension, generator string) !&WorldStore {
+pub fn create_world_store(worlds_dir string, name string, dim world.Dimension, generator string, seed i64) !&WorldStore {
 	full := safe_world_dir(worlds_dir, name)!
 	if os.is_dir(full) {
 		return error('world "${name}" already exists')
 	}
 	os.mkdir_all(full)!
-	write_world_meta(full, generator, dim)!
+	write_world_meta(full, generator, dim, seed)!
 	path := os.join_path(full, 'db')
 	return open_world(path, dim)!
 }

--- a/server/world/db/manage.v
+++ b/server/world/db/manage.v
@@ -52,7 +52,7 @@ pub fn delete_world_files(worlds_dir string, name string) ! {
 // returns its opened store. Errors if a world by that name already exists.
 pub fn create_world_store(worlds_dir string, name string, dim world.Dimension, generator string, seed i64) !&WorldStore {
 	full := safe_world_dir(worlds_dir, name)!
-	if os.is_dir(full) {
+	if world_exists(worlds_dir, name) {
 		return error('world "${name}" already exists')
 	}
 	os.mkdir_all(full)!

--- a/server/world/db/manage.v
+++ b/server/world/db/manage.v
@@ -55,6 +55,13 @@ pub fn create_world_store(worlds_dir string, name string, dim world.Dimension, g
 	if world_exists(worlds_dir, name) {
 		return error('world "${name}" already exists')
 	}
+
+	if os.is_dir(full) {
+		entries := os.ls(full) or { return error('cannot read ${full}: ${err.msg()}') }
+		if entries.len > 0 {
+			return error('world "${name}" has a folder with no db that is not empty; not creating over it')
+		}
+	}
 	os.mkdir_all(full)!
 	write_world_meta(full, generator, dim, seed, spawn_point)!
 	path := os.join_path(full, 'db')

--- a/server/world/db/vanilla.v
+++ b/server/world/db/vanilla.v
@@ -458,15 +458,22 @@ fn (mut c ChunkCache) remember_miss(key u64) {
 	}
 }
 
-pub fn (g StoredGenerator) spawn_y() int {
-	chunk := g.cached_chunk(0, 0) or { return g.fallback.spawn_y() }
+// spawn_point is the generator's spawn column, stood on whatever has been
+// built there since.
+pub fn (g StoredGenerator) spawn_point() world.SpawnPoint {
+	generated := g.fallback.spawn_point()
+	chunk := g.cached_chunk(generated.x >> 4, generated.z >> 4) or { return generated }
 	dim := g.store.dimension()
 	for y := dim.max_y(); y >= dim.min_y; y-- {
-		if chunk.block_id(0, y, 0) != world.air.network_id {
-			return y + 1
+		if chunk.block_id(generated.x & 15, y, generated.z & 15) != world.air.network_id {
+			return world.SpawnPoint{
+				x: generated.x
+				y: y + 1
+				z: generated.z
+			}
 		}
 	}
-	return g.fallback.spawn_y()
+	return generated
 }
 
 pub fn (g StoredGenerator) uses_blocks() bool {

--- a/server/world/db/vanilla.v
+++ b/server/world/db/vanilla.v
@@ -378,16 +378,18 @@ fn chunk_cache_key(cx int, cz int) u64 {
 }
 
 pub struct StoredGenerator {
-	store    Provider
-	fallback world.Generator
-	cache    &ChunkCache
+	store        Provider
+	fallback     world.Generator
+	cache        &ChunkCache
+	stored_spawn ?world.SpawnPoint
 }
 
-pub fn new_stored_generator(store Provider, fallback world.Generator, cache &ChunkCache) StoredGenerator {
+pub fn new_stored_generator(store Provider, fallback world.Generator, cache &ChunkCache, stored_spawn ?world.SpawnPoint) StoredGenerator {
 	return StoredGenerator{
-		store:    store
-		fallback: fallback
-		cache:    cache
+		store:        store
+		fallback:     fallback
+		cache:        cache
+		stored_spawn: stored_spawn
 	}
 }
 
@@ -458,10 +460,11 @@ fn (mut c ChunkCache) remember_miss(key u64) {
 	}
 }
 
-// spawn_point is the generator's spawn column, stood on whatever has been
-// built there since.
+// spawn_point is the world's spawn column, stood on whatever has been built
+// there since. The column is the one stored when the world was created; only a
+// world from before that asks its generator.
 pub fn (g StoredGenerator) spawn_point() world.SpawnPoint {
-	generated := g.fallback.spawn_point()
+	generated := g.stored_spawn or { g.fallback.spawn_point() }
 	chunk := g.cached_chunk(generated.x >> 4, generated.z >> 4) or { return generated }
 	dim := g.store.dimension()
 	for y := dim.max_y(); y >= dim.min_y; y-- {

--- a/server/world/db/world_instance.v
+++ b/server/world/db/world_instance.v
@@ -175,6 +175,9 @@ mut:
 	closed  bool
 pub mut:
 	generator_name string
+	// seed is what this world's generator is built with. 0 is a world made
+	// before seeds existed, which keeps generating as it always did.
+	seed i64
 }
 
 pub struct BlockOverride {

--- a/server/world/db/world_instance.v
+++ b/server/world/db/world_instance.v
@@ -178,6 +178,9 @@ pub mut:
 	// seed is what this world's generator is built with. 0 is a world made
 	// before seeds existed, which keeps generating as it always did.
 	seed i64
+	// spawn is where a player new to this world arrives, worked out once when
+	// it was created. none is a world from before spawns were stored.
+	spawn_point ?world.SpawnPoint
 }
 
 pub struct BlockOverride {
@@ -1008,7 +1011,7 @@ pub fn (mut w World) tile_entries_in_chunk(cx int, cz int) []TileEntry {
 // world has a backing store, so saved chunks are served before the fallback.
 pub fn (w &World) make_generator(fallback world.Generator) world.Generator {
 	store := w.store or { return fallback }
-	return new_stored_generator(store, fallback, w.chunk_cache)
+	return new_stored_generator(store, fallback, w.chunk_cache, w.spawn_point)
 }
 
 // flush persists this world's store to disk without unloading it, waiting

--- a/server/world/db/world_loader.v
+++ b/server/world/db/world_loader.v
@@ -9,13 +9,20 @@ pub fn load_named(worlds_dir string, name string, generator_name string, dim wor
 	full := os.join_path(worlds_dir, name)
 	mut resolved_generator := generator_name
 	mut resolved_dim := dim
+	mut resolved_seed := i64(0)
 	if meta := read_world_meta(full) {
 		resolved_generator = meta.generator
 		resolved_dim = world.dimension_by_id(meta.dimension) or { dim }
+		resolved_seed = meta.seed
+	} else {
+		if err !is NoWorldMeta {
+			return err
+		}
 	}
 	path := os.join_path(full, 'db')
 	store := open_world(path, resolved_dim)!
 	mut w := new_world(name, store, resolved_generator, resolved_dim)
+	w.seed = resolved_seed
 	w.load()
 	return w
 }

--- a/server/world/db/world_loader.v
+++ b/server/world/db/world_loader.v
@@ -10,10 +10,12 @@ pub fn load_named(worlds_dir string, name string, generator_name string, dim wor
 	mut resolved_generator := generator_name
 	mut resolved_dim := dim
 	mut resolved_seed := i64(0)
+	mut resolved_spawn := ?world.SpawnPoint(none)
 	if meta := read_world_meta(full) {
 		resolved_generator = meta.generator
 		resolved_dim = world.dimension_by_id(meta.dimension) or { dim }
 		resolved_seed = meta.seed
+		resolved_spawn = meta.spawn_point
 	} else {
 		if err !is NoWorldMeta {
 			return err
@@ -23,6 +25,7 @@ pub fn load_named(worlds_dir string, name string, generator_name string, dim wor
 	store := open_world(path, resolved_dim)!
 	mut w := new_world(name, store, resolved_generator, resolved_dim)
 	w.seed = resolved_seed
+	w.spawn_point = resolved_spawn
 	w.load()
 	return w
 }

--- a/server/world/db/world_meta.v
+++ b/server/world/db/world_meta.v
@@ -10,9 +10,10 @@ const meta_filename = 'meta.txt'
 // dimension it belongs to and the seed that generator was given.
 // world instead.
 struct WorldMeta {
-	generator string
-	dimension int
-	seed      i64
+	generator   string
+	dimension   int
+	seed        i64
+	spawn_point ?world.SpawnPoint
 }
 
 // NoWorldMeta is a world with no meta file, one made before metadata was
@@ -26,10 +27,10 @@ fn (e NoWorldMeta) msg() string {
 	return 'the world has no ${meta_filename}'
 }
 
-// write_world_meta persists generator/dim/seed next to a world's LevelDB
-// folders. Called once at creation time.
-fn write_world_meta(dir string, generator string, dim world.Dimension, seed i64) ! {
-	content := 'generator: ${generator}\ndimension: ${dim.id}\nseed: ${seed}\n'
+// write_world_meta persists generator/dim/seed/spawn next to a world's
+// LevelDB folders. Called once at creation time.
+fn write_world_meta(dir string, generator string, dim world.Dimension, seed i64, spawn_point world.SpawnPoint) ! {
+	content := 'generator: ${generator}\ndimension: ${dim.id}\nseed: ${seed}\nspawn: ${spawn_point.x} ${spawn_point.y} ${spawn_point.z}\n'
 	os.write_file(os.join_path(dir, meta_filename), content)!
 }
 
@@ -37,7 +38,8 @@ fn write_world_meta(dir string, generator string, dim world.Dimension, seed i64)
 // line was written before seeds existed and means seed 0, the terrain that
 // world was always generated with. Only a missing file is NoWorldMeta: one
 // that can't be read or names no generator is an error since falling back
-// would load a seeded world as seed 0.
+// would load a seeded world as seed 0. A file without a spawn line is a world
+// from before spawns were stored, whose generator is asked instead.
 fn read_world_meta(dir string) !WorldMeta {
 	path := os.join_path(dir, meta_filename)
 	if !os.exists(path) {
@@ -47,6 +49,7 @@ fn read_world_meta(dir string) !WorldMeta {
 	mut generator := ''
 	mut dimension := 0
 	mut seed := i64(0)
+	mut spawn_point := ?world.SpawnPoint(none)
 	for raw_line in content.split_into_lines() {
 		line := raw_line.trim_space()
 		idx := line.index(': ') or { continue }
@@ -64,6 +67,11 @@ fn read_world_meta(dir string) !WorldMeta {
 					return error('${meta_filename} in ${dir} has a seed that is not a number: "${value}"')
 				}
 			}
+			'spawn' {
+				spawn_point = parse_spawn(value) or {
+					return error('${meta_filename} in ${dir} has a spawn that is not three whole numbers: "${value}"')
+				}
+			}
 			else {}
 		}
 	}
@@ -71,8 +79,21 @@ fn read_world_meta(dir string) !WorldMeta {
 		return error('${path} names no generator')
 	}
 	return WorldMeta{
-		generator: generator
-		dimension: dimension
-		seed:      seed
+		generator:   generator
+		dimension:   dimension
+		seed:        seed
+		spawn_point: spawn_point
+	}
+}
+
+fn parse_spawn(value string) !world.SpawnPoint {
+	parts := value.split(' ').filter(it != '')
+	if parts.len != 3 {
+		return error('expected x y z')
+	}
+	return world.SpawnPoint{
+		x: strconv.atoi(parts[0])!
+		y: strconv.atoi(parts[1])!
+		z: strconv.atoi(parts[2])!
 	}
 }

--- a/server/world/db/world_meta.v
+++ b/server/world/db/world_meta.v
@@ -31,7 +31,9 @@ fn (e NoWorldMeta) msg() string {
 // LevelDB folders. Called once at creation time.
 fn write_world_meta(dir string, generator string, dim world.Dimension, seed i64, spawn_point world.SpawnPoint) ! {
 	content := 'generator: ${generator}\ndimension: ${dim.id}\nseed: ${seed}\nspawn: ${spawn_point.x} ${spawn_point.y} ${spawn_point.z}\n'
-	os.write_file(os.join_path(dir, meta_filename), content)!
+	path := os.join_path(dir, meta_filename)
+	os.write_file(path + '.tmp', content)!
+	os.rename(path + '.tmp', path)!
 }
 
 // read_world_meta reads a previously written meta file. A file without a seed

--- a/server/world/db/world_meta.v
+++ b/server/world/db/world_meta.v
@@ -35,9 +35,15 @@ fn write_world_meta(dir string, generator string, dim world.Dimension, seed i64)
 
 // read_world_meta reads a previously written meta file. A file without a seed
 // line was written before seeds existed and means seed 0, the terrain that
-// world was always generated with.
+// world was always generated with. Only a missing file is NoWorldMeta: one
+// that can't be read or names no generator is an error since falling back
+// would load a seeded world as seed 0.
 fn read_world_meta(dir string) !WorldMeta {
-	content := os.read_file(os.join_path(dir, meta_filename)) or { return NoWorldMeta{} }
+	path := os.join_path(dir, meta_filename)
+	if !os.exists(path) {
+		return NoWorldMeta{}
+	}
+	content := os.read_file(path) or { return error('cannot read ${path}: ${err.msg()}') }
 	mut generator := ''
 	mut dimension := 0
 	mut seed := i64(0)
@@ -62,7 +68,7 @@ fn read_world_meta(dir string) !WorldMeta {
 		}
 	}
 	if generator == '' {
-		return NoWorldMeta{}
+		return error('${path} names no generator')
 	}
 	return WorldMeta{
 		generator: generator

--- a/server/world/db/world_meta.v
+++ b/server/world/db/world_meta.v
@@ -1,49 +1,72 @@
 module db
 
 import os
+import strconv
 import server.world
 
 const meta_filename = 'meta.txt'
 
-// WorldMeta is a world's persisted identity which generator built it and
-// which dimension it belongs to. Restoring these correctly on load is the
-// whole point of this file: without it, a reloaded nether/end world would
-// silently come back as an overworld-shaped world instead.
+// WorldMeta is a world's persisted identity: which generator built it, which
+// dimension it belongs to and the seed that generator was given.
+// world instead.
 struct WorldMeta {
 	generator string
 	dimension int
+	seed      i64
 }
 
-// write_world_meta persists generator/dim next to a world's LevelDB folders.
-// Called once, at creation time.
-fn write_world_meta(dir string, generator string, dim world.Dimension) ! {
-	content := 'generator: ${generator}\ndimension: ${dim.id}\n'
+// NoWorldMeta is a world with no meta file, one made before metadata was
+// persisted. Callers fall back to their own defaults and seed 0, so such a
+// world keeps loading exactly as it did before.
+struct NoWorldMeta {
+	Error
+}
+
+fn (e NoWorldMeta) msg() string {
+	return 'the world has no ${meta_filename}'
+}
+
+// write_world_meta persists generator/dim/seed next to a world's LevelDB
+// folders. Called once at creation time.
+fn write_world_meta(dir string, generator string, dim world.Dimension, seed i64) ! {
+	content := 'generator: ${generator}\ndimension: ${dim.id}\nseed: ${seed}\n'
 	os.write_file(os.join_path(dir, meta_filename), content)!
 }
 
-// read_world_meta reads a previously written meta file or none if the world
-// predates metadata persistence. Callers fall back to their own defaults in
-// that case, so an existing world keeps loading exactly as it did before.
-fn read_world_meta(dir string) ?WorldMeta {
-	content := os.read_file(os.join_path(dir, meta_filename)) or { return none }
+// read_world_meta reads a previously written meta file. A file without a seed
+// line was written before seeds existed and means seed 0, the terrain that
+// world was always generated with.
+fn read_world_meta(dir string) !WorldMeta {
+	content := os.read_file(os.join_path(dir, meta_filename)) or { return NoWorldMeta{} }
 	mut generator := ''
 	mut dimension := 0
+	mut seed := i64(0)
 	for raw_line in content.split_into_lines() {
 		line := raw_line.trim_space()
 		idx := line.index(': ') or { continue }
 		key := line[..idx].trim_space()
 		value := line[idx + 2..].trim_space()
 		match key {
-			'generator' { generator = value }
-			'dimension' { dimension = value.int() }
+			'generator' {
+				generator = value
+			}
+			'dimension' {
+				dimension = value.int()
+			}
+			'seed' {
+				seed = strconv.parse_int(value, 10, 64) or {
+					return error('${meta_filename} in ${dir} has a seed that is not a number: "${value}"')
+				}
+			}
 			else {}
 		}
 	}
 	if generator == '' {
-		return none
+		return NoWorldMeta{}
 	}
 	return WorldMeta{
 		generator: generator
 		dimension: dimension
+		seed:      seed
 	}
 }

--- a/server/world/db/world_meta_test.v
+++ b/server/world/db/world_meta_test.v
@@ -17,7 +17,9 @@ fn test_create_world_store_persists_meta_and_load_named_restores_it() {
 	}
 	name := 'nether_meta_test'
 
-	mut store := create_world_store(dir, name, world.nether, 'nether', 1) or { panic(err) }
+	mut store := create_world_store(dir, name, world.nether, 'nether', 1, world.SpawnPoint{ y: 64 }) or {
+		panic(err)
+	}
 	store.close() or { panic(err) }
 
 	mut loaded := load_named(dir, name, 'flat', world.overworld) or { panic(err) }
@@ -33,7 +35,9 @@ fn test_create_world_store_persists_end_dimension() {
 	}
 	name := 'end_meta_test'
 
-	mut store := create_world_store(dir, name, world.the_end, 'end', 1) or { panic(err) }
+	mut store := create_world_store(dir, name, world.the_end, 'end', 1, world.SpawnPoint{ y: 4 }) or {
+		panic(err)
+	}
 	store.close() or { panic(err) }
 
 	mut loaded := load_named(dir, name, 'flat', world.overworld) or { panic(err) }
@@ -66,13 +70,20 @@ fn test_a_world_keeps_the_seed_it_was_created_with() {
 	defer {
 		os.rmdir_all(dir) or {}
 	}
-	mut store := create_world_store(dir, 'seeded', world.overworld, 'normal', -1234567890123) or {
+	mut store := create_world_store(dir, 'seeded', world.overworld, 'normal', -1234567890123,
+		world.SpawnPoint{ x: -40, y: 70, z: 12 }) or {
 		panic(err)
 	}
 	store.close() or { panic(err) }
 
 	mut loaded := load_named(dir, 'seeded', 'flat', world.overworld) or { panic(err) }
 	assert loaded.seed == -1234567890123
+	stored := loaded.spawn_point or { panic('the spawn was not kept') }
+	assert stored == world.SpawnPoint{
+		x: -40
+		y: 70
+		z: 12
+	}
 	loaded.close() or { panic(err) }
 }
 

--- a/server/world/db/world_meta_test.v
+++ b/server/world/db/world_meta_test.v
@@ -17,7 +17,7 @@ fn test_create_world_store_persists_meta_and_load_named_restores_it() {
 	}
 	name := 'nether_meta_test'
 
-	mut store := create_world_store(dir, name, world.nether, 'nether') or { panic(err) }
+	mut store := create_world_store(dir, name, world.nether, 'nether', 1) or { panic(err) }
 	store.close() or { panic(err) }
 
 	mut loaded := load_named(dir, name, 'flat', world.overworld) or { panic(err) }
@@ -33,7 +33,7 @@ fn test_create_world_store_persists_end_dimension() {
 	}
 	name := 'end_meta_test'
 
-	mut store := create_world_store(dir, name, world.the_end, 'end') or { panic(err) }
+	mut store := create_world_store(dir, name, world.the_end, 'end', 1) or { panic(err) }
 	store.close() or { panic(err) }
 
 	mut loaded := load_named(dir, name, 'flat', world.overworld) or { panic(err) }
@@ -57,5 +57,53 @@ fn test_load_named_falls_back_when_meta_file_is_absent() {
 	mut loaded := load_named(dir, name, 'flat', world.overworld) or { panic(err) }
 	assert loaded.dimension.id == world.overworld.id
 	assert loaded.generator_name == 'flat'
+	assert loaded.seed == 0
 	loaded.close() or { panic(err) }
+}
+
+fn test_a_world_keeps_the_seed_it_was_created_with() {
+	dir := meta_test_worlds_dir()
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	mut store := create_world_store(dir, 'seeded', world.overworld, 'normal', -1234567890123) or {
+		panic(err)
+	}
+	store.close() or { panic(err) }
+
+	mut loaded := load_named(dir, 'seeded', 'flat', world.overworld) or { panic(err) }
+	assert loaded.seed == -1234567890123
+	loaded.close() or { panic(err) }
+}
+
+fn test_a_meta_file_from_before_seeds_means_seed_zero() {
+	dir := meta_test_worlds_dir()
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	full := os.join_path(dir, 'pre_seed')
+	os.mkdir_all(full) or { panic(err) }
+	os.write_file(os.join_path(full, meta_filename), 'generator: normal\ndimension: 0\n') or {
+		panic(err)
+	}
+
+	mut loaded := load_named(dir, 'pre_seed', 'flat', world.overworld) or { panic(err) }
+	assert loaded.generator_name == 'normal'
+	assert loaded.seed == 0
+	loaded.close() or { panic(err) }
+}
+
+fn test_a_seed_that_is_not_a_number_is_an_error_rather_than_seed_zero() {
+	dir := meta_test_worlds_dir()
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	full := os.join_path(dir, 'bad_seed')
+	os.mkdir_all(full) or { panic(err) }
+	os.write_file(os.join_path(full, meta_filename), 'generator: normal\ndimension: 0\nseed: banana\n') or {
+		panic(err)
+	}
+
+	load_named(dir, 'bad_seed', 'flat', world.overworld) or { return }
+	assert false, 'a world whose seed could not be read was loaded'
 }

--- a/server/world/db/world_meta_test.v
+++ b/server/world/db/world_meta_test.v
@@ -107,3 +107,28 @@ fn test_a_seed_that_is_not_a_number_is_an_error_rather_than_seed_zero() {
 	load_named(dir, 'bad_seed', 'flat', world.overworld) or { return }
 	assert false, 'a world whose seed could not be read was loaded'
 }
+
+fn test_a_meta_file_that_cannot_be_read_is_an_error() {
+	dir := meta_test_worlds_dir()
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	full := os.join_path(dir, 'unreadable')
+	os.mkdir_all(os.join_path(full, meta_filename)) or { panic(err) }
+
+	load_named(dir, 'unreadable', 'flat', world.overworld) or { return }
+	assert false, 'a world whose meta file could not be read was loaded'
+}
+
+fn test_a_meta_file_naming_no_generator_is_an_error() {
+	dir := meta_test_worlds_dir()
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	full := os.join_path(dir, 'no_generator')
+	os.mkdir_all(full) or { panic(err) }
+	os.write_file(os.join_path(full, meta_filename), 'dimension: 0\nseed: 5\n') or { panic(err) }
+
+	load_named(dir, 'no_generator', 'flat', world.overworld) or { return }
+	assert false, 'a world whose meta file names no generator was loaded'
+}

--- a/server/world/generator.v
+++ b/server/world/generator.v
@@ -1,7 +1,20 @@
 module world
 
+import rand
+
+// SpawnPoint is where a player new to a world arrives: the block their feet
+// are in.
+pub struct SpawnPoint {
+pub:
+	x int
+	y int
+	z int
+}
+
 pub interface Generator {
-	spawn_y() int
+	// spawn_point picks the column as well as the height since the generator
+	// is what knows where its dry land is.
+	spawn_point() SpawnPoint
 	uses_blocks() bool
 	generate(chunk_x int, chunk_z int) Chunk
 	block_at(x int, y int, z int) int
@@ -60,11 +73,14 @@ const density_grid_xz = 5
 const density_grid_y = 17
 
 pub struct NetherGenerator {
-	dim Dimension = nether
+	dim  Dimension = nether
+	seed i64
 }
 
-pub fn (g NetherGenerator) spawn_y() int {
-	return safe_spawn_y(g, g.dim, 0, 0, nether_spawn_floor_y + 1)
+pub fn (g NetherGenerator) spawn_point() SpawnPoint {
+	return SpawnPoint{
+		y: safe_spawn_y(g, g.dim, 0, 0, nether_spawn_floor_y + 1)
+	}
 }
 
 pub fn (g NetherGenerator) uses_blocks() bool {
@@ -92,7 +108,7 @@ fn (g NetherGenerator) floor_bedrock_at(x int, y int, z int) bool {
 		return false
 	}
 	threshold := 0.70 - f64(y - g.dim.min_y) * 0.13
-	return hash3_unit(x, y, z, nether_floor_salt + 17) < threshold
+	return hash3_unit(x, y, z, (nether_floor_salt + 17) ^ seed_mask(g.seed)) < threshold
 }
 
 fn (g NetherGenerator) roof_bedrock_at(x int, y int, z int) bool {
@@ -104,7 +120,7 @@ fn (g NetherGenerator) roof_bedrock_at(x int, y int, z int) bool {
 		return false
 	}
 	threshold := 0.28 + f64(y - (roof_y - 4)) * 0.12
-	return hash3_unit(x, y, z, nether_ceiling_salt + 29) < threshold
+	return hash3_unit(x, y, z, (nether_ceiling_salt + 29) ^ seed_mask(g.seed)) < threshold
 }
 
 fn f64_clamp(v f64, min f64, max f64) f64 {
@@ -126,8 +142,9 @@ fn density_grid_index(gx int, gy int, gz int) int {
 }
 
 fn (g NetherGenerator) density_at(x int, y int, z int) f64 {
-	main := (fbm3d(f64(x) / 38.0, f64(y) / 28.0, f64(z) / 38.0, nether_density_salt, 4) - 0.5) * 2.0
-	detail := (fbm3d(f64(x) / 16.0, f64(y) / 14.0, f64(z) / 16.0, nether_detail_salt, 2) - 0.5) * 0.65
+	mask := seed_mask(g.seed)
+	main := (fbm3d(f64(x) / 38.0, f64(y) / 28.0, f64(z) / 38.0, nether_density_salt ^ mask, 4) - 0.5) * 2.0
+	detail := (fbm3d(f64(x) / 16.0, f64(y) / 14.0, f64(z) / 16.0, nether_detail_salt ^ mask, 2) - 0.5) * 0.65
 	lower := f64_clamp((38.0 - f64(y)) / 28.0, 0.0, 1.0) * 1.35
 	upper := f64_clamp((f64(y) - 82.0) / 32.0, 0.0, 1.0) * 1.35
 	middle_open := 0.22 + f64_clamp((f64(y) - 38.0) / 26.0, 0.0, 1.0) * 0.10
@@ -249,7 +266,7 @@ fn (g NetherGenerator) raw_block_at(x int, y int, z int) int {
 }
 
 fn (g NetherGenerator) surface_patch_at(x int, y int, z int) int {
-	n := hash3_unit(x / 2, y / 2, z / 2, nether_surface_salt)
+	n := hash3_unit(x / 2, y / 2, z / 2, nether_surface_salt ^ seed_mask(g.seed))
 	if y >= nether_lava_level - 1 && y <= nether_lava_level + 4 && n > 0.62 {
 		return soul_sand.network_id
 	}
@@ -273,7 +290,7 @@ fn (g NetherGenerator) glowstone_at_raw(x int, y int, z int, raw int, above int)
 		|| above == air.network_id {
 		return false
 	}
-	return hash3_unit(x / 2, y / 2, z / 2, nether_glowstone_salt) > 0.965
+	return hash3_unit(x / 2, y / 2, z / 2, nether_glowstone_salt ^ seed_mask(g.seed)) > 0.965
 }
 
 fn (g NetherGenerator) decorate_nether_raw(x int, y int, z int, raw int, above int) int {
@@ -344,15 +361,18 @@ const end_island_salt = u32(601)
 const end_hill_salt = u32(619)
 
 pub struct EndGenerator {
-	dim Dimension = the_end
+	dim  Dimension = the_end
+	seed i64
 }
 
 fn (g EndGenerator) layers() []Block {
 	return [bedrock, end_stone, end_stone, end_stone]
 }
 
-pub fn (g EndGenerator) spawn_y() int {
-	return g.dim.min_y + g.layers().len
+pub fn (g EndGenerator) spawn_point() SpawnPoint {
+	return SpawnPoint{
+		y: g.dim.min_y + g.layers().len
+	}
 }
 
 pub fn (g EndGenerator) uses_blocks() bool {
@@ -361,7 +381,8 @@ pub fn (g EndGenerator) uses_blocks() bool {
 
 fn (g EndGenerator) island_top_y(x int, z int) ?int {
 	dist := dist2d(x, z)
-	edge_noise := (fbm2d(f64(x) / 40.0, f64(z) / 40.0, end_island_salt, 3) - 0.5) * 2.0 * end_edge_jitter
+	mask := seed_mask(g.seed)
+	edge_noise := (fbm2d(f64(x) / 40.0, f64(z) / 40.0, end_island_salt ^ mask, 3) - 0.5) * 2.0 * end_edge_jitter
 	effective_radius := end_island_radius + edge_noise
 	if dist > effective_radius {
 		return none
@@ -371,7 +392,7 @@ fn (g EndGenerator) island_top_y(x int, z int) ?int {
 	if falloff < 0 {
 		falloff = 0
 	}
-	hill_noise := fbm2d(f64(x) / 30.0, f64(z) / 30.0, end_hill_salt, 3)
+	hill_noise := fbm2d(f64(x) / 30.0, f64(z) / 30.0, end_hill_salt ^ mask, 3)
 	extra := int(hill_noise * end_hill_amplitude * falloff)
 	return floor_top + extra
 }
@@ -442,9 +463,28 @@ pub fn new_generator(name string) Generator {
 	return g
 }
 
-// GeneratorFactory builds a fresh Generator sized for dim. Each lookup gets
+// GeneratorOptions is what a registered generator is built from for one
+// world: the dimension it is sized for and that world's seed.
+@[params]
+pub struct GeneratorOptions {
+pub:
+	dim  Dimension = overworld
+	seed i64
+}
+
+// new_world_seed picks the seed a new world is generated from. Never 0, which
+// is the seed of worlds made before seeds existed.
+pub fn new_world_seed() i64 {
+	mut seed := rand.i64()
+	for seed == 0 {
+		seed = rand.i64()
+	}
+	return seed
+}
+
+// GeneratorFactory builds a fresh Generator for one world. Each lookup gets
 // its own instance, mirroring entity.Registry's BehaviourFactory.
-pub type GeneratorFactory = fn (dim Dimension) Generator
+pub type GeneratorFactory = fn (opts GeneratorOptions) Generator
 
 pub struct GeneratorRegistry {
 mut:
@@ -453,29 +493,32 @@ mut:
 
 pub fn new_generator_registry() GeneratorRegistry {
 	mut r := GeneratorRegistry{}
-	r.register('void', fn (dim Dimension) Generator {
+	r.register('void', fn (opts GeneratorOptions) Generator {
 		return VoidGenerator{
-			dim: dim
+			dim: opts.dim
 		}
 	})
-	r.register('flat', fn (dim Dimension) Generator {
+	r.register('flat', fn (opts GeneratorOptions) Generator {
 		return FlatGenerator{
-			dim: dim
+			dim: opts.dim
 		}
 	})
-	r.register('normal', fn (dim Dimension) Generator {
+	r.register('normal', fn (opts GeneratorOptions) Generator {
 		return NormalGenerator{
-			dim: dim
+			dim:  opts.dim
+			seed: opts.seed
 		}
 	})
-	r.register('nether', fn (dim Dimension) Generator {
+	r.register('nether', fn (opts GeneratorOptions) Generator {
 		return NetherGenerator{
-			dim: dim
+			dim:  opts.dim
+			seed: opts.seed
 		}
 	})
-	r.register('end', fn (dim Dimension) Generator {
+	r.register('end', fn (opts GeneratorOptions) Generator {
 		return EndGenerator{
-			dim: dim
+			dim:  opts.dim
+			seed: opts.seed
 		}
 	})
 	return r
@@ -485,16 +528,16 @@ pub fn (mut r GeneratorRegistry) register(name string, factory GeneratorFactory)
 	r.factories[name.to_lower()] = factory
 }
 
-// create resolves name to a Generator sized for dim. An empty name or the
+// create resolves name to a Generator built from opts. An empty name or the
 // literal name "default" both mean "whatever this dimension's own default
 // generator is" (dim.default_generator - 'normal' for overworld, 'nether' for
 // nether, 'end' for end), so callers (e.g. /world create ... default) don't
 // need to know each dimension's concrete generator name.
-pub fn (r &GeneratorRegistry) create(name string, dim Dimension) ?Generator {
+pub fn (r &GeneratorRegistry) create(name string, opts GeneratorOptions) ?Generator {
 	lower := name.to_lower().trim_space()
-	resolved := if lower == '' || lower == 'default' { dim.default_generator } else { lower }
+	resolved := if lower == '' || lower == 'default' { opts.dim.default_generator } else { lower }
 	factory := r.factories[resolved.to_lower()] or { return none }
-	return factory(dim)
+	return factory(opts)
 }
 
 pub fn (r &GeneratorRegistry) names() []string {

--- a/server/world/generator.v
+++ b/server/world/generator.v
@@ -61,12 +61,12 @@ fn safe_spawn_y(g Generator, dim Dimension, x int, z int, preferred int) int {
 // Extra nether biomes, structures, netherite and portals are out of scope.
 pub const nether_lava_level = 31
 const nether_spawn_floor_y = 63
-const nether_floor_salt = u32(401)
-const nether_ceiling_salt = u32(409)
-const nether_density_salt = u32(419)
-const nether_detail_salt = u32(421)
-const nether_surface_salt = u32(431)
-const nether_glowstone_salt = u32(457)
+const nether_floor_salt = u64(401)
+const nether_ceiling_salt = u64(409)
+const nether_density_salt = u64(419)
+const nether_detail_salt = u64(421)
+const nether_surface_salt = u64(431)
+const nether_glowstone_salt = u64(457)
 const density_cell_xz = 4
 const density_cell_y = 8
 const density_grid_xz = 5
@@ -357,8 +357,8 @@ const end_platform_size = 5
 const end_island_radius = 96.0
 const end_edge_jitter = 10.0
 const end_hill_amplitude = 8.0
-const end_island_salt = u32(601)
-const end_hill_salt = u32(619)
+const end_island_salt = u64(601)
+const end_hill_salt = u64(619)
 
 pub struct EndGenerator {
 	dim  Dimension = the_end

--- a/server/world/generator_flat.v
+++ b/server/world/generator_flat.v
@@ -31,8 +31,10 @@ fn (g FlatGenerator) layers() []Block {
 	return [bedrock, dirt, dirt, grass_block]
 }
 
-pub fn (g FlatGenerator) spawn_y() int {
-	return safe_spawn_y(g, g.dim, 0, 0, g.dim.min_y + g.layers().len)
+pub fn (g FlatGenerator) spawn_point() SpawnPoint {
+	return SpawnPoint{
+		y: safe_spawn_y(g, g.dim, 0, 0, g.dim.min_y + g.layers().len)
+	}
 }
 
 pub fn (g FlatGenerator) uses_blocks() bool {

--- a/server/world/generator_normal.v
+++ b/server/world/generator_normal.v
@@ -405,23 +405,16 @@ pub fn (g NormalGenerator) block_at(x int, y int, z int) int {
 }
 
 // A world from before seeds spawns where it always has, over the origin. A
-// seeded one can have ocean there, so it looks outward ring by ring for the
-// nearest dry land, as far as the rings reach.
-const normal_spawn_search_step = 16
+// seeded one can have ocean there, so it looks outward chunk by chunk, ring by
+// ring, for the nearest dry land.
 const normal_spawn_search_rings = 64
 
 pub fn (g NormalGenerator) spawn_point() SpawnPoint {
 	if g.seed != 0 {
 		for ring in 0 .. normal_spawn_search_rings + 1 {
 			for pos in spawn_ring(ring) {
-				x := pos[0] * normal_spawn_search_step
-				z := pos[1] * normal_spawn_search_step
-				if y := g.dry_land_y(x, z) {
-					return SpawnPoint{
-						x: x
-						y: y
-						z: z
-					}
+				if p := g.spawn_in_chunk(pos[0], pos[1]) {
+					return p
 				}
 			}
 		}
@@ -431,20 +424,38 @@ pub fn (g NormalGenerator) spawn_point() SpawnPoint {
 	}
 }
 
-// dry_land_y is the height a player stands at on column x, z or none when
-// the column is under water. The biome is asked first: it is far cheaper than
-// building the column and rules out oceans and rivers on its own.
-fn (g NormalGenerator) dry_land_y(x int, z int) ?int {
-	biome := g.biome_at(x, z)
+// spawn_in_chunk is the first column of chunk cx, cz a player can stand on in
+// the chunk generate makes. column_ids leaves out trees and skips generate's
+// interpolation, so it can put a player inside a trunk or off the ground.
+fn (g NormalGenerator) spawn_in_chunk(cx int, cz int) ?SpawnPoint {
+	biome := g.biome_at(cx * 16 + 7, cz * 16 + 7)
 	if biome == biome_ocean || biome == biome_river {
 		return none
 	}
-	ids := g.column_ids(x, z)
-	top := column_top(ids)
-	if top <= 0 || !spawn_floor_solid(ids[top]) {
-		return none
+	c := g.generate(cx, cz)
+	for lx in 0 .. 16 {
+		for lz in 0 .. 16 {
+			mut top := normal_terrain_height - 1
+			for top > 0 && c.block_id(lx, top, lz) == air.network_id {
+				top--
+			}
+			if top > 0 && spawn_floor(c.block_id(lx, top, lz)) {
+				return SpawnPoint{
+					x: cx * 16 + lx
+					y: top + 1
+					z: cz * 16 + lz
+				}
+			}
+		}
 	}
-	return top + 1
+	return none
+}
+
+// spawn_floor is ground a new player may be put on: solid, dry and not part
+// of a tree.
+fn spawn_floor(id int) bool {
+	return spawn_floor_solid(id) && id != oak_leaves.network_id && id != spruce_leaves.network_id
+		&& id != oak_log.network_id && id != spruce_log.network_id
 }
 
 // column_top is the highest block of a column that isn't air.

--- a/server/world/generator_normal.v
+++ b/server/world/generator_normal.v
@@ -21,15 +21,15 @@ const normal_terrain_scale = 32.0
 const normal_climate_scale = 512.0
 const normal_climate_persistence = 0.0625
 
-const normal_terrain_salt = u32(3)
-const normal_temperature_salt = u32(5)
-const normal_rainfall_salt = u32(7)
+const normal_terrain_salt = u64(3)
+const normal_temperature_salt = u64(5)
+const normal_rainfall_salt = u64(7)
 
 // cave carving — two overlapping noise fields ("spaghetti") plus a separate
 // wider field ("cheese") cut open cavities of different shapes.
-const normal_cave_spaghetti_salt_a = u32(11)
-const normal_cave_spaghetti_salt_b = u32(13)
-const normal_cave_cheese_salt = u32(17)
+const normal_cave_spaghetti_salt_a = u64(11)
+const normal_cave_spaghetti_salt_b = u64(13)
+const normal_cave_cheese_salt = u64(17)
 const normal_cave_scale = 48.0
 const normal_cave_cheese_scale = 64.0
 const normal_cave_spaghetti_threshold = 0.03
@@ -62,7 +62,7 @@ pub fn (g NormalGenerator) uses_blocks() bool {
 
 // ---- biome map ----
 
-fn normal_climate(x int, z int, salt u32) f64 {
+fn normal_climate(x int, z int, salt u64) f64 {
 	return fbm2d_persist(f64(x) / normal_climate_scale, f64(z) / normal_climate_scale, salt, 2,
 		normal_climate_persistence)
 }
@@ -106,7 +106,7 @@ fn normal_biome_lookup(temperature f64, rainfall f64) int {
 
 // select_biome quantises the climate noise into a fixed lookup grid so the
 // biome map has flat plateaus rather than a different result for every block.
-fn normal_select_biome(x int, z int, mask u32) int {
+fn normal_select_biome(x int, z int, mask u64) int {
 	temperature := int(normal_climate(x, z, normal_temperature_salt ^ mask) * f64(normal_biome_buckets - 1))
 	rainfall := int(normal_climate(x, z, normal_rainfall_salt ^ mask) * f64(normal_biome_buckets - 1))
 	return normal_biome_lookup(f64(temperature) / f64(normal_biome_buckets - 1),
@@ -115,7 +115,7 @@ fn normal_select_biome(x int, z int, mask u32) int {
 
 // normal_biome_jitter breaks up the straight edges the quantised biome map
 // would otherwise produce by nudging the sample point by up to one block.
-fn normal_biome_jitter(x int, z int, mask u32) (int, int) {
+fn normal_biome_jitter(x int, z int, mask u64) (int, int) {
 	mut hash := i64(x) * 2345803 ^ i64(z) * 9236449 ^ i64(mask)
 	hash *= hash + 223
 	mut x_noise := int((hash >> 20) & 3)
@@ -532,7 +532,7 @@ pub fn (g NormalGenerator) generate(chunk_x int, chunk_z int) Chunk {
 // cheese pass opens up wide chambers where the noise is high enough. Blocks
 // below the lava level get filled with lava, blocks between the lava level
 // and the water height get filled with water when adjacent to water above.
-fn carve_caves(mut c Chunk, chunk_x int, chunk_z int, mask u32) {
+fn carve_caves(mut c Chunk, chunk_x int, chunk_z int, mask u64) {
 	base_x := chunk_x * 16
 	base_z := chunk_z * 16
 	for x in 0 .. 16 {
@@ -585,7 +585,7 @@ fn carve_caves(mut c Chunk, chunk_x int, chunk_z int, mask u32) {
 // ---- populators ----
 
 fn (g NormalGenerator) populate(mut c Chunk, chunk_x int, chunk_z int) {
-	mut r := new_random(u32(0xdeadbeef) ^ (u32(chunk_x) << 8) ^ u32(chunk_z) ^ seed_mask(g.seed))
+	mut r := new_random_wide(u64(u32(0xdeadbeef) ^ (u32(chunk_x) << 8) ^ u32(chunk_z)) ^ seed_mask(g.seed))
 	biome := c.biome_id(7, 7)
 
 	for t in normal_ore_types() {

--- a/server/world/generator_normal.v
+++ b/server/world/generator_normal.v
@@ -52,7 +52,8 @@ struct TreeSpec {
 }
 
 pub struct NormalGenerator {
-	dim Dimension = overworld
+	dim  Dimension = overworld
+	seed i64
 }
 
 pub fn (g NormalGenerator) uses_blocks() bool {
@@ -105,17 +106,17 @@ fn normal_biome_lookup(temperature f64, rainfall f64) int {
 
 // select_biome quantises the climate noise into a fixed lookup grid so the
 // biome map has flat plateaus rather than a different result for every block.
-fn normal_select_biome(x int, z int) int {
-	temperature := int(normal_climate(x, z, normal_temperature_salt) * f64(normal_biome_buckets - 1))
-	rainfall := int(normal_climate(x, z, normal_rainfall_salt) * f64(normal_biome_buckets - 1))
+fn normal_select_biome(x int, z int, mask u32) int {
+	temperature := int(normal_climate(x, z, normal_temperature_salt ^ mask) * f64(normal_biome_buckets - 1))
+	rainfall := int(normal_climate(x, z, normal_rainfall_salt ^ mask) * f64(normal_biome_buckets - 1))
 	return normal_biome_lookup(f64(temperature) / f64(normal_biome_buckets - 1),
 		f64(rainfall) / f64(normal_biome_buckets - 1))
 }
 
 // normal_biome_jitter breaks up the straight edges the quantised biome map
 // would otherwise produce by nudging the sample point by up to one block.
-fn normal_biome_jitter(x int, z int) (int, int) {
-	mut hash := i64(x) * 2345803 ^ i64(z) * 9236449
+fn normal_biome_jitter(x int, z int, mask u32) (int, int) {
+	mut hash := i64(x) * 2345803 ^ i64(z) * 9236449 ^ i64(mask)
 	hash *= hash + 223
 	mut x_noise := int((hash >> 20) & 3)
 	mut z_noise := int((hash >> 22) & 3)
@@ -129,8 +130,9 @@ fn normal_biome_jitter(x int, z int) (int, int) {
 }
 
 pub fn (g NormalGenerator) biome_at(x int, z int) int {
-	dx, dz := normal_biome_jitter(x, z)
-	return normal_select_biome(x + dx, z + dz)
+	mask := seed_mask(g.seed)
+	dx, dz := normal_biome_jitter(x, z, mask)
+	return normal_select_biome(x + dx, z + dz, mask)
 }
 
 fn normal_elevation(biome int) (int, int) {
@@ -278,7 +280,7 @@ fn (g NormalGenerator) smoothed_elevation(x int, z int) (f64, f64) {
 
 fn (g NormalGenerator) terrain_noise(x int, y int, z int) f64 {
 	n := fbm3d_persist(f64(x) / normal_terrain_scale, f64(y) / normal_terrain_scale,
-		f64(z) / normal_terrain_scale, normal_terrain_salt, 4, normal_terrain_persistence)
+		f64(z) / normal_terrain_scale, normal_terrain_salt ^ seed_mask(g.seed), 4, normal_terrain_persistence)
 	return (n - 0.5) * 2.0 * normal_terrain_amplitude
 }
 
@@ -360,6 +362,7 @@ fn (g NormalGenerator) column_ids(x int, z int) []int {
 	}
 	apply_ground_cover(mut ids, ids.len, normal_ground_cover(g.biome_at(x, z)))
 	// carve the same way generate() does so single block lookups stay consistent
+	mask := seed_mask(g.seed)
 	for y := 1; y < normal_terrain_height - 1; y++ {
 		if ids[y] != stone.network_id && ids[y] != dirt.network_id && ids[y] != gravel.network_id {
 			continue
@@ -367,13 +370,13 @@ fn (g NormalGenerator) column_ids(x int, z int) []int {
 		sx := f64(x) / normal_cave_scale
 		sy := f64(y) / normal_cave_scale
 		sz := f64(z) / normal_cave_scale
-		na := fbm3d(sx, sy, sz, normal_cave_spaghetti_salt_a, 3) - 0.5
-		nb := fbm3d(sx, sy, sz, normal_cave_spaghetti_salt_b, 3) - 0.5
+		na := fbm3d(sx, sy, sz, normal_cave_spaghetti_salt_a ^ mask, 3) - 0.5
+		nb := fbm3d(sx, sy, sz, normal_cave_spaghetti_salt_b ^ mask, 3) - 0.5
 		spaghetti := na * na + nb * nb < normal_cave_spaghetti_threshold
 		cx := f64(x) / normal_cave_cheese_scale
 		cy := f64(y) / normal_cave_cheese_scale
 		cz := f64(z) / normal_cave_cheese_scale
-		cheese := fbm3d(cx, cy, cz, normal_cave_cheese_salt, 2) > normal_cave_cheese_threshold
+		cheese := fbm3d(cx, cy, cz, normal_cave_cheese_salt ^ mask, 2) > normal_cave_cheese_threshold
 		if !spaghetti && !cheese {
 			continue
 		}
@@ -401,13 +404,74 @@ pub fn (g NormalGenerator) block_at(x int, y int, z int) int {
 	return g.column_ids(x, z)[y]
 }
 
-pub fn (g NormalGenerator) spawn_y() int {
-	ids := g.column_ids(0, 0)
+// A world from before seeds spawns where it always has, over the origin. A
+// seeded one can have ocean there, so it looks outward ring by ring for the
+// nearest dry land, as far as the rings reach.
+const normal_spawn_search_step = 16
+const normal_spawn_search_rings = 64
+
+pub fn (g NormalGenerator) spawn_point() SpawnPoint {
+	if g.seed != 0 {
+		for ring in 0 .. normal_spawn_search_rings + 1 {
+			for pos in spawn_ring(ring) {
+				x := pos[0] * normal_spawn_search_step
+				z := pos[1] * normal_spawn_search_step
+				if y := g.dry_land_y(x, z) {
+					return SpawnPoint{
+						x: x
+						y: y
+						z: z
+					}
+				}
+			}
+		}
+	}
+	return SpawnPoint{
+		y: safe_spawn_y(g, g.dim, 0, 0, column_top(g.column_ids(0, 0)) + 1)
+	}
+}
+
+// dry_land_y is the height a player stands at on column x, z or none when
+// the column is under water. The biome is asked first: it is far cheaper than
+// building the column and rules out oceans and rivers on its own.
+fn (g NormalGenerator) dry_land_y(x int, z int) ?int {
+	biome := g.biome_at(x, z)
+	if biome == biome_ocean || biome == biome_river {
+		return none
+	}
+	ids := g.column_ids(x, z)
+	top := column_top(ids)
+	if top <= 0 || !spawn_floor_solid(ids[top]) {
+		return none
+	}
+	return top + 1
+}
+
+// column_top is the highest block of a column that isn't air.
+fn column_top(ids []int) int {
 	mut top := ids.len - 1
 	for top > 0 && ids[top] == air.network_id {
 		top--
 	}
-	return safe_spawn_y(g, g.dim, 0, 0, top + 1)
+	return top
+}
+
+// spawn_ring lists the positions on the square ring ring steps out from the
+// origin.
+fn spawn_ring(ring int) [][]int {
+	if ring == 0 {
+		return [[0, 0]]
+	}
+	mut out := [][]int{cap: ring * 8}
+	for d in -ring .. ring + 1 {
+		out << [d, -ring]
+		out << [d, ring]
+	}
+	for d in -ring + 1 .. ring {
+		out << [-ring, d]
+		out << [ring, d]
+	}
+	return out
 }
 
 pub fn (g NormalGenerator) generate(chunk_x int, chunk_z int) Chunk {
@@ -458,7 +522,7 @@ pub fn (g NormalGenerator) generate(chunk_x int, chunk_z int) Chunk {
 		}
 	}
 
-	carve_caves(mut c, chunk_x, chunk_z)
+	carve_caves(mut c, chunk_x, chunk_z, seed_mask(g.seed))
 	g.populate(mut c, chunk_x, chunk_z)
 	return c
 }
@@ -468,7 +532,7 @@ pub fn (g NormalGenerator) generate(chunk_x int, chunk_z int) Chunk {
 // cheese pass opens up wide chambers where the noise is high enough. Blocks
 // below the lava level get filled with lava, blocks between the lava level
 // and the water height get filled with water when adjacent to water above.
-fn carve_caves(mut c Chunk, chunk_x int, chunk_z int) {
+fn carve_caves(mut c Chunk, chunk_x int, chunk_z int, mask u32) {
 	base_x := chunk_x * 16
 	base_z := chunk_z * 16
 	for x in 0 .. 16 {
@@ -484,14 +548,14 @@ fn carve_caves(mut c Chunk, chunk_x int, chunk_z int) {
 				sy := f64(y) / normal_cave_scale
 				sz := f64(wz) / normal_cave_scale
 
-				na := fbm3d(sx, sy, sz, normal_cave_spaghetti_salt_a, 3) - 0.5
-				nb := fbm3d(sx, sy, sz, normal_cave_spaghetti_salt_b, 3) - 0.5
+				na := fbm3d(sx, sy, sz, normal_cave_spaghetti_salt_a ^ mask, 3) - 0.5
+				nb := fbm3d(sx, sy, sz, normal_cave_spaghetti_salt_b ^ mask, 3) - 0.5
 				spaghetti := na * na + nb * nb < normal_cave_spaghetti_threshold
 
 				cx := f64(wx) / normal_cave_cheese_scale
 				cy := f64(y) / normal_cave_cheese_scale
 				cz := f64(wz) / normal_cave_cheese_scale
-				cheese := fbm3d(cx, cy, cz, normal_cave_cheese_salt, 2) > normal_cave_cheese_threshold
+				cheese := fbm3d(cx, cy, cz, normal_cave_cheese_salt ^ mask, 2) > normal_cave_cheese_threshold
 
 				if !spaghetti && !cheese {
 					continue
@@ -521,7 +585,7 @@ fn carve_caves(mut c Chunk, chunk_x int, chunk_z int) {
 // ---- populators ----
 
 fn (g NormalGenerator) populate(mut c Chunk, chunk_x int, chunk_z int) {
-	mut r := new_random(u32(0xdeadbeef) ^ (u32(chunk_x) << 8) ^ u32(chunk_z))
+	mut r := new_random(u32(0xdeadbeef) ^ (u32(chunk_x) << 8) ^ u32(chunk_z) ^ seed_mask(g.seed))
 	biome := c.biome_id(7, 7)
 
 	for t in normal_ore_types() {

--- a/server/world/generator_normal.v
+++ b/server/world/generator_normal.v
@@ -409,10 +409,29 @@ pub fn (g NormalGenerator) block_at(x int, y int, z int) int {
 // ring, for the nearest dry land.
 const normal_spawn_search_rings = 64
 
+// Every seed probed found land within five generated chunks. The cap only
+// bounds a pathological seed, which then spawns over the origin.
+const normal_spawn_search_chunks = 64
+
+// chunk_middle_is_water rules a chunk out of the spawn search before anything
+// is generated: the biome is far cheaper to ask than the chunk.
+fn (g NormalGenerator) chunk_middle_is_water(cx int, cz int) bool {
+	biome := g.biome_at(cx * 16 + 7, cz * 16 + 7)
+	return biome == biome_ocean || biome == biome_river
+}
+
 pub fn (g NormalGenerator) spawn_point() SpawnPoint {
 	if g.seed != 0 {
-		for ring in 0 .. normal_spawn_search_rings + 1 {
+		mut generated := 0
+		outer: for ring in 0 .. normal_spawn_search_rings + 1 {
 			for pos in spawn_ring(ring) {
+				if g.chunk_middle_is_water(pos[0], pos[1]) {
+					continue
+				}
+				if generated == normal_spawn_search_chunks {
+					break outer
+				}
+				generated++
 				if p := g.spawn_in_chunk(pos[0], pos[1]) {
 					return p
 				}
@@ -428,10 +447,6 @@ pub fn (g NormalGenerator) spawn_point() SpawnPoint {
 // the chunk generate makes. column_ids leaves out trees and skips generate's
 // interpolation, so it can put a player inside a trunk or off the ground.
 fn (g NormalGenerator) spawn_in_chunk(cx int, cz int) ?SpawnPoint {
-	biome := g.biome_at(cx * 16 + 7, cz * 16 + 7)
-	if biome == biome_ocean || biome == biome_river {
-		return none
-	}
 	c := g.generate(cx, cz)
 	for lx in 0 .. 16 {
 		for lz in 0 .. 16 {

--- a/server/world/generator_output_test.v
+++ b/server/world/generator_output_test.v
@@ -1,0 +1,91 @@
+module world
+
+import hash.fnv1a
+
+// A chunk nobody has edited is generated again every time its world loads, so
+// changing what a generator produces changes every existing world wherever
+// nothing has been built. These digests pin that output: one changes only when
+// the terrain is meant to.
+
+const pinned_chunks = [[0, 0], [1, -1], [-3, 2], [5, -7], [-20, 13], [40, 40]]
+
+// block_at builds its answer apart from generate, so it is pinned separately.
+const pinned_columns = [[0, 0], [7, -3], [-45, 18], [130, -260]]
+
+fn chunk_digest(g Generator, dim Dimension) u64 {
+	mut bytes := []u8{}
+	for pos in pinned_chunks {
+		c := g.generate(pos[0], pos[1])
+		for x in 0 .. 16 {
+			for z in 0 .. 16 {
+				push_int(mut bytes, c.biome_id(x, z))
+				for y in dim.min_y .. dim.max_y() + 1 {
+					push_int(mut bytes, c.block_id(x, y, z))
+				}
+			}
+		}
+	}
+	return fnv1a.sum64(bytes)
+}
+
+fn column_digest(g Generator, dim Dimension) u64 {
+	mut bytes := []u8{}
+	for pos in pinned_columns {
+		push_int(mut bytes, g.biome_at(pos[0], pos[1]))
+		for y in dim.min_y .. dim.max_y() + 1 {
+			push_int(mut bytes, g.block_at(pos[0], y, pos[1]))
+		}
+	}
+	push_int(mut bytes, g.spawn_point().y)
+	return fnv1a.sum64(bytes)
+}
+
+fn push_int(mut bytes []u8, v int) {
+	bytes << u8(v)
+	bytes << u8(v >> 8)
+	bytes << u8(v >> 16)
+	bytes << u8(v >> 24)
+}
+
+fn test_normal_generator_output_is_pinned() {
+	g := NormalGenerator{}
+	assert chunk_digest(g, overworld) == u64(11255914008902663412)
+	assert column_digest(g, overworld) == u64(18238884470794750234)
+	origin := g.spawn_point()
+	assert origin.x == 0 && origin.z == 0
+}
+
+fn test_nether_generator_output_is_pinned() {
+	g := NetherGenerator{}
+	assert chunk_digest(g, nether) == u64(10942659346042275470)
+	assert column_digest(g, nether) == u64(18239548844026247721)
+}
+
+fn test_end_generator_output_is_pinned() {
+	g := EndGenerator{}
+	assert chunk_digest(g, the_end) == u64(6133541026081350682)
+	assert column_digest(g, the_end) == u64(10002370967586145064)
+}
+
+// A seed has to reach both ways a generator answers. If it reached only one,
+// the chunks sent to players and single block lookups would describe two
+// different worlds.
+fn test_a_seed_changes_both_generate_and_block_at() {
+	for seed in [i64(42), -9_000_000_000] {
+		normal := NormalGenerator{
+			seed: seed
+		}
+		assert chunk_digest(normal, overworld) != u64(11255914008902663412)
+		assert column_digest(normal, overworld) != u64(18238884470794750234)
+		nether_gen := NetherGenerator{
+			seed: seed
+		}
+		assert chunk_digest(nether_gen, nether) != u64(10942659346042275470)
+		assert column_digest(nether_gen, nether) != u64(18239548844026247721)
+		end_gen := EndGenerator{
+			seed: seed
+		}
+		assert chunk_digest(end_gen, the_end) != u64(6133541026081350682)
+		assert column_digest(end_gen, the_end) != u64(10002370967586145064)
+	}
+}

--- a/server/world/generator_output_test.v
+++ b/server/world/generator_output_test.v
@@ -89,3 +89,17 @@ fn test_a_seed_changes_both_generate_and_block_at() {
 		assert column_digest(end_gen, the_end) != u64(10002370967586145064)
 	}
 }
+
+// 12158 and 16372 once folded to the same 32 bit mask and generated the same
+// world. Every bit of a seed has to reach the terrain.
+fn test_seeds_that_once_shared_a_mask_make_different_worlds() {
+	assert chunk_digest(NormalGenerator{ seed: 12158 }, overworld) != chunk_digest(NormalGenerator{
+		seed: 16372
+	}, overworld)
+	assert chunk_digest(NetherGenerator{ seed: 12158 }, nether) != chunk_digest(NetherGenerator{
+		seed: 16372
+	}, nether)
+	assert chunk_digest(EndGenerator{ seed: 12158 }, the_end) != chunk_digest(EndGenerator{
+		seed: 16372
+	}, the_end)
+}

--- a/server/world/generator_output_test.v
+++ b/server/world/generator_output_test.v
@@ -103,3 +103,9 @@ fn test_seeds_that_once_shared_a_mask_make_different_worlds() {
 		seed: 16372
 	}, the_end)
 }
+
+fn test_no_two_seeds_share_a_mask() {
+	remapped := seed_mask(7046029254386353131)
+	assert remapped != 0
+	assert remapped != seed_mask(-561184103760049731)
+}

--- a/server/world/generator_test.v
+++ b/server/world/generator_test.v
@@ -70,14 +70,19 @@ fn test_flat_and_normal_spawn_are_standable() {
 }
 
 fn test_a_seeded_world_spawns_on_dry_land() {
-	for seed in [i64(4), 9, 11, 1, 2, -7] {
+	for seed in [i64(4), 7, 9, 11, 43, 73, 100, -7] {
 		g := NormalGenerator{
 			seed: seed
 		}
 		p := g.spawn_point()
-		assert_standable(g, p.x, p.y, p.z)
-		floor := g.block_at(p.x, p.y - 1, p.z)
-		assert floor != water.network_id && floor != lava.network_id, 'seed ${seed} spawns on liquid'
+		c := g.generate(p.x >> 4, p.z >> 4)
+		lx := p.x & 15
+		lz := p.z & 15
+		floor := c.block_id(lx, p.y - 1, lz)
+		assert floor !in [air.network_id, water.network_id, lava.network_id, oak_leaves.network_id,
+			spruce_leaves.network_id, oak_log.network_id, spruce_log.network_id], 'seed ${seed} spawns on block ${floor}'
+		assert c.block_id(lx, p.y, lz) == air.network_id, 'seed ${seed} spawns inside a block'
+		assert c.block_id(lx, p.y + 1, lz) == air.network_id, 'seed ${seed} spawns with a block at head height'
 		if g.biome_at(0, 0) in [biome_ocean, biome_river] {
 			assert p.x != 0 || p.z != 0, 'seed ${seed} spawns over water at the origin'
 		}

--- a/server/world/generator_test.v
+++ b/server/world/generator_test.v
@@ -25,31 +25,31 @@ fn test_generator_registry_has_builtins() {
 
 fn test_generator_registry_create_unknown_returns_none() {
 	r := new_generator_registry()
-	if _ := r.create('moon', overworld) {
+	if _ := r.create('moon', dim: overworld) {
 		assert false, 'unregistered generator name should not resolve'
 	}
 }
 
 fn test_generator_registry_register_overrides_builtin() {
 	mut r := new_generator_registry()
-	r.register('flat', fn (dim Dimension) Generator {
+	r.register('flat', fn (opts GeneratorOptions) Generator {
 		return VoidGenerator{
-			dim: dim
+			dim: opts.dim
 		}
 	})
-	gen := r.create('flat', overworld) or { panic('expected flat to resolve') }
+	gen := r.create('flat', dim: overworld) or { panic('expected flat to resolve') }
 	assert !gen.uses_blocks()
 }
 
 fn test_generator_registry_builds_dimension_sized_chunks() {
 	r := new_generator_registry()
-	flat := r.create('flat', nether) or { panic('expected flat to resolve') }
+	flat := r.create('flat', dim: nether) or { panic('expected flat to resolve') }
 	chunk := flat.generate(0, 0)
 
 	assert chunk.subchunk_count == nether.subchunk_count
 	assert chunk.block_id(0, nether.min_y, 0) == bedrock.network_id
 	assert chunk.block_id(0, nether.min_y + 3, 0) == grass_block.network_id
-	assert flat.spawn_y() == nether.min_y + 4
+	assert flat.spawn_point().y == nether.min_y + 4
 }
 
 fn assert_standable(g Generator, x int, y int, z int) {
@@ -60,13 +60,28 @@ fn assert_standable(g Generator, x int, y int, z int) {
 
 fn test_flat_and_normal_spawn_are_standable() {
 	flat := FlatGenerator{}
-	assert_standable(flat, 0, flat.spawn_y(), 0)
+	assert_standable(flat, 0, flat.spawn_point().y, 0)
 
 	normal := NormalGenerator{}
-	spawn_y := normal.spawn_y()
+	spawn_y := normal.spawn_point().y
 	assert spawn_y >= overworld.min_y && spawn_y <= overworld.max_y()
 	assert_standable(normal, 0, spawn_y, 0)
 	assert normal.block_at(0, overworld.min_y - 1, 0) == air.network_id
+}
+
+fn test_a_seeded_world_spawns_on_dry_land() {
+	for seed in [i64(8), 9, 12, 1, 2, -7] {
+		g := NormalGenerator{
+			seed: seed
+		}
+		p := g.spawn_point()
+		assert_standable(g, p.x, p.y, p.z)
+		floor := g.block_at(p.x, p.y - 1, p.z)
+		assert floor != water.network_id && floor != lava.network_id, 'seed ${seed} spawns on liquid'
+		if g.biome_at(0, 0) in [biome_ocean, biome_river] {
+			assert p.x != 0 || p.z != 0, 'seed ${seed} spawns over water at the origin'
+		}
+	}
 }
 
 fn test_normal_generator_has_bedrock_floor_and_covered_surface() {
@@ -108,7 +123,7 @@ fn test_normal_generator_fills_columns_below_sea_level_with_water() {
 fn test_nether_generator_has_bedrock_floor_roof_and_safe_spawn() {
 	g := NetherGenerator{}
 	chunk := g.generate(0, 0)
-	spawn_y := g.spawn_y()
+	spawn_y := g.spawn_point().y
 	assert chunk.block_id(0, nether.min_y, 0) == bedrock.network_id
 	assert chunk.block_id(0, nether.max_y() - 1, 0) == netherrack.network_id
 	assert chunk.block_id(0, nether.max_y(), 0) == bedrock.network_id
@@ -168,19 +183,19 @@ fn test_end_generator_has_bedrock_floor_and_spawn_platform_near_origin() {
 	assert spawn_chunk.block_id(2, floor_top_y, 2) == end_stone.network_id
 	assert spawn_chunk.block_id(2, platform_y, 2) == obsidian.network_id
 	assert g.block_at(2, platform_y, 2) == obsidian.network_id
-	assert g.spawn_y() == platform_y
+	assert g.spawn_point().y == platform_y
 	assert g.biome_at(0, 0) == biome_the_end
 }
 
 fn test_generator_registry_void_and_normal_respect_dimension() {
 	r := new_generator_registry()
-	void := r.create('void', the_end) or { panic('expected void to resolve') }
+	void := r.create('void', dim: the_end) or { panic('expected void to resolve') }
 	assert void.generate(0, 0).subchunk_count == the_end.subchunk_count
 
-	normal := r.create('normal', nether) or { panic('expected normal to resolve') }
+	normal := r.create('normal', dim: nether) or { panic('expected normal to resolve') }
 	chunk := normal.generate(0, 0)
 	assert chunk.subchunk_count == nether.subchunk_count
-	assert normal.spawn_y() >= nether.min_y && normal.spawn_y() <= nether.max_y()
+	assert normal.spawn_point().y >= nether.min_y && normal.spawn_point().y <= nether.max_y()
 }
 
 fn test_density_column_matches_full_grid_sampling() {

--- a/server/world/generator_test.v
+++ b/server/world/generator_test.v
@@ -70,7 +70,7 @@ fn test_flat_and_normal_spawn_are_standable() {
 }
 
 fn test_a_seeded_world_spawns_on_dry_land() {
-	for seed in [i64(8), 9, 12, 1, 2, -7] {
+	for seed in [i64(4), 9, 11, 1, 2, -7] {
 		g := NormalGenerator{
 			seed: seed
 		}

--- a/server/world/generator_void.v
+++ b/server/world/generator_void.v
@@ -6,8 +6,10 @@ pub struct VoidGenerator {
 	dim Dimension = overworld
 }
 
-pub fn (g VoidGenerator) spawn_y() int {
-	return void_spawn_y
+pub fn (g VoidGenerator) spawn_point() SpawnPoint {
+	return SpawnPoint{
+		y: void_spawn_y
+	}
 }
 
 pub fn (g VoidGenerator) uses_blocks() bool {

--- a/server/world/noise.v
+++ b/server/world/noise.v
@@ -20,13 +20,17 @@ fn seed_mask(seed i64) u64 {
 	if seed == 0 {
 		return 0
 	}
-	// splitmix64, so seeds a bit apart still give unrelated masks.
-	mut z := u64(seed) + u64(0x9e3779b97f4a7c15)
+	mask := splitmix64(u64(seed))
+	return if mask == 0 { splitmix64(0) } else { mask }
+}
+
+// splitmix64 is a bijection on u64, so seeds a bit apart still give unrelated
+// masks.
+fn splitmix64(x u64) u64 {
+	mut z := x + u64(0x9e3779b97f4a7c15)
 	z = (z ^ (z >> 30)) * u64(0xbf58476d1ce4e5b9)
 	z = (z ^ (z >> 27)) * u64(0x94d049bb133111eb)
-	z ^= z >> 31
-	// Any other seed has to come out as a different world from seed 0.
-	return if z == 0 { u64(1) } else { z }
+	return z ^ (z >> 31)
 }
 
 // hash_salt folds a salt into h. Only a seed sets a salt's high half, a

--- a/server/world/noise.v
+++ b/server/world/noise.v
@@ -15,8 +15,8 @@ fn hash_unit(h u32) f64 {
 
 // seed_mask is what a world's seed changes every salt by. Seed 0 changes
 // nothing, which keeps a world made before seeds existed generating exactly as
-// it did.
-fn seed_mask(seed i64) u32 {
+// it did. All 64 bits are kept, so no two seeds share a world.
+fn seed_mask(seed i64) u64 {
 	if seed == 0 {
 		return 0
 	}
@@ -25,37 +25,47 @@ fn seed_mask(seed i64) u32 {
 	z = (z ^ (z >> 30)) * u64(0xbf58476d1ce4e5b9)
 	z = (z ^ (z >> 27)) * u64(0x94d049bb133111eb)
 	z ^= z >> 31
-	mask := u32(z) ^ u32(z >> 32)
 	// Any other seed has to come out as a different world from seed 0.
-	return if mask == 0 { u32(1) } else { mask }
+	return if z == 0 { u64(1) } else { z }
+}
+
+// hash_salt folds a salt into h. Only a seed sets a salt's high half, a
+// salt from before seeds hashes exactly as it did.
+fn hash_salt(h u32, salt u64) u32 {
+	mut out := hash_step(h, u32(salt))
+	high := u32(salt >> 32)
+	if high != 0 {
+		out = hash_step(out, high)
+	}
+	return out
 }
 
 // hash3_unit returns a deterministic pseudo random value in [0, 1) for an
 // integer (x, y, z, salt) tuple. Used directly for independent per block
 // decisions (ore placement) where no smoothing between neighbours is wanted.
-fn hash3_unit(x int, y int, z int, salt u32) f64 {
+fn hash3_unit(x int, y int, z int, salt u64) f64 {
 	mut h := noise_hash_offset
 	h = hash_step(h, u32(x))
 	h = hash_step(h, u32(y))
 	h = hash_step(h, u32(z))
-	h = hash_step(h, salt)
+	h = hash_salt(h, salt)
 	return hash_unit(h)
 }
 
-fn lattice_value(x int, z int, salt u32) f64 {
+fn lattice_value(x int, z int, salt u64) f64 {
 	mut h := noise_hash_offset
 	h = hash_step(h, u32(x))
 	h = hash_step(h, u32(z))
-	h = hash_step(h, salt)
+	h = hash_salt(h, salt)
 	return hash_unit(h)
 }
 
-fn lattice_value3d(x int, y int, z int, salt u32) f64 {
+fn lattice_value3d(x int, y int, z int, salt u64) f64 {
 	mut h := noise_hash_offset
 	h = hash_step(h, u32(x))
 	h = hash_step(h, u32(y))
 	h = hash_step(h, u32(z))
-	h = hash_step(h, salt)
+	h = hash_salt(h, salt)
 	return hash_unit(h)
 }
 
@@ -66,7 +76,7 @@ fn smoothstep(t f64) f64 {
 // value_noise2d samples smoothed value noise at fractional (x, z), bilinearly
 // interpolating between the 4 surrounding integer lattice points. Returns a
 // value in [0, 1).
-fn value_noise2d(x f64, z f64, salt u32) f64 {
+fn value_noise2d(x f64, z f64, salt u64) f64 {
 	x0 := int(math.floor(x))
 	z0 := int(math.floor(z))
 	fx := smoothstep(x - f64(x0))
@@ -80,7 +90,7 @@ fn value_noise2d(x f64, z f64, salt u32) f64 {
 	return top + (bottom - top) * fz
 }
 
-fn value_noise3d(x f64, y f64, z f64, salt u32) f64 {
+fn value_noise3d(x f64, y f64, z f64, salt u64) f64 {
 	x0 := int(math.floor(x))
 	y0 := int(math.floor(y))
 	z0 := int(math.floor(z))
@@ -109,20 +119,20 @@ fn value_noise3d(x f64, y f64, z f64, salt u32) f64 {
 // fbm2d sums octaves of value_noise2d (fractal Brownian motion) for a more
 // natural looking terrain/biome map than a single noise layer would give.
 // Returns a value in [0, 1).
-fn fbm2d(x f64, z f64, salt u32, octaves int) f64 {
+fn fbm2d(x f64, z f64, salt u64, octaves int) f64 {
 	return fbm2d_persist(x, z, salt, octaves, 0.5)
 }
 
 // fbm2d_persist is fbm2d with an explicit amplitude falloff per octave. A low
 // persistence keeps the first octave dominant, which is what wide biome maps
 // want; terrain detail wants the default 0.5.
-fn fbm2d_persist(x f64, z f64, salt u32, octaves int, persistence f64) f64 {
+fn fbm2d_persist(x f64, z f64, salt u64, octaves int, persistence f64) f64 {
 	mut total := 0.0
 	mut amplitude := 1.0
 	mut frequency := 1.0
 	mut max_amplitude := 0.0
 	for i in 0 .. octaves {
-		total += value_noise2d(x * frequency, z * frequency, salt + u32(i) * 7919) * amplitude
+		total += value_noise2d(x * frequency, z * frequency, salt + u64(i) * 7919) * amplitude
 		max_amplitude += amplitude
 		amplitude *= persistence
 		frequency *= 2.0
@@ -130,17 +140,17 @@ fn fbm2d_persist(x f64, z f64, salt u32, octaves int, persistence f64) f64 {
 	return total / max_amplitude
 }
 
-fn fbm3d(x f64, y f64, z f64, salt u32, octaves int) f64 {
+fn fbm3d(x f64, y f64, z f64, salt u64, octaves int) f64 {
 	return fbm3d_persist(x, y, z, salt, octaves, 0.5)
 }
 
-fn fbm3d_persist(x f64, y f64, z f64, salt u32, octaves int, persistence f64) f64 {
+fn fbm3d_persist(x f64, y f64, z f64, salt u64, octaves int, persistence f64) f64 {
 	mut total := 0.0
 	mut amplitude := 1.0
 	mut frequency := 1.0
 	mut max_amplitude := 0.0
 	for i in 0 .. octaves {
-		total += value_noise3d(x * frequency, y * frequency, z * frequency, salt + u32(i) * 7919) * amplitude
+		total += value_noise3d(x * frequency, y * frequency, z * frequency, salt + u64(i) * 7919) * amplitude
 		max_amplitude += amplitude
 		amplitude *= persistence
 		frequency *= 2.0

--- a/server/world/noise.v
+++ b/server/world/noise.v
@@ -13,6 +13,23 @@ fn hash_unit(h u32) f64 {
 	return f64(h % 1_000_000) / 1_000_000.0
 }
 
+// seed_mask is what a world's seed changes every salt by. Seed 0 changes
+// nothing, which keeps a world made before seeds existed generating exactly as
+// it did.
+fn seed_mask(seed i64) u32 {
+	if seed == 0 {
+		return 0
+	}
+	// splitmix64, so seeds a bit apart still give unrelated masks.
+	mut z := u64(seed) + u64(0x9e3779b97f4a7c15)
+	z = (z ^ (z >> 30)) * u64(0xbf58476d1ce4e5b9)
+	z = (z ^ (z >> 27)) * u64(0x94d049bb133111eb)
+	z ^= z >> 31
+	mask := u32(z) ^ u32(z >> 32)
+	// Any other seed has to come out as a different world from seed 0.
+	return if mask == 0 { u32(1) } else { mask }
+}
+
 // hash3_unit returns a deterministic pseudo random value in [0, 1) for an
 // integer (x, y, z, salt) tuple. Used directly for independent per block
 // decisions (ore placement) where no smoothing between neighbours is wanted.

--- a/server/world/random.v
+++ b/server/world/random.v
@@ -17,6 +17,14 @@ pub fn new_random(seed u32) Random {
 	return r
 }
 
+// new_random_wide seeds from 64 bits. With the high half zero it is exactly
+// new_random of the low half.
+fn new_random_wide(seed u64) Random {
+	mut r := new_random(u32(seed))
+	r.w ^= u32(seed >> 32)
+	return r
+}
+
 pub fn (mut r Random) set_seed(seed u32) {
 	r.x = u32(123456789) ^ seed
 	r.y = u32(362436069) ^ (seed << 17) ^ (seed >> 15)

--- a/server/world/world_test.v
+++ b/server/world/world_test.v
@@ -157,7 +157,7 @@ fn test_chunk_height_map_tracks_highest_non_air_block() {
 
 fn test_generator_selection() {
 	flat := new_generator('flat')
-	assert flat.spawn_y() == flat_spawn_y
+	assert flat.spawn_point().y == flat_spawn_y
 	assert flat.uses_blocks() == true
 	assert flat.generate(0, 0).section_count() == 1
 


### PR DESCRIPTION
<!-- Describe what this PR does and why. Keep it focused. -->

## Description

Closes #110

## Related issue

Closes #110


## Checklist
- [x] `v -check .` is clean
- [x] `v test server` is fully green
- [ ] Follows the conventions in AGENTS.md (OOP, `pub`/capitalized exports, no import cycles, minimal comments)
- [ ] Cross-session gameplay state is only mutated on its owning world's actor thread (via `world_call`/`wr.submit`/`WorldTx`), never through a global Hub actor
- [ ] No unrelated changes bundled in
